### PR TITLE
[MINOR] Tagged spark hadoop version in release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ rss-xxx.tgz will be generated for deployment
 ### Deploy Spark Client
 1. Add client jar to Spark classpath, eg, SPARK_HOME/jars/
 
-   The jar for Spark2 is located in <RSS_HOME>/jars/client/spark2/rss-client-XXXXX-shaded.jar
+   The jar for Spark2 is located in <RSS_HOME>/jars/client/spark2/rss-client-sparkXX-XXXXX-shaded.jar
 
-   The jar for Spark3 is located in <RSS_HOME>/jars/client/spark3/rss-client-XXXXX-shaded.jar
+   The jar for Spark3 is located in <RSS_HOME>/jars/client/spark3/rss-client-sparkXX-XXXXX-shaded.jar
 
 2. Update Spark conf to enable Uniffle, eg,
 
@@ -206,7 +206,7 @@ After apply the patch and rebuild spark, add following configuration in spark co
 
 1. Add client jar to the classpath of each NodeManager, e.g., <HADOOP>/share/hadoop/mapreduce/
 
-The jar for MapReduce is located in <RSS_HOME>/jars/client/mr/rss-client-mr-XXXXX-shaded.jar
+The jar for MapReduce is located in <RSS_HOME>/jars/client/mr/rss-client-mrXX-XXXXX-shaded.jar
 
 2. Update MapReduce conf to enable Uniffle, eg,
 

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ rss-xxx.tgz will be generated for deployment
 ### Deploy Spark Client
 1. Add client jar to Spark classpath, eg, SPARK_HOME/jars/
 
-   The jar for Spark2 is located in <RSS_HOME>/jars/client/spark2/rss-client-sparkXX-XXXXX-shaded.jar
+   The jar for Spark2 is located in <RSS_HOME>/jars/client/spark2/rss-client-XXXXX-shaded.jar
 
-   The jar for Spark3 is located in <RSS_HOME>/jars/client/spark3/rss-client-sparkXX-XXXXX-shaded.jar
+   The jar for Spark3 is located in <RSS_HOME>/jars/client/spark3/rss-client-XXXXX-shaded.jar
 
 2. Update Spark conf to enable Uniffle, eg,
 
@@ -206,7 +206,7 @@ After apply the patch and rebuild spark, add following configuration in spark co
 
 1. Add client jar to the classpath of each NodeManager, e.g., <HADOOP>/share/hadoop/mapreduce/
 
-The jar for MapReduce is located in <RSS_HOME>/jars/client/mr/rss-client-mrXX-XXXXX-shaded.jar
+The jar for MapReduce is located in <RSS_HOME>/jars/client/mr/rss-client-mr-XXXXX-shaded.jar
 
 2. Update MapReduce conf to enable Uniffle, eg,
 

--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -169,7 +169,6 @@ SPARK_CLIENT2_JAR_DIR="${CLIENT_JAR_DIR}/spark2"
 mkdir -p $SPARK_CLIENT2_JAR_DIR
 
 SPARK_CLIENT2_JAR="${RSS_HOME}/client-spark/spark2/target/shaded/rss-client-spark2-${VERSION}-shaded.jar"
-SPARK_CLIENT2_JAR_DIR="$SPARK_CLIENT2_JAR_DIR/rss-client-spark${SPARK2_VERSION}-${VERSION}-shaded.jar"
 echo "copy $SPARK_CLIENT2_JAR to ${SPARK_CLIENT2_JAR_DIR}"
 cp $SPARK_CLIENT2_JAR ${SPARK_CLIENT2_JAR_DIR}
 
@@ -182,7 +181,6 @@ echo -e "\$ ${BUILD_COMMAND_SPARK3[@]}\n"
 SPARK_CLIENT3_JAR_DIR="${CLIENT_JAR_DIR}/spark3"
 mkdir -p $SPARK_CLIENT3_JAR_DIR
 SPARK_CLIENT3_JAR="${RSS_HOME}/client-spark/spark3/target/shaded/rss-client-spark3-${VERSION}-shaded.jar"
-SPARK_CLIENT3_JAR_DIR="$SPARK_CLIENT3_JAR_DIR/rss-client-spark${SPARK3_VERSION}-${VERSION}-shaded.jar"
 echo "copy $SPARK_CLIENT3_JAR to ${SPARK_CLIENT3_JAR_DIR}"
 cp $SPARK_CLIENT3_JAR $SPARK_CLIENT3_JAR_DIR
 
@@ -193,7 +191,6 @@ echo -e "\$ ${BUILD_COMMAND_MR[@]}\n"
 MR_CLIENT_JAR_DIR="${CLIENT_JAR_DIR}/mr"
 mkdir -p $MR_CLIENT_JAR_DIR
 MR_CLIENT_JAR="${RSS_HOME}/client-mr/target/shaded/rss-client-mr-${VERSION}-shaded.jar"
-MR_CLIENT_JAR_DIR="$MR_CLIENT_JAR_DIR/rss-client-mr${HADOOP_VERSION}-${VERSION}-shaded.jar"
 echo "copy $MR_CLIENT_JAR to ${MR_CLIENT_JAR_DIR}"
 cp $MR_CLIENT_JAR $MR_CLIENT_JAR_DIR
 

--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -102,6 +102,20 @@ VERSION=$("$MVN" help:evaluate -Dexpression=project.version $@ 2>/dev/null |
   grep -v "WARNING" |
   tail -n 1)
 
