### PR TITLE
[CI] Test compile in Java 11 and Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,19 @@ jobs:
     with:
       maven-args: package
       reports-path: "**/target/surefire-reports/*.txt"
+  
+  java-11:
+    name: 'java 11'
+    uses: ./.github/workflows/parallel.yml
+    with:
+      maven-args: package -DskipTests
+      java-version: '11'
+      coverage: false
+
+  java-17:
+    name: 'java 17'
+    uses: ./.github/workflows/parallel.yml
+    with:
+      maven-args: package -DskipTests
+      java-version: '17'
+      coverage: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: CI
+name: build
 
 on: [push, pull_request]
 
@@ -38,7 +38,7 @@ jobs:
     with:
       maven-args: test-compile spotbugs:check
 
-  build:
+  package:
     uses: ./.github/workflows/parallel.yml
     with:
       maven-args: package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,23 +37,23 @@ jobs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: test-compile spotbugs:check
-
-  package:
-    uses: ./.github/workflows/parallel.yml
-    with:
-      maven-args: package
-      reports-path: "**/target/surefire-reports/*.txt"
   
   java-11:
-    name: 'java 11'
+    name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
       java-version: '11'
 
   java-17:
-    name: 'java 17'
+    name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
       java-version: '17'
+
+  package:
+    uses: ./.github/workflows/parallel.yml
+    with:
+      maven-args: package
+      reports-path: "**/target/surefire-reports/*.txt"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,16 +46,14 @@ jobs:
   
   java-11:
     name: 'java 11'
-    uses: ./.github/workflows/parallel.yml
+    uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
       java-version: '11'
-      coverage: false
 
   java-17:
     name: 'java 17'
-    uses: ./.github/workflows/parallel.yml
+    uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
       java-version: '17'
-      coverage: false

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -17,7 +17,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Multi Profiles in Parallel
+name: All Profiles in Parallel
 
 on:
   workflow_call:

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -51,7 +51,7 @@ on:
         type: string
 
 jobs:
-  mvn:
+  maven:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -63,6 +63,7 @@ jobs:
           - spark3.2
           - mr
       fail-fast: false
+    name: -P${{ matrix.profile }}
     steps:
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -17,7 +17,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Multi Profiles in Parallel
 
 on:
   workflow_call:
@@ -27,6 +27,10 @@ on:
         type: string
       experimental:
         default: false
+        required: false
+        type: boolean
+      coverage:
+        default: true
         required: false
         type: boolean
       summary:
@@ -41,7 +45,7 @@ on:
         default: 'test-reports'
         required: false
         type: string
-      jdk-version:
+      java-version:
         default: '8'
         required: false
         type: string
@@ -66,10 +70,10 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v2
-    - name: Set up JDK ${{ inputs.jdk-version }}
+    - name: Set up JDK ${{ inputs.java-version }}
       uses: actions/setup-java@v2
       with:
-        java-version: ${{ inputs.jdk-version }}
+        java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
     - name: Execute maven with -P${{ matrix.profile }}
@@ -93,4 +97,5 @@ jobs:
         path: ${{ inputs.reports-path }}
       continue-on-error: true
     - name: Upload coverage to Codecov
+      if: ${{ inputs.coverage }}
       uses: codecov/codecov-action@v3

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -29,10 +29,6 @@ on:
         default: false
         required: false
         type: boolean
-      coverage:
-        default: true
-        required: false
-        type: boolean
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
         required: false
@@ -97,5 +93,4 @@ jobs:
         path: ${{ inputs.reports-path }}
       continue-on-error: true
     - name: Upload coverage to Codecov
-      if: ${{ inputs.coverage }}
       uses: codecov/codecov-action@v3

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -55,6 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       PROFILE: 'spark2 spark2.3 spark3.0 spark3 spark3.2 mr'
+    name: java ${{ inputs.java-version }}
     steps:
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -17,7 +17,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Multi Profiles in Sequential
+name: Main Profiles in Sequential
 
 on:
   workflow_call:
@@ -54,7 +54,8 @@ jobs:
   maven:
     runs-on: ubuntu-20.04
     env:
-      PROFILE: 'spark2 spark2.3 spark3.0 spark3 spark3.2 mr'
+      # check main profiles only, just enough to cover all modules.
+      PROFILE: 'spark2 spark3 mr'
     name: java ${{ inputs.java-version }}
     steps:
     - name: Checkout project

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -17,7 +17,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Multi Profiles in Sequential
 
 on:
   workflow_call:
@@ -41,7 +41,7 @@ on:
         default: 'test-reports'
         required: false
         type: string
-      jdk-version:
+      java-version:
         default: '8'
         required: false
         type: string
@@ -58,10 +58,10 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v2
-    - name: Set up JDK ${{ inputs.jdk-version }}
+    - name: Set up JDK ${{ inputs.java-version }}
       uses: actions/setup-java@v2
       with:
-        java-version: ${{ inputs.jdk-version }}
+        java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
     - name: Execute maven with ${{ env.PROFILE }}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
     <java.version>1.8</java.version>
+    <javax.annotation.version>1.3.2</javax.annotation.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>
@@ -217,6 +218,11 @@
         <version>${metrics.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotation.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.uniffle</groupId>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -45,6 +45,10 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add dependency `javax.annotation-api`.
2. Add Java 11 and Java 17 build in CI, `mvn package -DskipTests` only.
3. Rename jobs and workflows in CI. 
4. Only check main profiles in sequential workflow, just enough to cover all modules.

### Why are the changes needed?

Support build in Java 11 and Java 17.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/actions/runs/2760618905