### PR TITLE
[Improvement] try read from backup shuffle servers when fetched data is inconsistent

### DIFF
--- a/client/src/test/java/org/apache/uniffle/client/TestUtils.java
+++ b/client/src/test/java/org/apache/uniffle/client/TestUtils.java
@@ -18,13 +18,15 @@
 package org.apache.uniffle.client;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestUtils {
 
@@ -53,6 +55,30 @@ public class TestUtils {
       }
     }
     assertEquals(expectedData.size(), blockNum);
+  }
+
+
+  public static void validateResult(
+      Map<Long, byte[]> expectedData,
+      ShuffleDataResult sdr) {
+    byte[] buffer = sdr.getData();
+    List<BufferSegment> bufferSegments = sdr.getBufferSegments();
+    assertEquals(expectedData.size(), bufferSegments.size());
+    for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {
+      BufferSegment bs = findBufferSegment(entry.getKey(), bufferSegments);
+      assertNotNull(bs);
+      byte[] data = new byte[bs.getLength()];
+      System.arraycopy(buffer, bs.getOffset(), data, 0, bs.getLength());
+    }
+  }
+
+  private static BufferSegment findBufferSegment(long blockId, List<BufferSegment> bufferSegments) {
+    for (BufferSegment bs : bufferSegments) {
+      if (bs.getBlockId() == blockId) {
+        return bs;
+      }
+    }
+    return null;
   }
 
   public static boolean compareByte(byte[] expected, ByteBuffer buffer) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import org.apache.uniffle.client.TestUtils;