+# Dependencies version
+HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ 2>/dev/null\
+    | grep -v "INFO"\
+    | grep -v "WARNING"\
+    | tail -n 1)
+SPARK2_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version -P$SPARK2_PROFILE_ID $@ $SPARK2_MVN_OPTS 2>/dev/null\
+    | grep -v "INFO"\
+    | grep -v "WARNING"\
+    | tail -n 1)
+SPARK3_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version -P$SPARK3_PROFILE_ID $@ $SPARK3_MVN_OPTS 2>/dev/null\
+    | grep -v "INFO"\
+    | grep -v "WARNING"\
+    | tail -n 1)
+
 echo "RSS version is $VERSION"
 
 export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
@@ -122,8 +136,8 @@ echo -e "\$ ${BUILD_COMMAND[@]}\n"
 DISTDIR="rss-$VERSION"
 rm -rf "$DISTDIR"
 mkdir -p "${DISTDIR}/jars"
-echo "RSS ${VERSION}${GITREVSTRING} built" >"${DISTDIR}/RELEASE"
-echo "Build flags: $@" >>"$DISTDIR/RELEASE"
+echo "RSS ${VERSION}${GITREVSTRING} built for Hadoop ${HADOOP_VERSION} Spark2 ${SPARK2_VERSION} Spark3 ${SPARK3_VERSION}" >"${DISTDIR}/RELEASE"
+echo "Build flags: --spark2-profile '$SPARK2_PROFILE_ID' --spark2-mvn '$SPARK2_MVN_OPTS' --spark3-profile '$SPARK3_PROFILE_ID' --spark3-mvn '$SPARK3_MVN_OPTS' $@" >>"$DISTDIR/RELEASE"
 mkdir -p "${DISTDIR}/logs"
 
 SERVER_JAR_DIR="${DISTDIR}/jars/server"
@@ -155,6 +169,7 @@ SPARK_CLIENT2_JAR_DIR="${CLIENT_JAR_DIR}/spark2"
 mkdir -p $SPARK_CLIENT2_JAR_DIR
 
 SPARK_CLIENT2_JAR="${RSS_HOME}/client-spark/spark2/target/shaded/rss-client-spark2-${VERSION}-shaded.jar"
+SPARK_CLIENT2_JAR_DIR="$SPARK_CLIENT2_JAR_DIR/rss-client-spark${SPARK2_VERSION}-${VERSION}-shaded.jar"
 echo "copy $SPARK_CLIENT2_JAR to ${SPARK_CLIENT2_JAR_DIR}"
 cp $SPARK_CLIENT2_JAR ${SPARK_CLIENT2_JAR_DIR}
 
@@ -167,6 +182,7 @@ echo -e "\$ ${BUILD_COMMAND_SPARK3[@]}\n"
 SPARK_CLIENT3_JAR_DIR="${CLIENT_JAR_DIR}/spark3"
 mkdir -p $SPARK_CLIENT3_JAR_DIR
 SPARK_CLIENT3_JAR="${RSS_HOME}/client-spark/spark3/target/shaded/rss-client-spark3-${VERSION}-shaded.jar"
+SPARK_CLIENT3_JAR_DIR="$SPARK_CLIENT3_JAR_DIR/rss-client-spark${SPARK3_VERSION}-${VERSION}-shaded.jar"
 echo "copy $SPARK_CLIENT3_JAR to ${SPARK_CLIENT3_JAR_DIR}"
 cp $SPARK_CLIENT3_JAR $SPARK_CLIENT3_JAR_DIR
 
@@ -177,6 +193,7 @@ echo -e "\$ ${BUILD_COMMAND_MR[@]}\n"
 MR_CLIENT_JAR_DIR="${CLIENT_JAR_DIR}/mr"
 mkdir -p $MR_CLIENT_JAR_DIR
 MR_CLIENT_JAR="${RSS_HOME}/client-mr/target/shaded/rss-client-mr-${VERSION}-shaded.jar"
+MR_CLIENT_JAR_DIR="$MR_CLIENT_JAR_DIR/rss-client-mr${HADOOP_VERSION}-${VERSION}-shaded.jar"
 echo "copy $MR_CLIENT_JAR to ${MR_CLIENT_JAR_DIR}"
 cp $MR_CLIENT_JAR $MR_CLIENT_JAR_DIR
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tag Spark and Hadoop version in release package.

1. ~~Add version information to client jar name~~
2. Add version information in RELEASE file



An example：

```
./build_distribution.sh --spark3-profile 'spark3.0' --spark3-mvn '-Dx.x1=1 -Dspark.version=3.0.2' -Dhadoop.version=2.8.0 -Dx.x2=2
```

Before PR：

```
$ cat RELEASE
RSS 0.6.0-snapshot (git revision 04cbdbb) built
Build flags: -Dhadoop.version=2.8.0 -Dx.x3=3    
```

After PR：

```
$ cat RELEASE
RSS 0.6.0-snapshot (git revision 27032c1) built for Hadoop 2.8.0 Spark2 2.4.6 Spark3 3.0.2
Build flags: --spark2-profile 'spark2' --spark2-mvn '' --spark3-profile 'spark3.0' --spark3-mvn '-Dx.x1=1 -Dspark.version=3.0.2' -Dhadoop.version=2.8.0 -Dx.x2=2
```

### Why are the changes needed?

Unable to determine spark and hadoop version of release package, which may cause confusion in usage.

### Does this PR introduce _any_ user-facing change?

No. 

~~Changed client jar name.~~


### How was this patch tested?

local test