### PR TITLE
[Bug] Fix skip() api maybe skip unexpected bytes which makes inconsistent data

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
@@ -41,20 +41,20 @@ public class LocalFileReader implements FileReader, Closeable {
 
   public byte[] read(long offset, int length) {
     try {
-      long at = offset;
+      long targetSkip = offset;
       // comments from skip API:
       // The skip method may, for a variety of reasons,
       // end up skipping over some smaller number of bytes, possibly 0
       // the result should be checked and try again until skip expectation length
-      while (at > 0) {
-        long realSkip = dataInputStream.skip(at);
+      while (targetSkip > 0) {
+        long realSkip = dataInputStream.skip(targetSkip);
         if (realSkip == -1) {
           throw new RuntimeException("Unexpected EOF when skip bytes");
         }
-        at -= realSkip;
-        if (at > 0) {
+        targetSkip -= realSkip;
+        if (targetSkip > 0) {
           LOG.warn("Got unexpected skip for path:" + path + " with offset["
-              + offset + "], length[" + length + "], remain[" + at + "]");
+              + offset + "], length[" + length + "], remain[" + targetSkip + "]");
         }
       }
       byte[] buf = new byte[length];

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
@@ -41,7 +41,22 @@ public class LocalFileReader implements FileReader, Closeable {
 
   public byte[] read(long offset, int length) {
     try {
-      dataInputStream.skip(offset);
+      long at = offset;
+      // comments from skip API:
+      // The skip method may, for a variety of reasons,
+      // end up skipping over some smaller number of bytes, possibly 0
+      // the result should be checked and try again until skip expectation length
+      while(at > 0) {
+        long realSkip = dataInputStream.skip(at);
+        if (realSkip == -1) {
+          throw new RuntimeException("Unexpected EOF when skip bytes");
+        }
+        at -= realSkip;
+        if (at > 0) {
+          LOG.warn("Got unexpected skip for path:" + path + " with offset["
+              + offset + "], length[" + length + "], remain[" + at + "]");
+        }
+      }
       byte[] buf = new byte[length];
       dataInputStream.readFully(buf);
       return buf;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
@@ -46,7 +46,7 @@ public class LocalFileReader implements FileReader, Closeable {
       // The skip method may, for a variety of reasons,
       // end up skipping over some smaller number of bytes, possibly 0
       // the result should be checked and try again until skip expectation length
-      while(at > 0) {
+      while (at > 0) {
         long realSkip = dataInputStream.skip(at);
         if (realSkip == -1) {
           throw new RuntimeException("Unexpected EOF when skip bytes");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix bug when call `inputstream.skip()` which may return unexpected result


### Why are the changes needed?
Get exception messages as following, and it maybe caused by unexpected data from `Local` storage
```
com.tencent.rss.common.exception.RssException: Unexpected crc value for blockId[9992363390829154], expected:2562548848, actual:2244862586
        at com.tencent.rss.client.impl.ShuffleReadClientImpl.readShuffleBlockData(ShuffleReadClientImpl.java:184)
        at org.apache.spark.shuffle.reader.RssShuffleDataIterator.hasNext(RssShuffleDataIterator.java:99)
        at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:39)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
With current UTs