+import org.apache.uniffle.client.api.ShuffleServerClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
+import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.coordinator.CoordinatorServer;
+import org.apache.uniffle.server.MockedShuffleServer;
+import org.apache.uniffle.server.ShuffleServer;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.server.buffer.ShuffleBuffer;
+import org.apache.uniffle.storage.handler.api.ClientReadHandler;
+import org.apache.uniffle.storage.handler.impl.ComposedClientReadHandler;
+import org.apache.uniffle.storage.handler.impl.LocalFileQuorumClientReadHandler;
+import org.apache.uniffle.storage.handler.impl.MemoryQuorumClientReadHandler;
+import org.apache.uniffle.storage.util.StorageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
+
+  private List<ShuffleServerClient> shuffleServerClients;
+
+  @BeforeAll
+  public static void setupServers() throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    createCoordinatorServer(coordinatorConf);
+    shuffleServers.add(createServer(0));
+    shuffleServers.add(createServer(1));
+    shuffleServers.add(createServer(2));
+    startServers();
+  }
+
+  @BeforeEach
+  public void createClient() {
+    shuffleServerClients = new ArrayList<>();
+    for (ShuffleServer shuffleServer : shuffleServers) {
+      shuffleServerClients.add(new ShuffleServerGrpcClient(shuffleServer.getIp(), shuffleServer.getPort()));
+    }
+  }
+
+  @AfterEach
+  public void cleanEnv() throws Exception {
+    shuffleServerClients.forEach((client) -> {
+      client.close();
+    });
+    cleanCluster();
+    setupServers();
+  }
+
+  @Test
+  public void testReadFaultTolerance() throws Exception {
+    String testAppId = "ShuffleServerFaultToleranceTest.testReadFaultTolerance";
+    int shuffleId = 0;
+    int partitionId = 0;
+
+    RssRegisterShuffleRequest rrsr = new RssRegisterShuffleRequest(testAppId, shuffleId,
+        Lists.newArrayList(new PartitionRange(0, 0)), "");
+    registerShuffle(rrsr);
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
+    Map<Long, byte[]> dataMap = Maps.newHashMap();
+    Roaring64NavigableMap[] bitmaps = new Roaring64NavigableMap[1];
+    bitmaps[0] = Roaring64NavigableMap.bitmapOf();
+    List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+        shuffleId, partitionId, 0, 3, 25,
+        expectBlockIds, dataMap, mockSSI);
+
+
+    RssSendShuffleDataRequest rssdr = getRssSendShuffleDataRequest(testAppId, shuffleId, partitionId, blocks);
+    shuffleServerClients.get(1).sendShuffleData(rssdr);
+    shuffleServerClients.get(2).sendShuffleData(rssdr);
+
+    MemoryQuorumClientReadHandler memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
+        testAppId, shuffleId, partitionId, 150, shuffleServerClients, processBlockIds);
+    LocalFileQuorumClientReadHandler localFileQuorumClientReadHandler = new LocalFileQuorumClientReadHandler(
+        testAppId, shuffleId, partitionId, 0, 1, 1,
+        75, expectBlockIds, processBlockIds, shuffleServerClients);
+    ClientReadHandler[] handlers = new ClientReadHandler[2];
+    handlers[0] = memoryQuorumClientReadHandler;
+    handlers[1] = localFileQuorumClientReadHandler;
+    ComposedClientReadHandler composedClientReadHandler = new ComposedClientReadHandler(handlers);
+    ShuffleDataResult sdr  = composedClientReadHandler.readShuffleData();
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    expectedData.clear();
+    expectedData.put(blocks.get(0).getBlockId(), blocks.get(0).getData());
+    expectedData.put(blocks.get(1).getBlockId(), blocks.get(1).getData());
+    expectedData.put(blocks.get(2).getBlockId(), blocks.get(1).getData());
+    TestUtils.validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks.get(0).getBlockId());
+    processBlockIds.addLong(blocks.get(1).getBlockId());
+    processBlockIds.addLong(blocks.get(2).getBlockId());
+
+    // send data to shuffle server, and wait until flush finish
+    List<ShuffleBlockInfo> blocks2 = createShuffleBlockList(
+        shuffleId, partitionId, 0, 3, 50,
+        expectBlockIds, dataMap, mockSSI);
+    rssdr = getRssSendShuffleDataRequest(testAppId, shuffleId, partitionId, blocks2);
+    shuffleServerClients.get(1).sendShuffleData(rssdr);
+    shuffleServerClients.get(2).sendShuffleData(rssdr);
+
+    int retry = 0;
+    while (true) {
+      if (retry > 5) {
+        fail("Timeout for flush data");
+      }
+      ShuffleBuffer shuffleBuffer = shuffleServers.get(0).getShuffleBufferManager()
+          .getShuffleBuffer(testAppId, shuffleId, 0);
+      if (shuffleBuffer.getBlocks().size() == 0 && shuffleBuffer.getInFlushBlockMap().size() == 0) {
+        break;
+      }
+      Thread.sleep(1000);
+      retry++;
+    }
+
+    // read the 2-th segment from localFile
+    // notice: the 1-th segment is skipped, because it is processed
+    sdr  = composedClientReadHandler.readShuffleData();
+    expectedData.clear();
+    expectedData.put(blocks2.get(0).getBlockId(), blocks2.get(0).getData());
+    expectedData.put(blocks2.get(1).getBlockId(), blocks2.get(1).getData());
+    TestUtils.validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks2.get(0).getBlockId());
+    processBlockIds.addLong(blocks2.get(1).getBlockId());
+
+    // read the 3-th segment from localFile
+    sdr  = composedClientReadHandler.readShuffleData();
+    expectedData.clear();
+    expectedData.put(blocks2.get(2).getBlockId(), blocks2.get(2).getData());
+    TestUtils.validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks2.get(2).getBlockId());
+
+    // all segments are processed
+    sdr  = composedClientReadHandler.readShuffleData();
+    assertNull(sdr);
+  }
+
+  private RssSendShuffleDataRequest getRssSendShuffleDataRequest(String appId, int shuffleId, int partitionId, List<ShuffleBlockInfo> blocks) {
+    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(partitionId, blocks);
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(shuffleId, partitionToBlocks);
+    return new RssSendShuffleDataRequest(
+        appId, 3, 1000, shuffleToBlocks);
+  }
+
+  private void registerShuffle(RssRegisterShuffleRequest rrsr) {
+    shuffleServerClients.forEach((client) -> {
+      client.registerShuffle(rrsr);
+    });
+  }
+
+  public static MockedShuffleServer createServer(int id) throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 40.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 500L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
+    shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    File dataDir1 = new File(tmpDir, id + "_1");
+    File dataDir2 = new File(tmpDir, id + "_2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
+    shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + id);
+    shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    return new MockedShuffleServer(shuffleServerConf);
+  }
+
+  public static void cleanCluster() throws Exception {
+    for (CoordinatorServer coordinator : coordinators) {
+      coordinator.stopServer();
+    }
+    for (ShuffleServer shuffleServer : shuffleServers) {
+      shuffleServer.stopServer();
+    }
+    shuffleServers = Lists.newArrayList();
+    coordinators = Lists.newArrayList();
+  }
+}

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -203,7 +203,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
     shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + id);
     shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
     return new MockedShuffleServer(shuffleServerConf);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -203,7 +203,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
     shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + id);
     shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
