### PR TITLE
[Improvement] Add timeout reconnection when DelegationRssShuffleManager send the request of AccessCluster

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -215,12 +215,12 @@ public class RssSparkConfig {
           new ConfigBuilder(SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES))
           .createWithDefault(RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE);
 
-  public static final ConfigEntry<Long> RSS_CLIENT_FALLBACK_RETRY_INTERVAL = createLongBuilder(
+  public static final ConfigEntry<Long> RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS = createLongBuilder(
       new ConfigBuilder("spark.rss.client.access.retry.interval.ms")
           .doc("Interval between retries fallback to SortShuffleManager"))
       .createWithDefault(20000L);
 
-  public static final ConfigEntry<Integer> RSS_CLIENT_FALLBACK_RETRY_TIMES = createIntegerBuilder(
+  public static final ConfigEntry<Integer> RSS_CLIENT_ACCESS_RETRY_TIMES = createIntegerBuilder(
       new ConfigBuilder("spark.rss.client.access.retry.times")
           .doc("Number of retries fallback to SortShuffleManager"))
       .createWithDefault(0);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -214,7 +214,17 @@ public class RssSparkConfig {
   public static final ConfigEntry<Integer> RSS_CLIENT_ASSIGNMENT_RETRY_TIMES = createIntegerBuilder(
           new ConfigBuilder(SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES))
           .createWithDefault(RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE);
-  
+
+  public static final ConfigEntry<Long> RSS_CLIENT_FALLBACK_RETRY_INTERVAL = createLongBuilder(
+      new ConfigBuilder("spark.rss.client.fallback.retry.interval")
+          .doc("Interval between retries fallback to SortShuffleManager"))
+      .createWithDefault(20000L);
+
+  public static final ConfigEntry<Integer> RSS_CLIENT_FALLBACK_RETRY_TIMES = createIntegerBuilder(
+      new ConfigBuilder("spark.rss.client.fallback.retry.times")
+          .doc("Number of retries fallback to SortShuffleManager"))
+      .createWithDefault(3);
+
   public static final ConfigEntry<String> RSS_COORDINATOR_QUORUM = createStringBuilder(
       new ConfigBuilder(SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_COORDINATOR_QUORUM)
           .doc("Coordinator quorum"))

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -216,14 +216,14 @@ public class RssSparkConfig {
           .createWithDefault(RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE);
 
   public static final ConfigEntry<Long> RSS_CLIENT_FALLBACK_RETRY_INTERVAL = createLongBuilder(
-      new ConfigBuilder("spark.rss.client.fallback.retry.interval")
+      new ConfigBuilder("spark.rss.client.access.retry.interval.ms")
           .doc("Interval between retries fallback to SortShuffleManager"))
       .createWithDefault(20000L);
 
   public static final ConfigEntry<Integer> RSS_CLIENT_FALLBACK_RETRY_TIMES = createIntegerBuilder(
-      new ConfigBuilder("spark.rss.client.fallback.retry.times")
+      new ConfigBuilder("spark.rss.client.access.retry.times")
           .doc("Number of retries fallback to SortShuffleManager"))
-      .createWithDefault(3);
+      .createWithDefault(0);
 
   public static final ConfigEntry<String> RSS_COORDINATOR_QUORUM = createStringBuilder(
       new ConfigBuilder(SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_COORDINATOR_QUORUM)

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -96,8 +96,8 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       LOG.warn("Access id key is empty");
       return false;
     }
-    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
-    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
       Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -34,6 +34,7 @@ import org.apache.uniffle.client.response.ResponseStatusCode;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.common.util.RetryUtils;
 
 public class DelegationRssShuffleManager implements ShuffleManager {
 
@@ -95,25 +96,29 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       LOG.warn("Access id key is empty");
       return false;
     }
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
+      boolean canAccess = false;
       try {
-        Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
-
-        RssAccessClusterResponse response =
-            coordinatorClient.accessCluster(new RssAccessClusterRequest(
-                accessId, assignmentTags, accessTimeoutMs));
-        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
-          LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
-          return true;
-        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
-          LOG.warn("Request to access cluster {} is denied using {} for {}",
-              coordinatorClient.getDesc(), accessId, response.getMessage());
-          return false;
-        } else {
-          LOG.warn("Fail to reach cluster {} for {}", coordinatorClient.getDesc(), response.getMessage());
-        }
-      } catch (Exception e) {
+        canAccess = RetryUtils.retry(() -> {
+          RssAccessClusterResponse response = coordinatorClient.accessCluster(new RssAccessClusterRequest(
+              accessId, assignmentTags, accessTimeoutMs));
+          if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+            LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
+            return true;
+          } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+            throw new RssException("Request to access cluster " + coordinatorClient.getDesc() + " is denied using "
+                + accessId + " for " + response.getMessage());
+          } else {
+            throw new RssException("Fail to reach cluster " + coordinatorClient.getDesc()
+                + " for " + response.getMessage());
+          }
+        }, retryInterval, retryTimes);
+        return canAccess;
+      } catch (Throwable e) {
         LOG.warn("Fail to access cluster {} using {} for {}",
             coordinatorClient.getDesc(), accessId, e.getMessage());
       }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -101,7 +101,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
       Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
-      boolean canAccess = false;
+      boolean canAccess;
       try {
         canAccess = RetryUtils.retry(() -> {
           RssAccessClusterResponse response = coordinatorClient.accessCluster(new RssAccessClusterRequest(

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -159,6 +159,24 @@ public class DelegationRssShuffleManagerTest {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     assertCreateRssShuffleManager(conf);
+
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> SecondCoordinatorClients = Lists.newArrayList();
+    SecondCoordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssSparkShuffleUtils.createCoordinatorClients(any())).thenReturn(SecondCoordinatorClients);
+    SparkConf SecondConf = new SparkConf();
+    SecondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
+    SecondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES, 3);
+    SecondConf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    SecondConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    SecondConf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    SecondConf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    assertCreateSortShuffleManager(SecondConf);
   }
 
   private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -143,7 +143,7 @@ public class DelegationRssShuffleManagerTest {
     String message = null;
     try {
       canAccess = RetryUtils.retry(() -> {
-        RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "")
+        RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "");
         if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
           return true;
         } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
@@ -155,7 +155,7 @@ public class DelegationRssShuffleManagerTest {
     } catch (Throwable e) {
       message = e.getMessage();
     }
-    assertTrue(message.startsWith("Request to access cluster m1 is denied"))
+    assertTrue(message.startsWith("Request to access cluster m1 is denied"));
     assertFalse(canAccess);
   }
 

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mockito;
 
 import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.RetryUtils;
 
 import static org.apache.uniffle.client.response.ResponseStatusCode.ACCESS_DENIED;
 import static org.apache.uniffle.client.response.ResponseStatusCode.SUCCESS;
@@ -137,16 +139,16 @@ public class DelegationRssShuffleManagerTest {
   @Test
   public void testTryAccessCluster() {
     SparkConf conf = new SparkConf();
-    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
-    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
+    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
     boolean canAccess = false;
     String message = null;
     try {
       canAccess = RetryUtils.retry(() -> {
         RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "");
-        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+        if (response.getStatusCode() == SUCCESS) {
           return true;
-        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+        } else if (response.getStatusCode() == ACCESS_DENIED) {
           throw new RssException("Request to access cluster m1 is denied");
         } else {
           throw new RssException("Fail to reach cluster");

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -96,8 +96,8 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       LOG.warn("Access id key is empty");
       return false;
     }
-    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
-    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
       Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -34,6 +34,7 @@ import org.apache.uniffle.client.response.ResponseStatusCode;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.common.util.RetryUtils;
 
 public class DelegationRssShuffleManager implements ShuffleManager {
 
@@ -95,25 +96,29 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       LOG.warn("Access id key is empty");
       return false;
     }
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
+      boolean canAccess = false;
       try {
-        Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
-
-        RssAccessClusterResponse response =
-            coordinatorClient.accessCluster(new RssAccessClusterRequest(
-                accessId, assignmentTags, accessTimeoutMs));
-        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
-          LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
-          return true;
-        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
-          LOG.warn("Request to access cluster {} is denied using {} for {}",
-              coordinatorClient.getDesc(), accessId, response.getMessage());
-          return false;
-        } else {
-          LOG.warn("Fail to reach cluster {} for {}", coordinatorClient.getDesc(), response.getMessage());
-        }
-      } catch (Exception e) {
+        canAccess = RetryUtils.retry(() -> {
+          RssAccessClusterResponse response = coordinatorClient.accessCluster(new RssAccessClusterRequest(
+              accessId, assignmentTags, accessTimeoutMs));
+          if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+            LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
+            return true;
+          } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+            throw new RssException("Request to access cluster " + coordinatorClient.getDesc() + " is denied using "
+                + accessId + " for " + response.getMessage());
+          } else {
+            throw new RssException("Fail to reach cluster " + coordinatorClient.getDesc()
+                + " for " + response.getMessage());
+          }
+        }, retryInterval, retryTimes);
+        return canAccess;
+      } catch (Throwable e) {
         LOG.warn("Fail to access cluster {} using {} for {}",
             coordinatorClient.getDesc(), accessId, e.getMessage());
       }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -101,7 +101,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
 
     for (CoordinatorClient coordinatorClient : coordinatorClients) {
       Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
-      boolean canAccess = false;
+      boolean canAccess;
       try {
         canAccess = RetryUtils.retry(() -> {
           RssAccessClusterResponse response = coordinatorClient.accessCluster(new RssAccessClusterRequest(

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -138,28 +138,24 @@ public class DelegationRssShuffleManagerTest {
   }
 
   @Test
-  public void testTryAccessCluster() {
+  public void testTryAccessCluster() throws Exception {
+    CoordinatorClient mockDeniedCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockDeniedCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockDeniedCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssSparkShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
     SparkConf conf = new SparkConf();
-    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
-    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
-    boolean canAccess = false;
-    String message = null;
-    try {
-      canAccess = RetryUtils.retry(() -> {
-        RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "");
-        if (response.getStatusCode() == SUCCESS) {
-          return true;
-        } else if (response.getStatusCode() == ACCESS_DENIED) {
-          throw new RssException("Request to access cluster m1 is denied");
-        } else {
-          throw new RssException("Fail to reach cluster");
-        }
-      }, retryInterval, retryTimes);
-    } catch (Throwable e) {
-      message = e.getMessage();
-    }
-    assertTrue(message.startsWith("Request to access cluster m1 is denied"));
-    assertFalse(canAccess);
+    conf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
+    conf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES, 3);
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    assertCreateRssShuffleManager(conf);
   }
 
   private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -33,6 +33,8 @@ import org.mockito.Mockito;
 
 import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.RetryUtils;
 
 import static org.apache.uniffle.client.response.ResponseStatusCode.ACCESS_DENIED;
 import static org.apache.uniffle.client.response.ResponseStatusCode.SUCCESS;
@@ -138,16 +140,16 @@ public class DelegationRssShuffleManagerTest {
   @Test
   public void testTryAccessCluster() {
     SparkConf conf = new SparkConf();
-    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
-    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
+    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
     boolean canAccess = false;
     String message = null;
     try {
       canAccess = RetryUtils.retry(() -> {
         RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "");
-        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+        if (response.getStatusCode() == SUCCESS) {
           return true;
-        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+        } else if (response.getStatusCode() == ACCESS_DENIED) {
           throw new RssException("Request to access cluster m1 is denied");
         } else {
           throw new RssException("Fail to reach cluster");

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -156,6 +156,24 @@ public class DelegationRssShuffleManagerTest {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     assertCreateRssShuffleManager(conf);
+
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> SecondCoordinatorClients = Lists.newArrayList();
+    SecondCoordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssSparkShuffleUtils.createCoordinatorClients(any())).thenReturn(SecondCoordinatorClients);
+    SparkConf SecondConf = new SparkConf();
+    SecondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
+    SecondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES, 3);
+    SecondConf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    SecondConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    SecondConf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    SecondConf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    assertCreateSortShuffleManager(SecondConf);
   }
 
   private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -135,6 +135,31 @@ public class DelegationRssShuffleManagerTest {
     assertTrue(hasException);
   }
 
+  @Test
+  public void testTryAccessCluster() {
+    SparkConf conf = new SparkConf();
+    long retryInterval = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_INTERVAL);
+    int retryTimes = conf.get(RssSparkConfig.RSS_CLIENT_FALLBACK_RETRY_TIMES);
+    boolean canAccess = false;
+    String message = null;
+    try {
+      canAccess = RetryUtils.retry(() -> {
+        RssAccessClusterResponse response = new RssAccessClusterResponse(ACCESS_DENIED, "");
+        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+          return true;
+        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+          throw new RssException("Request to access cluster m1 is denied");
+        } else {
+          throw new RssException("Fail to reach cluster");
+        }
+      }, retryInterval, retryTimes);
+    } catch (Throwable e) {
+      message = e.getMessage();
+    }
+    assertTrue(message.startsWith("Request to access cluster m1 is denied"));
+    assertFalse(canAccess);
+  }
+
   private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -113,6 +113,8 @@ Other configuration:
 |Property Name|Default|Description|
 |---|---|---|
 |spark.rss.access.timeout.ms|10000|The timeout to access Uniffle coordinator|
+|spark.rss.client.access.retry.interval.ms|20000|The interval between retries fallback to SortShuffleManager|
+|spark.rss.client.access.retry.times|0|The number of retries fallback to SortShuffleManager|
   
 
 ### Client Quorum Setting 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
To solve issue [#127](https://github.com/apache/incubator-uniffle/issues/127)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid some memory shortage situations, and retry to ensure that the tasks run in the RSS cluster as much as possible.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Two new parameters are added on the client side, `spark.rss.client.access.retry.times`  the number of retry reconnection and `spark.rss.client.access.retry.interval.ms`  the reconnection interval. The user can set these two parameters within his expected time to make the task run in the RSS cluster as much as possible.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No need.