### PR TITLE
[Improvement] Filter null value when selecting remote storage in ApplicationManager

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
@@ -19,13 +19,16 @@ package org.apache.uniffle.coordinator;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -119,25 +122,8 @@ public class ApplicationManager {
 
     // create list for sort
     List<Map.Entry<String, AtomicInteger>> sizeList =
-        Lists.newArrayList(remoteStoragePathCounter.entrySet());
-
-    sizeList.sort((entry1, entry2) -> {
-      if (entry1 == null && entry2 == null) {
-        return 0;
-      }
-      if (entry1 == null) {
-        return -1;
-      }
-      if (entry2 == null) {
-        return 1;
-      }
-      if (entry1.getValue().get() > entry2.getValue().get()) {
-        return 1;
-      } else if (entry1.getValue().get() == entry2.getValue().get()) {
-        return 0;
-      }
-      return -1;
-    });
+        Lists.newArrayList(remoteStoragePathCounter.entrySet()).stream().filter(Objects::nonNull)
+            .sorted(Comparator.comparingInt(entry -> entry.getValue().get())).collect(Collectors.toList());
 
     for (Map.Entry<String, AtomicInteger> entry : sizeList) {
       String storagePath = entry.getKey();

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/ApplicationManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/ApplicationManagerTest.java
@@ -99,24 +99,6 @@ public class ApplicationManagerTest {
   }
 
   @Test
-  public void pickRemoteStorageTest() {
-    String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
-    Set<String> expectedAvailablePath = Sets.newHashSet(remotePath1, remotePath2);
-    applicationManager.refreshRemoteStorage(remoteStoragePath, "");
-
-    applicationManager.incRemoteStorageCounter(remotePath2);
-    applicationManager.incRemoteStorageCounter(remotePath1);
-    String testApp1 = "testApp1";
-    applicationManager.refreshAppId(testApp1);
-    applicationManager.incRemoteStorageCounter(remotePath2);
-    String testApp2 = "testApp2";
-    applicationManager.refreshAppId(testApp2);
-    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStorageInfo().keySet());
-    assertEquals(remotePath1, applicationManager.pickRemoteStorage(testApp2).getPath());
-    assertEquals(remotePath2, applicationManager.pickRemoteStorage(testApp1).getPath());
-  }
-
-  @Test
   public void storageCounterTest() throws Exception {
     String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
     applicationManager.refreshRemoteStorage(remoteStoragePath, "");

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/ApplicationManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/ApplicationManagerTest.java
@@ -99,6 +99,24 @@ public class ApplicationManagerTest {
   }
 
   @Test
+  public void pickRemoteStorageTest() {
+    String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
+    Set<String> expectedAvailablePath = Sets.newHashSet(remotePath1, remotePath2);
+    applicationManager.refreshRemoteStorage(remoteStoragePath, "");
+
+    applicationManager.incRemoteStorageCounter(remotePath2);
+    applicationManager.incRemoteStorageCounter(remotePath1);
+    String testApp1 = "testApp1";
+    applicationManager.refreshAppId(testApp1);
+    applicationManager.incRemoteStorageCounter(remotePath2);
+    String testApp2 = "testApp2";
+    applicationManager.refreshAppId(testApp2);
+    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStorageInfo().keySet());
+    assertEquals(remotePath1, applicationManager.pickRemoteStorage(testApp2).getPath());
+    assertEquals(remotePath2, applicationManager.pickRemoteStorage(testApp1).getPath());
+  }
+
+  @Test
   public void storageCounterTest() throws Exception {
     String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
     applicationManager.refreshRemoteStorage(remoteStoragePath, "");


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Filter null value when selecting remote storage.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Using the original comparison method, after sorting, the null value is placed in front of the `sizeList`, and a null pointer will be thrown.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added.