### PR TITLE
[INFRA] Improve asf.yaml to reduce the notifications

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,6 +23,7 @@ github:
     - mapreduce
     - shuffle
     - remote-shuffle-service
+    - rss
   features:
     # Enable wiki for documentation
     wiki: true
@@ -43,6 +44,6 @@ github:
         required_approving_review_count: 1
 
   notifications:
-  commits: notifications@uniffle.apache.org
-  issues: dev@uniffle.apache.org
-  pullrequests: notifications@uniffle.apache.org
+    commits: commits@uniffle.apache.org
+    issues: dev@uniffle.apache.org
+    pullrequests: issues@uniffle.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the asf.yaml to reduce the PR notifications to dev@

### Why are the changes needed?

Currently there're some many gitbox notifications to dev@, which is actually duplicated with GH notification itself, so trying to reduce this in dev@


### Does this PR introduce _any_ user-facing change?
 
No

### How was this patch tested?

NA
