### PR TITLE
[BUGFIX] Fix memory leak which cause oom

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -120,11 +120,7 @@ public class WriteBufferManager extends MemoryConsumer {
     if (buffers.containsKey(partitionId)) {
       WriterBuffer wb = buffers.get(partitionId);
       if (wb.askForMemory(serializedDataLength)) {
-        if (serializedDataLength > bufferSegmentSize) {
-          requestMemory(serializedDataLength);
-        } else {
-          requestMemory(bufferSegmentSize);
-        }
+        requestMemory(Math.max(bufferSegmentSize, serializedDataLength));
       }
       wb.addRecord(serializedData, serializedDataLength);
       if (wb.getMemoryUsed() > bufferSize) {
@@ -136,7 +132,7 @@ public class WriteBufferManager extends MemoryConsumer {
             + "], dataLength[" + wb.getDataLength() + "]");
       }
     } else {
-      requestMemory(bufferSegmentSize);
+      requestMemory(Math.max(bufferSegmentSize, serializedDataLength));
       WriterBuffer wb = new WriterBuffer(bufferSegmentSize);
       wb.addRecord(serializedData, serializedDataLength);
       buffers.put(partitionId, wb);

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -123,6 +123,20 @@ public class WriteBufferManagerTest {
   }
 
   @Test
+  public void addHugeRecordTest() {
+    SparkConf conf = getConf();
+    WriteBufferManager wbm = createManager(conf);
+    String testKey = "len_more_than_32";
+    String testValue = "len_more_than_32";
+    List<ShuffleBlockInfo> result = wbm.addRecord(0, testKey, testValue);
+    assertEquals(0, result.size());
+    assertEquals(512, wbm.getAllocatedBytes());
+    assertEquals(36, wbm.getUsedBytes());
+    assertEquals(0, wbm.getInSendListBytes());
+    assertEquals(1, wbm.getBuffers().size());
+  }
+
+  @Test
   public void createBlockIdTest() {
     SparkConf conf = getConf();
     WriteBufferManager wbm = createManager(conf);


### PR DESCRIPTION
### What changes were proposed in this pull request?
the behavior of buffer management and memory allocate
when adding a huge record to a partition where the buffer is not initialized, we only allocate bufferSegmentSize memory, however release the real huge size memory after the buffer is sent.
this will easily cause OOM.

### Why are the changes needed?
better manage memory

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
pass testing