### PR TITLE
[WIP] Support unregister shuffle

### DIFF
--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -324,8 +324,8 @@ public class SortWriteBufferManagerTest {
     }
 
     @Override
-    public void unregisterShuffle(String appId, int shuffleId) {
-
+    public boolean unregisterShuffle(String appId, int shuffleId) {
+      return true;
     }
 
     @Override

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -324,6 +324,11 @@ public class SortWriteBufferManagerTest {
     }
 
     @Override
+    public void unregisterShuffle(String appId, int shuffleId) {
+
+    }
+
+    @Override
     public void close() {
 
     }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -411,6 +411,11 @@ public class FetcherTest {
     }
 
     @Override
+    public void unregisterShuffle(String appId, int shuffleId) {
+
+    }
+
+    @Override
     public void close() {
 
     }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -411,8 +411,8 @@ public class FetcherTest {
     }
 
     @Override
-    public void unregisterShuffle(String appId, int shuffleId) {
-
+    public boolean unregisterShuffle(String appId, int shuffleId) {
+      return true;
     }
 
     @Override

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -370,7 +370,7 @@ public class RssShuffleManager implements ShuffleManager {
 
   @Override
   public boolean unregisterShuffle(int shuffleId) {
-    return true;
+    return shuffleWriteClient.unregisterShuffle(appId, shuffleId);
   }
 
   @Override

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -539,7 +539,7 @@ public class RssShuffleManager implements ShuffleManager {
 
   @Override
   public boolean unregisterShuffle(int shuffleId) {
-    return true;
+    return shuffleWriteClient.unregisterShuffle(id.get(), shuffleId);
   }
 
   @Override

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -65,5 +65,7 @@ public interface ShuffleWriteClient {
   Roaring64NavigableMap getShuffleResult(String clientType, Set<ShuffleServerInfo> shuffleServerInfoSet,
       String appId, int shuffleId, int partitionId);
 
+  void unregisterShuffle(String appId, int shuffleId);
+
   void close();
 }

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -65,7 +65,7 @@ public interface ShuffleWriteClient {
   Roaring64NavigableMap getShuffleResult(String clientType, Set<ShuffleServerInfo> shuffleServerInfoSet,
       String appId, int shuffleId, int partitionId);
 
-  void unregisterShuffle(String appId, int shuffleId);
+  boolean unregisterShuffle(String appId, int shuffleId);
 
   void close();
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -34,9 +34,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
-import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +53,7 @@ import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssReportShuffleResultRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
 import org.apache.uniffle.client.response.ClientResponse;
 import org.apache.uniffle.client.response.ResponseStatusCode;
 import org.apache.uniffle.client.response.RssAppHeartBeatResponse;
@@ -68,6 +66,7 @@ import org.apache.uniffle.client.response.RssRegisterShuffleResponse;
 import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
 import org.apache.uniffle.client.response.RssSendCommitResponse;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -514,21 +513,20 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     RssUnregisterShuffleRequest request = new RssUnregisterShuffleRequest(appId, shuffleId);
     List<Callable<Void>> callableList = Lists.newArrayList();
     shuffleServerInfoSet.stream().forEach(shuffleServerInfo -> {
-              callableList.add(() -> {
-                try {
-                  ShuffleServerClient client =
-                          ShuffleServerClientFactory.getInstance().getShuffleServerClient(clientType, shuffleServerInfo);
-                  RssUnregisterShuffleResponse response = client.unregisterShuffle(request);
-                  if (response.getStatusCode() != ResponseStatusCode.SUCCESS) {
-                    LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
-                  }
-                } catch (Exception e) {
-                  LOG.warn("Error happened when unregister shuffle to " + shuffleServerInfo, e);
-                }
-                return null;
-              });
-            }
-    );
+      callableList.add(() -> {
+        try {
+          ShuffleServerClient client =
+                  ShuffleServerClientFactory.getInstance().getShuffleServerClient(clientType, shuffleServerInfo);
+          RssUnregisterShuffleResponse response = client.unregisterShuffle(request);
+          if (response.getStatusCode() != ResponseStatusCode.SUCCESS) {
+            LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
+          }
+        } catch (Exception e) {
+          LOG.warn("Error happened when unregister shuffle to " + shuffleServerInfo, e);
+        }
+        return null;
+      });
+    });
     try {
       List<Future<Void>> futures = clientExecutorService.invokeAll(callableList);
       for (Future<Void> future : futures) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
@@ -27,6 +27,7 @@ import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssReportShuffleResultRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
 import org.apache.uniffle.client.response.RssAppHeartBeatResponse;
 import org.apache.uniffle.client.response.RssFinishShuffleResponse;
 import org.apache.uniffle.client.response.RssGetInMemoryShuffleDataResponse;
@@ -37,6 +38,7 @@ import org.apache.uniffle.client.response.RssRegisterShuffleResponse;
 import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
 import org.apache.uniffle.client.response.RssSendCommitResponse;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 
 public interface ShuffleServerClient {
 
@@ -60,6 +62,8 @@ public interface ShuffleServerClient {
 
   RssGetInMemoryShuffleDataResponse getInMemoryShuffleData(
       RssGetInMemoryShuffleDataRequest request);
+
+  RssUnregisterShuffleResponse unregisterShuffle(RssUnregisterShuffleRequest request);
 
   String getDesc();
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -25,6 +25,9 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+
+import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
+import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +87,8 @@ import org.apache.uniffle.proto.RssProtos.ShuffleDataBlockSegment;
 import org.apache.uniffle.proto.RssProtos.ShufflePartitionRange;
 import org.apache.uniffle.proto.RssProtos.ShuffleRegisterRequest;
 import org.apache.uniffle.proto.RssProtos.ShuffleRegisterResponse;
+import org.apache.uniffle.proto.RssProtos.ShuffleUnregisterRequest;
+import org.apache.uniffle.proto.RssProtos.ShuffleUnregisterResponse;
 import org.apache.uniffle.proto.RssProtos.StatusCode;
 import org.apache.uniffle.proto.ShuffleServerGrpc;
 import org.apache.uniffle.proto.ShuffleServerGrpc.ShuffleServerBlockingStub;
@@ -544,6 +549,25 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             + " for " + requestInfo + ", errorMsg:" + rpcResponse.getRetMsg();
         LOG.error(msg);
         throw new RssException(msg);
+    }
+    return response;
+  }
+
+  @Override
+  public RssUnregisterShuffleResponse unregisterShuffle(RssUnregisterShuffleRequest request) {
+    ShuffleUnregisterRequest rpcRequest = ShuffleUnregisterRequest.newBuilder()
+            .setAppId(request.getAppId()).setShuffleId(request.getShuffleId()).build();
+    ShuffleUnregisterResponse rpcResponse = blockingStub.unregisterShuffle(rpcRequest);
+
+    RssUnregisterShuffleResponse response;
+    if (rpcResponse.getStatus() != StatusCode.SUCCESS) {
+      String msg = "Can't unregister shuffle process to " + host + ":" + port
+              + " for [appId=" + request.getAppId() + ", shuffleId=" + request.getShuffleId() + "], "
+              + "errorMsg:" + rpcResponse.getRetMsg();
+      LOG.error(msg);
+      throw new RssException(msg);
+    } else {
+      response = new RssUnregisterShuffleResponse(ResponseStatusCode.SUCCESS);
     }
     return response;
   }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -25,9 +25,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-
-import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
-import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +39,7 @@ import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssReportShuffleResultRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
 import org.apache.uniffle.client.response.ResponseStatusCode;
 import org.apache.uniffle.client.response.RssAppHeartBeatResponse;
 import org.apache.uniffle.client.response.RssFinishShuffleResponse;
@@ -53,6 +51,7 @@ import org.apache.uniffle.client.response.RssRegisterShuffleResponse;
 import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
 import org.apache.uniffle.client.response.RssSendCommitResponse;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssUnregisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssUnregisterShuffleRequest.java
@@ -15,16 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.storage.handler.api;
+package org.apache.uniffle.client.request;
 
-import java.util.Set;
+public class RssUnregisterShuffleRequest {
 
-public interface ShuffleDeleteHandler {
+  private String appId;
+  private int shuffleId;
 
-  /**
-   * Delete shuffle data with appId
-   *
-   * @param subPaths SubPaths for delete
-   */
-  void delete(String[] storageBasePaths, Set<String> subPaths);
+  public RssUnregisterShuffleRequest(String appId, int shuffleId) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssUnregisterShuffleResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssUnregisterShuffleResponse.java
@@ -15,16 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.storage.handler.api;
+package org.apache.uniffle.client.response;
 
-import java.util.Set;
+public class RssUnregisterShuffleResponse extends ClientResponse {
 
-public interface ShuffleDeleteHandler {
-
-  /**
-   * Delete shuffle data with appId
-   *
-   * @param subPaths SubPaths for delete
-   */
-  void delete(String[] storageBasePaths, Set<String> subPaths);
+  public RssUnregisterShuffleResponse(ResponseStatusCode statusCode) {
+    super(statusCode);
+  }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -35,6 +35,7 @@ service ShuffleServer {
   rpc finishShuffle (FinishShuffleRequest) returns (FinishShuffleResponse);
   rpc requireBuffer (RequireBufferRequest) returns (RequireBufferResponse);
   rpc appHeartbeat(AppHeartBeatRequest) returns (AppHeartBeatResponse);
+  rpc unregisterShuffle (ShuffleUnregisterRequest) returns (ShuffleUnregisterResponse);
 }
 
 message FinishShuffleRequest {
@@ -217,6 +218,16 @@ message ShuffleServerId {
 }
 
 message ShuffleServerResult {
+  StatusCode status = 1;
+  string retMsg = 2;
+}
+
+message ShuffleUnregisterRequest {
+  string appId = 1;
+  int32 shuffleId = 2;
+}
+
+message ShuffleUnregisterResponse {
   StatusCode status = 1;
   string retMsg = 2;
 }

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -25,11 +25,11 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.uniffle.common.util.RssUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.server.Checker;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleDataReadEvent;

--- a/server/src/main/java/org/apache/uniffle/server/storage/MultiStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/MultiStorageManager.java
@@ -142,10 +142,10 @@ public class MultiStorageManager implements StorageManager {
   }
 
   @Override
-  public void removeResources(String appId, Set<Integer> shuffleSet) {
+  public void removeResources(String appId, Set<Integer> shuffleSet, boolean clean) {
     LOG.info("Start to remove resource of appId: {}, shuffles: {}", appId, shuffleSet.toString());
-    warmStorageManager.removeResources(appId, shuffleSet);
-    coldStorageManager.removeResources(appId, shuffleSet);
+    warmStorageManager.removeResources(appId, shuffleSet, clean);
+    coldStorageManager.removeResources(appId, shuffleSet, clean);
   }
 
   public StorageManager getColdStorageManager() {

--- a/server/src/main/java/org/apache/uniffle/server/storage/StorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/StorageManager.java
@@ -39,7 +39,7 @@ public interface StorageManager {
 
   // todo: add an interface for updateReadMetrics
 
-  void removeResources(String appId, Set<Integer> shuffleSet);
+  void removeResources(String appId, Set<Integer> shuffleSet, boolean clean);
 
   void start();
 

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -209,7 +209,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     manager.removeResources(appId1);
 
     assertTrue(((HdfsStorageManager)storageManager).getAppIdToStorages().containsKey(appId1));
-    storageManager.removeResources(appId1, Sets.newHashSet(1));
+    storageManager.removeResources(appId1, Sets.newHashSet(1), true);
     assertFalse(((HdfsStorageManager)storageManager).getAppIdToStorages().containsKey(appId1));
     try {
       fs.listStatus(new Path(remoteStorage.getPath() + "/" + appId1 + "/"));
@@ -224,7 +224,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     assertEquals(1, size);
     manager.removeResources(appId2);
     assertTrue(((HdfsStorageManager)storageManager).getAppIdToStorages().containsKey(appId2));
-    storageManager.removeResources(appId2, Sets.newHashSet(1));
+    storageManager.removeResources(appId2, Sets.newHashSet(1), true);
     assertFalse(((HdfsStorageManager)storageManager).getAppIdToStorages().containsKey(appId2));
     assertEquals(0, manager.getCommittedBlockIds(appId2, 1).getLongCardinality());
     size = storage.getHandlerSize();
@@ -258,7 +258,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     assertEquals(2, storage.getHandlerSize());
     File file = new File(tempDir, appId1);
     assertTrue(file.exists());
-    storageManager.removeResources(appId1, Sets.newHashSet(1));
+    storageManager.removeResources(appId1, Sets.newHashSet(1), true);
     manager.removeResources(appId1);
     assertFalse(file.exists());
     ShuffleDataFlushEvent event3 =
@@ -269,7 +269,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     assertEquals(5, manager.getCommittedBlockIds(appId2, 1).getLongCardinality());
     assertEquals(1, storage.getHandlerSize());
     manager.removeResources(appId2);
-    storageManager.removeResources(appId2, Sets.newHashSet(1));
+    storageManager.removeResources(appId2, Sets.newHashSet(1), true);
     assertEquals(0, manager.getCommittedBlockIds(appId2, 1).getLongCardinality());
     assertEquals(0, storage.getHandlerSize());
   }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileDeleteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileDeleteHandler.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.storage.handler.impl;
 
 import java.io.File;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -31,17 +32,21 @@ public class LocalFileDeleteHandler implements ShuffleDeleteHandler {
   private static final Logger LOG = LoggerFactory.getLogger(LocalFileDeleteHandler.class);
 
   @Override
-  public void delete(String[] storageBasePaths, String appId) {
+  public void delete(String[] storageBasePaths, Set<String> subPaths) {
+    subPaths.forEach(subPath -> delete(storageBasePaths, subPath));
+  }
+
+  public void delete(String[] storageBasePaths, String subPath) {
     for (String basePath : storageBasePaths) {
-      String shufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(basePath, appId);
+      String shufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(basePath, subPath);
       long start = System.currentTimeMillis();
       try {
         File baseFolder = new File(shufflePath);
         FileUtils.deleteDirectory(baseFolder);
-        LOG.info("Delete shuffle data for appId[" + appId + "] with " + shufflePath
+        LOG.info("Delete shuffle data for subPath[" + subPath + "] with " + shufflePath
             + " cost " + (System.currentTimeMillis() - start) + " ms");
       } catch (Exception e) {
-        LOG.warn("Can't delete shuffle data for appId[" + appId + "] with " + shufflePath, e);
+        LOG.warn("Can't delete shuffle data for subPath[" + subPath + "] with " + shufflePath, e);
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Support unregister shuffle.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, the shuffle data is cleaned up after the heartbeat of the spark app times out. For a long-running app like sts, the shuffle data may be stored for a long time, so I want to implement unregister shuffle to clean up the shuffle data.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the shuffle service adds the unregisterShuffle protocol.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

TODO