### PR TITLE
[CI] Change default checkstyle severity to error

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -22,8 +22,6 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
-
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->
     <!-- See https://checkstyle.org/config_filefilters.html -->
@@ -288,7 +286,6 @@
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
              <!-- new add -->
-            <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="specialImportsRegExp" value="^org\.apache\.uniffle"/>
             <property name="standardPackageRegExp" value="^java\.|^javax\."/>

--- a/pom.xml
+++ b/pom.xml
@@ -797,7 +797,6 @@
           <failsOnError>true</failsOnError>
           <linkXRef>false</linkXRef>
           <failOnViolation>true</failOnViolation>
-          <violationSeverity>warning</violationSeverity>
         </configuration>
         <dependencies>
           <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change default checkstyle severity to error.

### Why are the changes needed?

In common sense, "warning" is something can be ignored.
It is better to use "error" to mean something must be fixed. 
And current CI workflow displays "Summary of failures" by filtering errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Example of checkstyle failure, click "Summary of failures" to see the filtered result.
https://github.com/kaijchen/incubator-uniffle/runs/7319512298?check_suite_focus=true