### PR TITLE
Use NIO's Files API to replace FileInputStream/FileOutputStream in some paths

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
@@ -33,6 +32,7 @@ import java.net.NetworkInterface;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -86,7 +86,8 @@ public class RssUtils {
     LOGGER.info("Load config from {}", filename);
     final Map<String, String> result = new HashMap<>();
 
-    try (InputStreamReader inReader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+    try (InputStreamReader inReader =
+             new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8)) {
       Properties properties = new Properties();
       properties.load(inReader);
       properties.stringPropertyNames().forEach(k -> result.put(k, properties.getProperty(k).trim()));

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -18,9 +18,10 @@
 package org.apache.uniffle.server;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -164,7 +165,7 @@ public class LocalStorageChecker extends Checker {
         }
         byte[] readData = new byte[1024];
         int readBytes = -1;
-        try (FileInputStream fis = new FileInputStream(writeFile)) {
+        try (InputStream fis = Files.newInputStream(writeFile.toPath())) {
           int hasReadBytes = 0;
           do {
             readBytes = fis.read(readData);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsFileWriter.java
@@ -18,8 +18,8 @@
 package org.apache.uniffle.storage.handler.impl;
 
 import java.io.Closeable;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -141,7 +141,7 @@ public class HdfsFileWriter implements Closeable {
     }
   }
 
-  public long copy(FileInputStream inputStream, int bufferSize) throws IOException {
+  public long copy(InputStream inputStream, int bufferSize) throws IOException {
     long start = fsDataOutputStream.getPos();
     IOUtils.copyBytes(inputStream, fsDataOutputStream, bufferSize);
     return fsDataOutputStream.getPos() - start;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
@@ -20,19 +20,23 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
 
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
 
 public class LocalFileWriter implements Closeable {
 
   private DataOutputStream dataOutputStream;
-  private FileOutputStream fileOutputStream;
+  private OutputStream fileOutputStream;
   private long nextOffset;
 
   public LocalFileWriter(File file) throws IOException {
-    fileOutputStream = new FileOutputStream(file, true);
+    fileOutputStream = Files.newOutputStream(file.toPath(), CREATE, APPEND);
     // init fsDataOutputStream
     dataOutputStream = new DataOutputStream(fileOutputStream);
     nextOffset = file.length();

--- a/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
@@ -18,9 +18,10 @@
 package org.apache.uniffle.storage.util;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
@@ -232,7 +233,7 @@ public class ShuffleStorageUtils {
   }
 
   public static long uploadFile(File file, HdfsFileWriter writer, int bufferSize) throws IOException {
-    try (FileInputStream inputStream = new FileInputStream(file)) {
+    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
       return writer.copy(inputStream, bufferSize);
     } catch (IOException e) {
       LOG.error("Fail to upload file {}, {}", file.getAbsolutePath(), e);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Use NIO's Files API to replace FileInputStream/FileOutputStream in some paths.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->



### Why are the changes needed?
Follow this PR of spark: https://github.com/apache/spark/pull/20144 and https://github.com/apache/spark/pull/18684

Refer to reason of this change:

> Java's FileInputStream and FileOutputStream overrides finalize(), even this file input/output stream is closed correctly and promptly, it will still leave some memory footprints which will only get cleaned in Full GC. This will introduce two side effects:
Lots of memory footprints regarding to Finalizer will be kept in memory and this will increase the memory overhead. In our use case of external shuffle service, a busy shuffle service will have bunch of this object and potentially lead to OOM.
The Finalizer will only be called in Full GC, and this will increase the overhead of Full GC and lead to long GC pause.
https://bugs.openjdk.java.net/browse/JDK-8080225
https://www.cloudbees.com/blog/fileinputstream-fileoutputstream-considered-harmful
So to fix this potential issue, here propose to use NIO's Files#newInput/OutputStream instead in some critical paths like shuffle.


<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
No need.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
