### PR TITLE
[Improvement]record split across writer buffer to save memory

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
@@ -41,14 +41,15 @@ public class WriterBuffer {
   public void addRecord(byte[] recordBuffer, int length) {
     int require = calculateMemoryCost(length);
     int hasCopied = 0;
-    if (require > 0 && buffer != null && buffer.length - nextOffset > 0) {
-      hasCopied = buffer.length - nextOffset;
-      System.arraycopy(recordBuffer, 0, buffer, nextOffset, hasCopied);
-    }
-    if (require > 0 && buffer != null) {
-      buffers.add(new WrappedBuffer(buffer, buffer.length));
-    }
     if (require > 0) {
+      if (buffer != null) {
+        int toCopy = buffer.length - nextOffset;
+        if (toCopy > 0) {
+          hasCopied = toCopy;
+          System.arraycopy(recordBuffer, 0, buffer, nextOffset, hasCopied);
+        }
+        buffers.add(new WrappedBuffer(buffer, buffer.length));
+      }
       buffer = new byte[require];
       nextOffset = 0;
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
@@ -39,35 +39,34 @@ public class WriterBuffer {
   }
 
   public void addRecord(byte[] recordBuffer, int length) {
-    if (askForMemory(length)) {
-      // buffer has data already, add buffer to list
-      if (nextOffset > 0) {
-        buffers.add(new WrappedBuffer(buffer, nextOffset));
-        nextOffset = 0;
-      }
-      if (length > bufferSize) {
-        buffer = new byte[length];
-        memoryUsed += length;
-      } else {
-        buffer = new byte[bufferSize];
-        memoryUsed += bufferSize;
-      }
+    int require = calculateMemoryCost(length);
+    int hasCopied = 0;
+    if (require > 0 && buffer != null && buffer.length - nextOffset > 0) {
+      hasCopied = buffer.length - nextOffset;
+      System.arraycopy(recordBuffer, 0, buffer, nextOffset, hasCopied);
     }
-
-    try {
-      System.arraycopy(recordBuffer, 0, buffer, nextOffset, length);
-    } catch (Exception e) {
-      LOG.error("Unexpect exception for System.arraycopy, length[" + length + "], nextOffset["
-          + nextOffset + "], bufferSize[" + bufferSize + "]");
-      throw e;
+    if (require > 0 && buffer != null) {
+      buffers.add(new WrappedBuffer(buffer, buffer.length));
     }
-
-    nextOffset += length;
+    if (require > 0) {
+      buffer = new byte[require];
+      nextOffset = 0;
+    }
+    System.arraycopy(recordBuffer, hasCopied, buffer, nextOffset, length - hasCopied);
+    nextOffset += length - hasCopied;
+    memoryUsed += require;
     dataLength += length;
   }
 
-  public boolean askForMemory(long length) {
-    return buffer == null || nextOffset + length > bufferSize;
+  public int calculateMemoryCost(int length) {
+    if (buffer == null) {
+      return Math.max(length, bufferSize);
+    }
+    int require = length + nextOffset - buffer.length;
+    if (require <= 0) {
+      return 0;
+    }
+    return Math.max(require, bufferSize);
   }
 
   public byte[] getData() {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -78,6 +78,7 @@ public class WriteBufferManagerTest {
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(0, testKey, testValue);
     wbm.addRecord(0, testKey, testValue);
+    wbm.addRecord(0, testKey, testValue);
     result = wbm.addRecord(0, testKey, testValue);
     // single buffer is full
     assertEquals(1, result.size());
@@ -108,7 +109,7 @@ public class WriteBufferManagerTest {
     assertEquals(192, wbm.getUsedBytes());
     assertEquals(192, wbm.getInSendListBytes());
 
-    assertEquals(11, wbm.getShuffleWriteMetrics().recordsWritten());
+    assertEquals(12, wbm.getShuffleWriteMetrics().recordsWritten());
     assertTrue(wbm.getShuffleWriteMetrics().bytesWritten() > 0);
 
     wbm.freeAllocatedMemory(192);

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
@@ -58,7 +58,7 @@ public class WriteBufferTest {
     wb.addRecord(serializedData, serializedDataLength);
     // case: data size > output buffer size, when getData(), 2 buffer + output with 12b = 60b
     assertEquals(60, wb.getData().length);
-    assertEquals(96, wb.getMemoryUsed());
+    assertEquals(64, wb.getMemoryUsed());
 
     wb = new WriterBuffer(32);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Record added to `WriterBuffer` will split across byte array buffer, all the byte array will be fully used

### Why are the changes needed?
Previously for example, the length of every record is 2k, every time we add a record, we create a buffer with 3k length by default and wrap the previous buffer as `WrappedBuffer` which resulting in wasting 1k memory in every `WrappedBuffer`.
Apply this PR will save memory

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass unit test
