### PR TITLE
[Bugfix]Fix memory leak & Improve buffer management

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -78,20 +78,21 @@ public class WriteBufferManagerTest {
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(0, testKey, testValue);
+    wbm.addRecord(0, testKey, testValue);
     result = wbm.addRecord(0, testKey, testValue);
     // single buffer is full
     assertEquals(1, result.size());
     assertEquals(512, wbm.getAllocatedBytes());
-    assertEquals(96, wbm.getUsedBytes());
-    assertEquals(96, wbm.getInSendListBytes());
+    assertEquals(35, wbm.getUsedBytes());
+    assertEquals(35, wbm.getInSendListBytes());
     assertEquals(0, wbm.getBuffers().size());
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(1, testKey, testValue);
     wbm.addRecord(2, testKey, testValue);
     // single buffer is not full, and less than spill size
     assertEquals(512, wbm.getAllocatedBytes());
-    assertEquals(192, wbm.getUsedBytes());
-    assertEquals(96, wbm.getInSendListBytes());
+    assertEquals(131, wbm.getUsedBytes());
+    assertEquals(35, wbm.getInSendListBytes());
     assertEquals(3, wbm.getBuffers().size());
     // all buffer size > spill size
     wbm.addRecord(3, testKey, testValue);
@@ -99,27 +100,26 @@ public class WriteBufferManagerTest {
     result = wbm.addRecord(5, testKey, testValue);
     assertEquals(6, result.size());
     assertEquals(512, wbm.getAllocatedBytes());
-    assertEquals(288, wbm.getUsedBytes());
-    assertEquals(288, wbm.getInSendListBytes());
+    assertEquals(113, wbm.getUsedBytes());
+    assertEquals(113, wbm.getInSendListBytes());
     assertEquals(0, wbm.getBuffers().size());
     // free memory
-    wbm.freeAllocatedMemory(96);
-    assertEquals(416, wbm.getAllocatedBytes());
-    assertEquals(192, wbm.getUsedBytes());
-    assertEquals(192, wbm.getInSendListBytes());
+    wbm.freeAllocatedMemory(113);
+    assertEquals(399, wbm.getAllocatedBytes());
+    assertEquals(0, wbm.getUsedBytes());
+    assertEquals(0, wbm.getInSendListBytes());
 
-    assertEquals(11, wbm.getShuffleWriteMetrics().recordsWritten());
+    assertEquals(12, wbm.getShuffleWriteMetrics().recordsWritten());
     assertTrue(wbm.getShuffleWriteMetrics().bytesWritten() > 0);
 
-    wbm.freeAllocatedMemory(192);
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(1, testKey, testValue);
     wbm.addRecord(2, testKey, testValue);
     result = wbm.clear();
     assertEquals(3, result.size());
-    assertEquals(224, wbm.getAllocatedBytes());
-    assertEquals(96, wbm.getUsedBytes());
-    assertEquals(96, wbm.getInSendListBytes());
+    assertEquals(399, wbm.getAllocatedBytes());
+    assertEquals(39, wbm.getUsedBytes());
+    assertEquals(39, wbm.getInSendListBytes());
   }
 
   @Test

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
@@ -49,16 +49,16 @@ public class WriteBufferTest {
     wb.addRecord(serializedData, serializedDataLength);
     assertEquals(32, wb.getMemoryUsed());
     // case: data size < output buffer size, when getData(), [] + buffer with 24b = 24b
-    assertEquals(24, wb.getData().length);
+    assertEquals(24, wb.getDataLength());
     wb.addRecord(serializedData, serializedDataLength);
     // case: data size > output buffer size, when getData(), [1 buffer] + buffer with 12 = 36b
-    assertEquals(36, wb.getData().length);
+    assertEquals(36, wb.getDataLength());
     assertEquals(64, wb.getMemoryUsed());
     wb.addRecord(serializedData, serializedDataLength);
     wb.addRecord(serializedData, serializedDataLength);
     // case: data size > output buffer size, when getData(), 2 buffer + output with 12b = 60b
     assertEquals(60, wb.getData().length);
-    assertEquals(96, wb.getMemoryUsed());
+    assertEquals(64, wb.getMemoryUsed());
 
     wb = new WriterBuffer(32);
 
@@ -73,7 +73,6 @@ public class WriteBufferTest {
     assertEquals(99, wb.getMemoryUsed());
     // 67 + 12
     assertEquals(79, wb.getDataLength());
-    assertEquals(79, wb.getData().length);
 
     wb.addRecord(serializedData, serializedDataLength);
     assertEquals(99, wb.getMemoryUsed());


### PR DESCRIPTION
### What changes were proposed in this pull request?
the behavior of buffer management and memory allocate
1.when adding a huge record to a partition where the buffer is not initialized, we only allocate `bufferSegmentSize` memory, however  release the real huge size memory after the buffer is sent
2.byte array will be fully used as possible to save memory

### Why are the changes needed?
fix memory leak & improve buffer management

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
pass testing
