### PR TITLE
Minimize apache-rat excluded files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,20 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 # Contributing to Firestorm
 Welcome to [report Issues](https://github.com/Tencent/Firestorm/issues) or [pull requests](https://github.com/Tencent/Firestorm/pulls). It's recommended to read the following Contributing Guide first before contributing. 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 # What is Firestorm
 
 Firestorm is a Remote Shuffle Service, and provides the capability for Apache Spark applications

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -10,7 +10,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -3,6 +3,19 @@ layout: page
 displayTitle: Firestorm Shuffle Client Guide
 title: Firestorm Shuffle Client Guide
 description: Firestorm Shuffle Client Guide
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 # Firestorm Shuffle Client Guide
 

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -10,7 +10,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -3,6 +3,19 @@ layout: page
 displayTitle: Firestorm Coordinator Guide
 title: Firestorm Coordinator Guide
 description: Firestorm Coordinator Guide
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 
 # Firestorm Coordinator Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,19 @@ layout: page
 displayTitle: Firestorm Overview
 title: Overview
 description: Firestorm documentation homepage
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 
 Firestorm is a Remote Shuffle Service, and provides the capability for Apache Spark applications

--- a/docs/server_guide.md
+++ b/docs/server_guide.md
@@ -10,7 +10,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/server_guide.md
+++ b/docs/server_guide.md
@@ -3,5 +3,18 @@ layout: page
 displayTitle: Firestorm Shuffle Server Guide
 title: Firestorm Shuffle Server Guide
 description: Firestorm Shuffle Server Guide
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 # Firestorm Shuffle Server Guide

--- a/pom.xml
+++ b/pom.xml
@@ -906,7 +906,6 @@
             <exclude>quantity_temp.properties</exclude>
             <exclude>rss*/</exclude>
             <exclude>spark-patches/**</exclude>
-            <exclude>docs/*.md</exclude>
             <exclude>.github/PULL_REQUEST_TEMPLATE</exclude>
           </excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -890,7 +890,6 @@
             <exclude>**/target/**</exclude>
             <exclude>src/test/resources/empty</exclude>
             <exclude>**/dependency-reduced-pom.xml</exclude>
-            <exclude>spark-patches/**</exclude>
             <exclude>.github/PULL_REQUEST_TEMPLATE</exclude>
           </excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -884,8 +884,6 @@
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>README.md</exclude>
-            <exclude>CONTRIBUTING.md</exclude>
             <exclude>LICENSE</exclude>
             <exclude>**/target/**</exclude>
             <exclude>src/test/resources/empty</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -888,23 +888,8 @@
             <exclude>CONTRIBUTING.md</exclude>
             <exclude>LICENSE</exclude>
             <exclude>**/target/**</exclude>
-            <exclude>**/**/target/**</exclude>
-            <exclude>tencent-bin/**</exclude>
-            <exclude>*.iml</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>**/**/*.iml</exclude>
-            <exclude>dependency-reduced-pom.xml</exclude>
             <exclude>src/test/resources/empty</exclude>
             <exclude>**/dependency-reduced-pom.xml</exclude>
-            <exclude>**/**/dependency-reduced-pom.xml</exclude>
-            <exclude>**/pom.xml.versionsBackup</exclude>
-            <exclude>**/**/pom.xml.versionsBackup</exclude>
-            <exclude>pom.xml.versionsBackup</exclude>
-            <exclude>*.log</exclude>
-            <exclude>CovTemp/**</exclude>
-            <exclude>coverage_ogid.txt</exclude>
-            <exclude>quantity_temp.properties</exclude>
-            <exclude>rss*/</exclude>
             <exclude>spark-patches/**</exclude>
             <exclude>.github/PULL_REQUEST_TEMPLATE</exclude>
           </excludes>

--- a/spark-patches/spark-2.4.6_dynamic_allocation_support.patch
+++ b/spark-patches/spark-2.4.6_dynamic_allocation_support.patch
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 diff --git a/core/src/main/scala/org/apache/spark/Dependency.scala b/core/src/main/scala/org/apache/spark/Dependency.scala
 index 9ea6d2fa2f..d6101cdcef 100644
 --- a/core/src/main/scala/org/apache/spark/Dependency.scala

--- a/spark-patches/spark-3.1.2_dynamic_allocation_support.patch
+++ b/spark-patches/spark-3.1.2_dynamic_allocation_support.patch
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 diff --git a/core/src/main/scala/org/apache/spark/Dependency.scala b/core/src/main/scala/org/apache/spark/Dependency.scala
 index d21b9d9833..fe4507f81f 100644
 --- a/core/src/main/scala/org/apache/spark/Dependency.scala

--- a/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
+++ b/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 diff --git a/core/src/main/scala/org/apache/spark/Dependency.scala b/core/src/main/scala/org/apache/spark/Dependency.scala
 index 1b4e7ba5106..95818ff72ca 100644
 --- a/core/src/main/scala/org/apache/spark/Dependency.scala


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add license header to files so we can minimize files to exclude in apache-rat check.

### Why are the changes needed?

Asf podding issues

### Does this PR introduce _any_ user-facing change?

License header is visible in docs, just like [spark](https://github.com/apache/spark/blob/master/docs/index.md?plain=1), for example:
https://github.com/kaijchen/incubator-uniffle/blob/rat-exclude/docs/index.md

### How was this patch tested?

CI: https://github.com/kaijchen/incubator-uniffle/runs/7176341386?check_suite_focus=true