### PR TITLE
[TYPO] Fix misspelled word "integration"

### DIFF
--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>rss-integration-common-test</artifactId>
     <version>0.6.0-snapshot</version>
     <packaging>jar</packaging>
-    <name>Apache Uniffle Intergration Test (Common)</name>
+    <name>Apache Uniffle Integration Test (Common)</name>
 
     <dependencies>
         <dependency>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>rss-integration-mr-test</artifactId>
     <version>0.6.0-snapshot</version>
     <packaging>jar</packaging>
-    <name>Apache Uniffle Intergration Test (MapReduce)</name>
+    <name>Apache Uniffle Integration Test (MapReduce)</name>
 
     <dependencies>
         <dependency>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>rss-integration-spark-common-test</artifactId>
   <version>0.6.0-snapshot</version>
   <packaging>jar</packaging>
-  <name>Apache Uniffle Intergration Test (Spark Common)</name>
+  <name>Apache Uniffle Integration Test (Spark Common)</name>
 
   <dependencies>
     <dependency>

--- a/integration-test/spark2/pom.xml
+++ b/integration-test/spark2/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>rss-integration-spark2-test</artifactId>
   <version>0.6.0-snapshot</version>
   <packaging>jar</packaging>
-  <name>Apache Uniffle Intergration Test (Spark 2)</name>
+  <name>Apache Uniffle Integration Test (Spark 2)</name>
 
   <dependencies>
 

--- a/integration-test/spark3/pom.xml
+++ b/integration-test/spark3/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>rss-integration-spark3-test</artifactId>
     <version>0.6.0-snapshot</version>
     <packaging>jar</packaging>
-    <name>Apache Uniffle Intergration Test (Spark 3)</name>
+    <name>Apache Uniffle Integration Test (Spark 3)</name>
 
     <dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix misspelled word "integration" in pom.xml

### Why are the changes needed?

Fix typo.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.