### PR TITLE
[CI] Switch to temurin JDK

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -46,7 +46,7 @@ on:
         required: false
         type: string
       jdk-distro:
-        default: 'adopt'
+        default: 'temurin'
         required: false
         type: string
 

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -46,7 +46,7 @@ on:
         required: false
         type: string
       jdk-distro:
-        default: 'adopt'
+        default: 'temurin'
         required: false
         type: string
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Switch to temurin JDK in CI.

### Why are the changes needed?

> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By CI.
