### PR TITLE
[Bug] Fix NPE problem when process the event if application was cleared already

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -139,18 +139,18 @@ public class ShuffleFlushManager {
 
   private void flushToFile(ShuffleDataFlushEvent event) {
 
+    Storage storage = storageManager.selectStorage(event);
+    if (storage != null && !storage.canWrite()) {
+      addPendingEvents(event);
+      return;
+    }
+
     long start = System.currentTimeMillis();
     List<ShufflePartitionedBlock> blocks = event.getShuffleBlocks();
     boolean writeSuccess = false;
     try {
-      Storage storage = storageManager.selectStorage(event);
       // storage info maybe null if the application cache was cleared already
       if (storage != null) {
-        if (!storage.canWrite()) {
-          addPendingEvents(event);
-          return;
-        }
-
         if (blocks == null || blocks.isEmpty()) {
           LOG.info("There is no block to be flushed: " + event);
         } else if (!event.isValid()) {

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -75,7 +75,8 @@ public class HdfsStorageManager extends SingleStorageManager {
       storage.removeHandlers(appId);
       appIdToStorages.remove(appId);
       ShuffleDeleteHandler deleteHandler = ShuffleHandlerFactory.getInstance()
-          .createShuffleDeleteHandler(new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf()));
+          .createShuffleDeleteHandler(
+              new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf()));
       deleteHandler.delete(new String[] {storage.getStoragePath()}, appId);
     }
   }

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -71,11 +71,13 @@ public class HdfsStorageManager extends SingleStorageManager {
   @Override
   public void removeResources(String appId, Set<Integer> shuffleSet) {
     HdfsStorage storage = getStorageByAppId(appId);
-    storage.removeHandlers(appId);
-    appIdToStorages.remove(appId);
-    ShuffleDeleteHandler deleteHandler = ShuffleHandlerFactory.getInstance()
-        .createShuffleDeleteHandler(new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf()));
-    deleteHandler.delete(new String[] {storage.getStoragePath()}, appId);
+    if (storage != null) {
+      storage.removeHandlers(appId);
+      appIdToStorages.remove(appId);
+      ShuffleDeleteHandler deleteHandler = ShuffleHandlerFactory.getInstance()
+          .createShuffleDeleteHandler(new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf()));
+      deleteHandler.delete(new String[] {storage.getStoragePath()}, appId);
+    }
   }
 
   @Override
@@ -109,7 +111,9 @@ public class HdfsStorageManager extends SingleStorageManager {
     if (!appIdToStorages.containsKey(appId)) {
       String msg = "Can't find HDFS storage for appId[" + appId + "]";
       LOG.error(msg);
-      throw new RuntimeException(msg);
+      // outside should deal with null situation
+      // todo: it's better to have a fake storage for null situation
+      return null;
     }
     return appIdToStorages.get(appId);
   }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import io.prometheus.client.Gauge;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -130,6 +131,14 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
 
     assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.get(storageHost).get(), 0.5);
     assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageSuccessWrite.get(storageHost).get(), 0.5);
+
+    // test case for process event whose related app was cleared already
+    assertEquals(0, ShuffleServerMetrics.gaugeWriteHandler.get(), 0.5);
+    ShuffleDataFlushEvent fakeEvent =
+        createShuffleDataFlushEvent("fakeAppId", 1, 1, 1, null);
+    manager.addToFlushQueue(fakeEvent);
+    waitForQueueClear(manager);
+    waitForMetrics(ShuffleServerMetrics.gaugeWriteHandler, 0, 0.5);
   }
 
   @Test
@@ -263,6 +272,37 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     storageManager.removeResources(appId2, Sets.newHashSet(1));
     assertEquals(0, manager.getCommittedBlockIds(appId2, 1).getLongCardinality());
     assertEquals(0, storage.getHandlerSize());
+  }
+
+  private void waitForMetrics(Gauge gauge, double expected, double delta) throws Exception {
+    int retry = 0;
+    boolean match = false;
+    do {
+      Thread.sleep(500);
+      if (retry > 10) {
+        fail("Unexpected flush process when waitForMetrics");
+      }
+      retry++;
+      try {
+        assertEquals(0, gauge.get(), delta);
+        match = true;
+      } catch(Exception e) {
+        // ignore
+      }
+    } while (!match);
+  }
+
+  private void waitForQueueClear(ShuffleFlushManager manager) throws Exception {
+    int retry = 0;
+    int size = 0;
+    do {
+      Thread.sleep(500);
+      if (retry > 10) {
+        fail("Unexpected flush process when waitForQueueClear");
+      }
+      retry++;
+      size = manager.getEventNumInFlush();
+    } while (size > 0);
   }
 
   private void waitForFlush(ShuffleFlushManager manager,


### PR DESCRIPTION
### What changes were proposed in this pull request?
There will be NPE problem when process the event if application was cleared already


### Why are the changes needed?
Fix a critical bug which cause resource leak. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT is added
