### PR TITLE
[ISSUE-48] [Feature] Init Kubernetes operator directory

### DIFF
--- a/deploy/kubernetes/build-operator.sh
+++ b/deploy/kubernetes/build-operator.sh
@@ -1,2 +1,20 @@
 #!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 echo "Build kubernetes operator..."

--- a/deploy/kubernetes/build-operator.sh
+++ b/deploy/kubernetes/build-operator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Build kubernetes operator..."

--- a/deploy/kubernetes/docker/.gitkeep
+++ b/deploy/kubernetes/docker/.gitkeep
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/deploy/kubernetes/integration-test/.gitkeep
+++ b/deploy/kubernetes/integration-test/.gitkeep
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/deploy/kubernetes/operator/.gitkeep
+++ b/deploy/kubernetes/operator/.gitkeep
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/deploy/kubernetes/pom.xml
+++ b/deploy/kubernetes/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.uniffle</groupId>
+    <artifactId>uniffle-parent</artifactId>
+    <version>0.6.0-snapshot</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>rss-kubernetes</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache Uniffle Kubernetes</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>Build Kubernetes operator</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${basedir}/build-operator.sh</executable>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Test Kubernetes Operator</id>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${basedir}/test-operator.sh</executable>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/deploy/kubernetes/test-operator.sh
+++ b/deploy/kubernetes/test-operator.sh
@@ -1,2 +1,20 @@
 #!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 echo "Test Kubernetes Operator.."

--- a/deploy/kubernetes/test-operator.sh
+++ b/deploy/kubernetes/test-operator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Test Kubernetes Operator.."

--- a/pom.xml
+++ b/pom.xml
@@ -1374,6 +1374,11 @@
         </dependencies>
       </dependencyManagement>
     </profile>
+    <profile>
+      <id>kubernetes</id>
+      <modules>
+        <module>deploy/kubernetes</module>
+      </modules>
+    </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
To solve issue #48, First step. we add Kubernetes operator profile and directory. We add two scripts build-operator.sh and test-operator.sh. We can use these scripts to build and test our operator. When we use the command `mvn compile -Pkubernetes`, we can build the operator. When we use the command `mvn test -Pkubernetes`, we can test the operator.

### Why are the changes needed?
We hope use Kubernetes to deploy Uniffle.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need.