### PR TITLE
[Improvement] Ignore partial failure on initializing local storage in shuffle server side

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -271,11 +271,17 @@ public class ShuffleServerConf extends RssBaseConf {
       .withDescription("For multistorage, fail times exceed the number, will switch storage");
 
   public static final ConfigOption<List<String>> TAGS = ConfigOptions
-          .key("rss.server.tags")
-          .stringType()
-          .asList()
-          .noDefaultValue()
-          .withDescription("Tags list supported by shuffle server");
+      .key("rss.server.tags")
+      .stringType()
+      .asList()
+      .noDefaultValue()
+      .withDescription("Tags list supported by shuffle server");
+
+  public static final ConfigOption<Integer> LOCAL_STORAGE_INITIALIZE_MAX_FAIL_NUMBER = ConfigOptions
+      .key("rss.server.localstorage.initialize.max.fail.number")
+      .intType()
+      .defaultValue(0)
+      .withDescription("For localstorage, it will exit when the failed initialized local storage exceed the number");
 
   public ShuffleServerConf() {
   }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -277,10 +277,11 @@ public class ShuffleServerConf extends RssBaseConf {
       .noDefaultValue()
       .withDescription("Tags list supported by shuffle server");
 
-  public static final ConfigOption<Integer> LOCAL_STORAGE_INITIALIZE_MAX_FAIL_NUMBER = ConfigOptions
+  public static final ConfigOption<Long> LOCAL_STORAGE_INITIALIZE_MAX_FAIL_NUMBER = ConfigOptions
       .key("rss.server.localstorage.initialize.max.fail.number")
-      .intType()
-      .defaultValue(0)
+      .longType()
+      .checkValue(ConfigUtils.NON_NEGATIVE_LONG_VALIDATOR, " max fail times must be non-negative")
+      .defaultValue(0L)
       .withDescription("For localstorage, it will exit when the failed initialized local storage exceed the number");
 
   public ShuffleServerConf() {

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -17,9 +17,7 @@
 
 package org.apache.uniffle.server.storage;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 
 import org.apache.uniffle.server.ShuffleServerConf;

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -17,19 +17,29 @@
 
 package org.apache.uniffle.server.storage;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.ShuffleServerMetrics;
 import org.apache.uniffle.storage.common.LocalStorage;
 import org.apache.uniffle.storage.util.StorageType;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * The class is to test the {@link LocalStorageManager}
+ */
 public class LocalStorageManagerTest {
 
   private static LocalStorageManager localStorageManager;
@@ -59,5 +69,50 @@ public class LocalStorageManagerTest {
       assertTrue(storagePaths[i].equals(storages.get(i).getBasePath()));
     }
   }
-}
 
+  @Test
+  public void testInitializeLocalStorage() throws IOException {
+    String tmpDir1 = Files.createTempDirectory("rss-data1").toString();
+    String tmpDir2 = Files.createTempDirectory("rss-data2").toString();
+
+    // case1: when no candidates, it should throw exception.
+    ShuffleServerConf conf = new ShuffleServerConf();
+    conf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 2000L);
+    conf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH, tmpDir1 + "," + tmpDir2);
+    conf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L);
+    conf.setInteger(ShuffleServerConf.LOCAL_STORAGE_INITIALIZE_MAX_FAIL_NUMBER, 1);
+    MockedLocalStorageBuilder.setErrorPath(Arrays.asList(tmpDir1, tmpDir2));
+    conf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE_HDFS.name());
+    try {
+      LocalStorageManager localStorageManager = new LocalStorageManager(conf, new MockedLocalStorageBuilder());
+      fail();
+    } catch (Exception e) {
+      // ignore
+    }
+
+    // case2: when candidates exist, it should initialize successfully.
+    MockedLocalStorageBuilder.setErrorPath(Arrays.asList(tmpDir1));
+    LocalStorageManager localStorageManager = new LocalStorageManager(conf, new MockedLocalStorageBuilder());
+    assertEquals(1, localStorageManager.getStorages().size());
+
+    // case3: all ok
+    MockedLocalStorageBuilder.setErrorPath(Collections.EMPTY_LIST);
+    localStorageManager = new LocalStorageManager(conf, new MockedLocalStorageBuilder());
+    assertEquals(2, localStorageManager.getStorages().size());
+  }
+
+  public static class MockedLocalStorageBuilder extends LocalStorage.Builder {
+    private static List<String> errorPaths;
+
+    public static void setErrorPath(List<String> errorPaths) {
+      MockedLocalStorageBuilder.errorPaths = errorPaths;
+    }
+
+    public LocalStorage build() {
+      if (errorPaths.contains(getBasePath())) {
+        throw new RuntimeException("ERROR Disk.");
+      }
+      return super.build();
+    }
+  }
+}

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -105,5 +105,15 @@ public class LocalStorageManagerTest {
     } catch (Exception e) {
       // ignore
     }
+
+    // case5: if failed=2, but lower than rss.server.localstorage.initialize.max.fail.number, should exit
+    conf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH, "/a/rss-data,/b/rss-data-1");
+    conf.setLong(ShuffleServerConf.LOCAL_STORAGE_INITIALIZE_MAX_FAIL_NUMBER, 10L);
+    try {
+      localStorageManager = new LocalStorageManager(conf);
+      fail();
+    } catch (Exception e) {
+      // ignore
+    }
   }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -317,8 +317,7 @@ public class LocalStorage extends AbstractStorage {
     private long cleanIntervalMs;
     private long shuffleExpiredTimeoutMs;
 
-    @VisibleForTesting
-    protected Builder() {
+    private Builder() {
     }
 
     public Builder capacity(long capacity) {
@@ -354,11 +353,6 @@ public class LocalStorage extends AbstractStorage {
     public Builder shuffleExpiredTimeoutMs(long shuffleExpiredTimeoutMs) {
       this.shuffleExpiredTimeoutMs = shuffleExpiredTimeoutMs;
       return this;
-    }
-
-    @VisibleForTesting
-    public String getBasePath() {
-      return basePath;
     }
 
     public LocalStorage build() {

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -77,7 +77,7 @@ public class LocalStorage extends AbstractStorage {
     }
     long freeSpace = baseFolder.getFreeSpace();
     if (freeSpace < capacity) {
-      throw new IllegalArgumentException("Disk Available Capacity " + freeSpace
+      throw new IllegalArgumentException("The Disk of " + basePath + " Available Capacity " + freeSpace
           + " is smaller than configuration");
     }
   }
@@ -317,7 +317,8 @@ public class LocalStorage extends AbstractStorage {
     private long cleanIntervalMs;
     private long shuffleExpiredTimeoutMs;
 
-    private Builder() {
+    @VisibleForTesting
+    protected Builder() {
     }
 
     public Builder capacity(long capacity) {
@@ -353,6 +354,11 @@ public class LocalStorage extends AbstractStorage {
     public Builder shuffleExpiredTimeoutMs(long shuffleExpiredTimeoutMs) {
       this.shuffleExpiredTimeoutMs = shuffleExpiredTimeoutMs;
       return this;
+    }
+
+    @VisibleForTesting
+    public String getBasePath() {
+      return basePath;
     }
 
     public LocalStorage build() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Ignore partial failure on initializing local storage in shuffle server side
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
When setting multiple storage paths, only one disk is insufficient capacity, shuffle server will directly throw exception. We hope it can be ignored, because bad disks are more common in production environments

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
UT
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
