### PR TITLE
[BUGFIX] Fix flush event bug which cause app resource delete not clean

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractRssReaderTest extends HdfsTestBase {
       blocks.add(createShuffleBlock(output.toBytes(), blockId));
       serializeStream.close();
     }
-    handler.write(blocks);
+    handler.write(blocks, () -> true);
   }
 
   protected ShufflePartitionedBlock createShuffleBlock(byte[] data, long blockId) {

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -464,7 +464,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
       expectedData.put(blockId, buf);
       blockIdBitmap.addLong(blockId);
     }
-    writeHandler.write(blocks);
+    writeHandler.write(blocks, () -> true);
   }
 
   private void writeDuplicatedData(
@@ -485,6 +485,6 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
       expectedData.put(blockId, buf);
       blockIdBitmap.addLong(blockId);
     }
-    writeHandler.write(blocks);
+    writeHandler.write(blocks, () -> true);
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
@@ -90,6 +90,10 @@ public class ShuffleDataFlushEvent {
     return shuffleBuffer;
   }
 
+  public Supplier<Boolean> getValidSupplier() {
+    return valid;
+  }
+
   public boolean isValid() {
     if (valid == null) {
       return true;

--- a/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
@@ -66,7 +66,7 @@ public abstract class SingleStorageManager implements StorageManager {
 
     try {
       long startWrite = System.currentTimeMillis();
-      handler.write(event.getShuffleBlocks());
+      handler.write(event.getShuffleBlocks(), event.getValidSupplier());
       long writeTime = System.currentTimeMillis() - startWrite;
       updateWriteMetrics(event, writeTime);
       return true;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/api/ShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/api/ShuffleWriteHandler.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.storage.handler.api;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 
@@ -28,8 +29,11 @@ public interface ShuffleWriteHandler {
    * Write the blocks to storage
    *
    * @param shuffleBlocks blocks to storage
+   * @param valid function to check blocks valid or not
    * @throws IOException
    * @throws IllegalStateException
    */
-  void write(List<ShufflePartitionedBlock> shuffleBlocks) throws IOException, IllegalStateException;
+  void write(
+      List<ShufflePartitionedBlock> shuffleBlocks,
+      Supplier<Boolean> valid) throws IOException, IllegalStateException;
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -87,7 +88,13 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
 
   @Override
   public synchronized void write(
-      List<ShufflePartitionedBlock> shuffleBlocks) throws IOException, IllegalStateException {
+      List<ShufflePartitionedBlock> shuffleBlocks,
+      Supplier<Boolean> valid) throws IOException, IllegalStateException {
+    if (!valid.get()) {
+      LOG.warn("Event is invalid, the app with basePath {}, fileNamePrefix {} was removed already", this.basePath,
+          this.fileNamePrefix);
+      return;
+    }
 
     // Ignore this write, if the shuffle directory is deleted after being uploaded in multi mode
     // or after its app heartbeat times out.

--- a/storage/src/test/java/org/apache/uniffle/storage/HdfsShuffleHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HdfsShuffleHandlerTestBase.java
@@ -58,7 +58,7 @@ public class HdfsShuffleHandlerTestBase extends HdfsTestBase {
           length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
       expectedData.put(blockId, buf);
     }
-    writeHandler.write(blocks);
+    writeHandler.write(blocks, () -> true);
   }
 
   protected void writeTestData(

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsHandlerTest.java
@@ -69,7 +69,7 @@ public class HdfsHandlerTest extends HdfsTestBase {
       expectedIndex.add(new FileBasedShuffleSegment(i, pos, i * 8, i * 8, i, 0));
       pos += i * 8;
     }
-    writeHandler.write(blocks);
+    writeHandler.write(blocks, () -> true);
 
     compareDataAndIndex("appId", 1, 1, basePath, expectedData, expectedBlockId);
 
@@ -86,7 +86,7 @@ public class HdfsHandlerTest extends HdfsTestBase {
     }
     writeHandler =
         new HdfsShuffleWriteHandler("appId", 1, 1, 1, basePath, "test", conf);
-    writeHandler.write(blocksAppend);
+    writeHandler.write(blocksAppend, () -> true);
 
     compareDataAndIndex("appId", 1, 1, basePath, expectedData, expectedBlockId);
   }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
@@ -145,7 +145,7 @@ public class LocalFileHandlerTest {
       expectedData.put(blockId, buf);
       expectedBlockIds.add(blockId);
     }
-    writeHandler.write(blocks);
+    writeHandler.write(blocks, () -> true);
   }
 
   protected void validateResult(ServerReadHandler readHandler, Set<Long> expectedBlockIds,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Modify the interface ShuffleWriteHandler
- change the method "write", add a param "valid" which check whether the shuffleBlocks is valid


### Why are the changes needed?
There is a bug when multi thread which use the same ShuffleWriteHandler flush event to storage concurrently.

for example: 
- there are two event with the same appId、shuffleId and partitionId in ShuffleFlushManager.flushQueue
- because the same appId、shuffleId and partitionId, two event will get the same ShuffleWriteHandler in method ShuffleFlushManager.flushToFile
![图片](https://user-images.githubusercontent.com/16055211/183663082-3bf4bd63-5e8f-44b7-a171-353730a6cdc0.png)
- as shown below, both them check is valid in the method ShuffleFlushManager.flushToFile
![图片](https://user-images.githubusercontent.com/16055211/183661104-bdcc70da-ac1d-4c2b-b6dc-1ab2ffc3f7fe.png)
- suppose the writeHandler is instance of HdfsShuffleWriteHandler, when the first event execute method write the second event will be block
![图片](https://user-images.githubusercontent.com/16055211/183665166-a3b4ac41-1c72-4932-9760-92166635c700.png)
- the first event is executing write method while the app is expire, so the hdfs path will be deleted
- then the second event will execute write method. Normally the shuffleBlocks of the second event will be Marked as invalid, but we don't check in this method, so the hdfs path will be recreated, and the second event will still flush to hdfs

to fix this bug, we should double chech the valid of the event, so I add add a param "valid" which check whether the shuffleBlocks is valid in method ShuffleWriteHandler.write.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need
