### PR TITLE
[CI] Enable codecov report

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -92,3 +92,5 @@ jobs:
         name: ${{ inputs.reports-name }}-${{ matrix.profile }}
         path: ${{ inputs.reports-path }}
       continue-on-error: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable codecov report in CI. The service is also used by [Apache Spark](https://app.codecov.io/gh/apache/spark).

We may need infra team to help enable it on this repository.
(Or it may have already been enabled for all apache projects).

### Why are the changes needed?

To measure code coverage and improve the tests.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The codecov report aggregated when running CI on current master:
https://codecov.io/gh/kaijchen/incubator-uniffle/tree/d3372ff61cdd9701082b72e130b4e2b7bc4fe764
