### PR TITLE
[Chore]: document update and build time optimize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,18 +15,18 @@
   ~ limitations under the License.
   -->
 
-# Contributing to Firestorm
-Welcome to [report Issues](https://github.com/Tencent/Firestorm/issues) or [pull requests](https://github.com/Tencent/Firestorm/pulls). It's recommended to read the following Contributing Guide first before contributing. 
+# Contributing to Uniffle
+Welcome to report [Issues](https://github.com/apache/incubator-uniffle/issues) or make [pull requests](https://github.com/apache/incubator-uniffle/pulls). It's recommended to read the following contributing guide first before contributing. 
 
 ## Issues
-We use Github Issues to track public bugs and feature requests.
+We use GitHub Issues to track public bugs and feature requests.
 
 ### Search Known Issues First
-Please search on [report Issues](https://github.com/Tencent/Firestorm/issues) to avoid creating duplicate issue.
+Please search on [Issues](https://github.com/apache/incubator-uniffle/issues) to avoid creating duplicate issues.
 
 ### Reporting New Issues
 * Be sure to include a title and clear description, as much relevant information as possible.
-* A code sample or an executable test case demonstrating is high recommended.
+* A code sample or an executable test case demonstrating is highly recommended.
 
 ## Pull Requests
 * We use master branch as our developing branch.
@@ -34,20 +34,20 @@ Please search on [report Issues](https://github.com/Tencent/Firestorm/issues) to
 * When maintaining a branch, merge frequently with the master.
 * When maintaining a branch, submit pull requests to the master frequently.
 * If you are working on a bigger issue try to split it up into several smaller issues.
-* We reserve full and final discretion over whether or not we will merge a pull request. Adhering to these guidelines is not a complete guarantee that your pull request will be merged.
+* We reserve full and final discretion over whether we will merge a pull request. Adhering to these guidelines is not a complete guarantee that your pull request will be merged.
 
 ### Make Pull Requests
-The code team will monitor all pull request, we run some code check and test on it. After all tests passed, we will accecpt this PR. But it won't merge to `master` branch at once, which have some delay.
+The code team will monitor all pull requests, we run some code check and test on it. After all tests passed and all the review comments addressed, we will accept the PR.
 
 Before submitting a pull request, please make sure the followings are done:
 
 1. Fork the repo and create your branch from `master`.
 2. Update code or documentation if you have changed APIs.
 3. Add the copyright notice to the top of any new files you've added.
-4. Check your code lints and checkstyles.
+4. Check your code lints and checkstyle.
 5. Test and test again your code.
 
 ## Code Style Guide
-Use [Code Style](https://github.com/Tencent/Firestorm/blob/master/checkstyle.xml) for Java.
+Use [Code Style](https://github.com/apache/incubator-uniffle/blob/master/checkstyle.xml) for Java.
 
 * 2 spaces for indentation rather than tabs

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Note: To support dynamic allocation, the patch(which is included in client-spark
 Current support Hadoop 2.8.5's MapReduce framework.
 
 ## Building Uniffle
+> note: currently Uniffle requires JDK 1.8 to build, adding later JDK support is on our roadmap.
 
 Uniffle is built using [Apache Maven](https://maven.apache.org/).
 To build it, run:

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,12 @@
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <scope>${hadoop.scope}</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. update README.md to reflect JDK requirement
2. exclude json-smart in hadoop-common
3. update CONTRIBUTION.md to change the project name and polish wording



### Why are the changes needed?
> For the first two changes: 

When building uniffle locally, I noticed that it requires JDK1.8 to build and suspicious maven-default-http-blocker for json-smart.
```
[WARNING] net.minidev:json-smart/maven-metadata.xml failed to transfer from http://0.0.0.0/ during a previous attempt. 
This failure was cached in the local repository and resolution will not be reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced.
Original error: Could not transfer metadata net.minidev:json-smart/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): transfer failed for http://0.0.0.0/net/minidev/json-smart/maven-metadata.xml
```


> For the third change:

Before I'm making a PR, I found the project name in CONTRIBUTING.md is not changed yet. Thus, this commit
also updates the CONTRIBUTING.md and makes some amend to the doc.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
No new tests are required.