-    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    shuffleServerConf.setString("rss.storage.basePath", basePath);
     return new MockedShuffleServer(shuffleServerConf);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -115,7 +115,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
 
     // read the 1-th segment from memory
     MemoryQuorumClientReadHandler memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
-      testAppId, shuffleId, partitionId, 150, Lists.newArrayList(shuffleServerClient));
+      testAppId, shuffleId, partitionId, 150, Lists.newArrayList(shuffleServerClient), Roaring64NavigableMap.bitmapOf());
     LocalFileQuorumClientReadHandler localFileQuorumClientReadHandler = new LocalFileQuorumClientReadHandler(
       testAppId, shuffleId, partitionId, 0, 1, 3,
       75, expectBlockIds, processBlockIds, Lists.newArrayList(shuffleServerClient));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemoryTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemoryTest.java
@@ -114,7 +114,7 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
         .getShuffleBuffer(testAppId, shuffleId, 0).getBlocks().size());
     // create memory handler to read data,
     MemoryQuorumClientReadHandler memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
-        testAppId, shuffleId, partitionId, 20, Lists.newArrayList(shuffleServerClient));
+        testAppId, shuffleId, partitionId, 20, Lists.newArrayList(shuffleServerClient), Roaring64NavigableMap.bitmapOf());
     // start to read data, one block data for every call
     ShuffleDataResult sdr  = memoryQuorumClientReadHandler.readShuffleData();
     Map<Long, byte[]> expectedData = Maps.newHashMap();
@@ -137,7 +137,7 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
 
     // case: read with ComposedClientReadHandler
     memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
-        testAppId, shuffleId, partitionId, 50, Lists.newArrayList(shuffleServerClient));
+        testAppId, shuffleId, partitionId, 50, Lists.newArrayList(shuffleServerClient), Roaring64NavigableMap.bitmapOf());
     LocalFileQuorumClientReadHandler localFileQuorumClientReadHandler = new LocalFileQuorumClientReadHandler(
         testAppId, shuffleId, partitionId, 0, 1, 3,
         50, expectBlockIds, processBlockIds, Lists.newArrayList(shuffleServerClient));
@@ -235,7 +235,7 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
 
     // read the 1-th segment from memory
     MemoryQuorumClientReadHandler memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
-      testAppId, shuffleId, partitionId, 150, Lists.newArrayList(shuffleServerClient));
+      testAppId, shuffleId, partitionId, 150, Lists.newArrayList(shuffleServerClient), Roaring64NavigableMap.bitmapOf());
     LocalFileQuorumClientReadHandler localFileQuorumClientReadHandler = new LocalFileQuorumClientReadHandler(
       testAppId, shuffleId, partitionId, 0, 1, 3,
       75, expectBlockIds, processBlockIds, Lists.newArrayList(shuffleServerClient));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
+import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -52,6 +53,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -234,8 +236,8 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
 
     try {
-      readClient.readShuffleBlockData();
-      fail(EXPECTED_EXCEPTION_MESSAGE);
+      CompressedShuffleBlock compressedShuffleBlock = readClient.readShuffleBlockData();
+      assertNull(compressedShuffleBlock);
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Failed to read all replicas for"));
     }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetInMemoryShuffleDataRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetInMemoryShuffleDataRequest.java
@@ -17,20 +17,25 @@
 
 package org.apache.uniffle.client.request;
 
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
 public class RssGetInMemoryShuffleDataRequest {
   private final String appId;
   private final int shuffleId;
   private final int partitionId;
   private final long lastBlockId;
   private final int readBufferSize;
+  private final Roaring64NavigableMap processBlockIds;
 
   public RssGetInMemoryShuffleDataRequest(
-      String appId, int shuffleId, int partitionId, long lastBlockId, int readBufferSize) {
+      String appId, int shuffleId, int partitionId, long lastBlockId, int readBufferSize,
+      Roaring64NavigableMap processBlockIds) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
     this.lastBlockId = lastBlockId;
     this.readBufferSize = readBufferSize;
+    this.processBlockIds = processBlockIds;
   }
 
   public String getAppId() {
@@ -51,5 +56,9 @@ public class RssGetInMemoryShuffleDataRequest {
 
   public int getReadBufferSize() {
     return readBufferSize;
+  }
+
+  public Roaring64NavigableMap getProcessBlockIds() {
+    return processBlockIds;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -88,6 +88,7 @@ message GetMemoryShuffleDataRequest {
   int32 partitionId = 3;
   int64 lastBlockId = 4;
   int32 readBufferSize = 5;
+  bytes processedBlockIds = 6;
 }
 
 message GetMemoryShuffleDataResponse {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -28,6 +28,7 @@ import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.proto.RssProtos.AppHeartBeatRequest;
 import org.apache.uniffle.proto.RssProtos.AppHeartBeatResponse;
@@ -516,8 +518,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     // todo: if can get the exact memory size?
     if (shuffleServer.getShuffleBufferManager().requireReadMemoryWithRetry(readBufferSize)) {
       try {
+        Roaring64NavigableMap processedBlockIds =
+            RssUtils.deserializeBitMap(request.getProcessedBlockIds().toByteArray());
         ShuffleDataResult shuffleDataResult = shuffleServer.getShuffleTaskManager()
-            .getInMemoryShuffleData(appId, shuffleId, partitionId, blockId, readBufferSize);
+            .getInMemoryShuffleData(appId, shuffleId, partitionId, blockId, readBufferSize, processedBlockIds);
         byte[] data = new byte[]{};
         List<BufferSegment> bufferSegments = Lists.newArrayList();
         if (shuffleDataResult != null) {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -322,9 +322,10 @@ public class ShuffleTaskManager {
   }
 
   public ShuffleDataResult getInMemoryShuffleData(
-      String appId, Integer shuffleId, Integer partitionId, long blockId, int readBufferSize) {
+      String appId, Integer shuffleId, Integer partitionId, long blockId,
+      int readBufferSize, Roaring64NavigableMap processedBlockIds) {
     return shuffleBufferManager.getShuffleData(appId,
-        shuffleId, partitionId, blockId, readBufferSize);
+        shuffleId, partitionId, blockId, readBufferSize, processedBlockIds);
   }
 
   public ShuffleDataResult getShuffleData(

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,12 +123,12 @@ public class ShuffleBuffer {
   // 2. according to info from step 1, generate data
   // todo: if block was flushed, it's possible to get duplicated data
   public synchronized ShuffleDataResult getShuffleData(
-      long lastBlockId, int readBufferSize) {
+      long lastBlockId, int readBufferSize, Roaring64NavigableMap processedBlockIds) {
     try {
       List<BufferSegment> bufferSegments = Lists.newArrayList();
       List<ShufflePartitionedBlock> readBlocks = Lists.newArrayList();
       updateBufferSegmentsAndResultBlocks(
-          lastBlockId, readBufferSize, bufferSegments, readBlocks);
+          lastBlockId, readBufferSize, bufferSegments, readBlocks, processedBlockIds);
       if (!bufferSegments.isEmpty()) {
         int length = calculateDataLength(bufferSegments);
         byte[] data = new byte[length];
@@ -141,6 +142,12 @@ public class ShuffleBuffer {
     return new ShuffleDataResult();
   }
 
+  public synchronized ShuffleDataResult getShuffleData(
+      long lastBlockId, int readBufferSize) {
+    return getShuffleData(lastBlockId, readBufferSize, Roaring64NavigableMap.bitmapOf());
+  }
+
+
   // here is the rule to read data in memory:
   // 1. read from inFlushBlockMap order by eventId asc, then from blocks
   // 2. if can't find lastBlockId, means related data may be flushed to storage, repeat step 1
@@ -148,7 +155,8 @@ public class ShuffleBuffer {
       long lastBlockId,
       long readBufferSize,
       List<BufferSegment> bufferSegments,
-      List<ShufflePartitionedBlock> resultBlocks) {
+      List<ShufflePartitionedBlock> resultBlocks,
+      Roaring64NavigableMap processedBlockIds) {
     long nextBlockId = lastBlockId;
     List<Long> sortedEventId = sortFlushingEventId();
     int offset = 0;
@@ -161,12 +169,12 @@ public class ShuffleBuffer {
       for (Long eventId : sortedEventId) {
         // update bufferSegments with different strategy according to lastBlockId
         if (nextBlockId == Constants.INVALID_BLOCK_ID) {
-          updateSegmentsWithoutBlockId(offset, inFlushBlockMap.get(eventId), readBufferSize,
-              bufferSegments, resultBlocks);
+          updateSegmentsWithBlockId(offset, inFlushBlockMap.get(eventId), readBufferSize,
+              nextBlockId, bufferSegments, resultBlocks, processedBlockIds);
           hasLastBlockId = true;
         } else {
           hasLastBlockId = updateSegmentsWithBlockId(offset, inFlushBlockMap.get(eventId),
-              readBufferSize, nextBlockId, bufferSegments, resultBlocks);
+              readBufferSize, nextBlockId, bufferSegments, resultBlocks, processedBlockIds);
           // if last blockId is found, read from begin with next cached blocks
           if (hasLastBlockId) {
             // reset blockId to read from begin in next cached blocks
@@ -184,11 +192,12 @@ public class ShuffleBuffer {
     // try to read from cached blocks which is not in flush queue
     if (blocks.size() > 0 && offset < readBufferSize) {
       if (nextBlockId == Constants.INVALID_BLOCK_ID) {
-        updateSegmentsWithoutBlockId(offset, blocks, readBufferSize, bufferSegments, resultBlocks);
+        updateSegmentsWithBlockId(offset, blocks, readBufferSize, nextBlockId,
+            bufferSegments, resultBlocks, processedBlockIds);
         hasLastBlockId = true;
       } else {
         hasLastBlockId = updateSegmentsWithBlockId(offset, blocks,
-            readBufferSize, nextBlockId, bufferSegments, resultBlocks);
+            readBufferSize, nextBlockId, bufferSegments, resultBlocks, processedBlockIds);
       }
     }
     if ((!inFlushBlockMap.isEmpty() || blocks.size() > 0) && offset == 0 && !hasLastBlockId) {
@@ -196,7 +205,7 @@ public class ShuffleBuffer {
       // but there still has data in memory
       // try read again with blockId = Constants.INVALID_BLOCK_ID
       updateBufferSegmentsAndResultBlocks(
-          Constants.INVALID_BLOCK_ID, readBufferSize, bufferSegments, resultBlocks);
+          Constants.INVALID_BLOCK_ID, readBufferSize, bufferSegments, resultBlocks, processedBlockIds);
     }
   }
 
@@ -232,50 +241,33 @@ public class ShuffleBuffer {
     return eventIdList;
   }
 
-  private void updateSegmentsWithoutBlockId(
-      int offset,
-      List<ShufflePartitionedBlock> cachedBlocks,
-      long readBufferSize,
-      List<BufferSegment> bufferSegments,
-      List<ShufflePartitionedBlock> readBlocks) {
-    int currentOffset = offset;
-    // read from first block
-    for (ShufflePartitionedBlock block : cachedBlocks) {
-      // add bufferSegment with block
-      bufferSegments.add(new BufferSegment(block.getBlockId(), currentOffset, block.getLength(),
-          block.getUncompressLength(), block.getCrc(), block.getTaskAttemptId()));
-      readBlocks.add(block);
-      // update offset
-      currentOffset += block.getLength();
-      // check if length >= request buffer size
-      if (currentOffset >= readBufferSize) {
-        break;
-      }
-    }
-  }
-
   private boolean updateSegmentsWithBlockId(
       int offset,
       List<ShufflePartitionedBlock> cachedBlocks,
       long readBufferSize,
       long lastBlockId,
       List<BufferSegment> bufferSegments,
-      List<ShufflePartitionedBlock> readBlocks) {
+      List<ShufflePartitionedBlock> readBlocks,
+      Roaring64NavigableMap processedBlockIds) {
     int currentOffset = offset;
     // find lastBlockId, then read from next block
     boolean foundBlockId = false;
     for (ShufflePartitionedBlock block : cachedBlocks) {
-      if (!foundBlockId) {
+      if (lastBlockId != Constants.INVALID_BLOCK_ID && !foundBlockId) {
         // find lastBlockId
         if (block.getBlockId() == lastBlockId) {
           foundBlockId = true;
         }
         continue;
       }
+      if (processedBlockIds.contains(block.getBlockId())) {
+        continue;
+      }
       // add bufferSegment with block
       bufferSegments.add(new BufferSegment(block.getBlockId(), currentOffset, block.getLength(),
           block.getUncompressLength(), block.getCrc(), block.getTaskAttemptId()));
       readBlocks.add(block);
+      processedBlockIds.addLong(block.getBlockId());
       // update offset
       currentOffset += block.getLength();
       if (currentOffset >= readBufferSize) {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeMap;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,12 @@ public class ShuffleBufferManager {
   public ShuffleDataResult getShuffleData(
       String appId, int shuffleId, int partitionId, long blockId,
       int readBufferSize) {
+    return getShuffleData(appId, shuffleId, partitionId, blockId, readBufferSize, Roaring64NavigableMap.bitmapOf());
+  }
+
+  public ShuffleDataResult getShuffleData(
+      String appId, int shuffleId, int partitionId, long blockId,
+      int readBufferSize, Roaring64NavigableMap processedBlockIds) {
     Map.Entry<Range<Integer>, ShuffleBuffer> entry = getShuffleBufferEntry(
         appId, shuffleId, partitionId);
     if (entry == null) {
@@ -154,7 +161,7 @@ public class ShuffleBufferManager {
     if (buffer == null) {
       return null;
     }
-    return buffer.getShuffleData(blockId, readBufferSize);
+    return buffer.getShuffleData(blockId, readBufferSize, processedBlockIds);
   }
 
   void flushIfNecessary() {

--- a/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
@@ -116,7 +116,8 @@ public class ShuffleHandlerFactory {
           request.getShuffleId(),
           request.getPartitionId(),
           request.getReadBufferSize(),
-          shuffleServerClients);
+          shuffleServerClients,
+          request.getProcessBlockIds());
       ClientReadHandler localClientReadHandler = new LocalFileQuorumClientReadHandler(request.getAppId(),
           request.getShuffleId(), request.getPartitionId(), request.getIndexReadLimit(),
           request.getPartitionNumPerRange(), request.getPartitionNum(),
@@ -135,7 +136,8 @@ public class ShuffleHandlerFactory {
           request.getShuffleId(),
           request.getPartitionId(),
           request.getReadBufferSize(),
-          shuffleServerClients);
+          shuffleServerClients,
+          request.getProcessBlockIds());
       }, () -> {
         return new HdfsClientReadHandler(
             request.getAppId(),
@@ -162,7 +164,8 @@ public class ShuffleHandlerFactory {
             request.getShuffleId(),
             request.getPartitionId(),
             request.getReadBufferSize(),
-            shuffleServerClients);
+            shuffleServerClients,
+            request.getProcessBlockIds());
       }, () -> {
         return new LocalFileQuorumClientReadHandler(request.getAppId(),
             request.getShuffleId(), request.getPartitionId(), request.getIndexReadLimit(),

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.File;
 import java.io.FilenameFilter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,8 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
     File baseFolder = new File(fullShufflePath);
     if (!baseFolder.exists()) {
       // the partition doesn't exist in this base folder, skip
-      throw new RuntimeException("Can't find folder " + fullShufflePath);
+      LOG.warn("Can't find folder " + fullShufflePath);
+      return;
     }
     File[] indexFiles;
     String failedGetIndexFileMsg = "No index file found in  " + storageBasePath;
@@ -117,6 +119,9 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
 
   @Override
   public ShuffleDataResult getShuffleData(long offset, int length) {
+    if (StringUtils.isBlank(dataFileName)) {
+      throw new RuntimeException(dataFileName + "is empty!");
+    }
     byte[] readBuffer = new byte[0];
 
     try {
@@ -136,6 +141,9 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
 
   @Override
   public ShuffleIndexResult getShuffleIndex() {
+    if (StringUtils.isBlank(indexFileName)) {
+      return new ShuffleIndexResult();
+    }
     int indexNum = 0;
     int len = 0;
     try (LocalFileReader reader = createFileReader(indexFileName)) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
@@ -20,7 +20,6 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.File;
 import java.io.FilenameFilter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,8 +80,7 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
     File baseFolder = new File(fullShufflePath);
     if (!baseFolder.exists()) {
       // the partition doesn't exist in this base folder, skip
-      LOG.warn("Can't find folder " + fullShufflePath);
-      return;
+      throw new RuntimeException("Can't find folder " + fullShufflePath);
     }
     File[] indexFiles;
     String failedGetIndexFileMsg = "No index file found in  " + storageBasePath;
@@ -119,9 +117,6 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
 
   @Override
   public ShuffleDataResult getShuffleData(long offset, int length) {
-    if (StringUtils.isBlank(dataFileName)) {
-      throw new RuntimeException(dataFileName + "is empty!");
-    }
     byte[] readBuffer = new byte[0];
 
     try {
@@ -141,9 +136,6 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
 
   @Override
   public ShuffleIndexResult getShuffleIndex() {
-    if (StringUtils.isBlank(indexFileName)) {
-      return new ShuffleIndexResult();
-    }
     int indexNum = 0;
     int len = 0;
     try (LocalFileReader reader = createFileReader(indexFileName)) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MemoryClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MemoryClientReadHandler.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.storage.handler.impl;
 
 import java.util.List;
 
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import org.apache.uniffle.common.util.Constants;
 public class MemoryClientReadHandler extends AbstractClientReadHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(MemoryClientReadHandler.class);
+  private final Roaring64NavigableMap processBlockIds;
   private long lastBlockId = Constants.INVALID_BLOCK_ID;
   private ShuffleServerClient shuffleServerClient;
 
@@ -41,12 +43,14 @@ public class MemoryClientReadHandler extends AbstractClientReadHandler {
       int shuffleId,
       int partitionId,
       int readBufferSize,
-      ShuffleServerClient shuffleServerClient) {
+      ShuffleServerClient shuffleServerClient,
+      Roaring64NavigableMap processBlockIds) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
     this.readBufferSize = readBufferSize;
     this.shuffleServerClient = shuffleServerClient;
+    this.processBlockIds = processBlockIds;
   }
 
   @Override
@@ -54,7 +58,7 @@ public class MemoryClientReadHandler extends AbstractClientReadHandler {
     ShuffleDataResult result = null;
 
     RssGetInMemoryShuffleDataRequest request = new RssGetInMemoryShuffleDataRequest(
-        appId,shuffleId, partitionId, lastBlockId, readBufferSize);
+        appId,shuffleId, partitionId, lastBlockId, readBufferSize, processBlockIds);
 
     try {
       RssGetInMemoryShuffleDataResponse response =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1.In client side, try read from all shuffle servers when read shuffle data. When read shuffle data from memory, pass `processBlockIds` to server side to achieve exclude duplication blocks
2.In server side,  exclude duplication blocks when read memory shuffle data

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When the data in this first server is damaged, application will fail. #124 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Already added