### PR TITLE
[Improvement] Should match from pathToStorages when appId does not exist in appIdToStorages

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -131,6 +131,7 @@ public class HdfsStorageManager extends SingleStorageManager {
           LOG.error("Some error happened when fileSystem got the file status.", e);
         }
         // outside should deal with null situation
+        // todo: it's better to have a fake storage for null situation
         return null;
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
![createlog](https://user-images.githubusercontent.com/84573424/185648279-a6a51d39-cd1d-4b0a-8c2a-95069fb96cd2.png)
![deletelog](https://user-images.githubusercontent.com/84573424/185648346-b320fce4-7131-404b-baaf-4def5ad7a1a1.png)
From the audit log of HDFS, it can be seen that when the HDFS path of this app was last deleted at 18:00:55, the log in the `shuffleServer` found that the error about `file could not be found`, and the file would continue to be written. At last we found that when some appId cache was removed in `appIdToStorages`, and then `HdfsStorageManager` calls `removeResources` will cause storagePath to not be deleted.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When the cache of `appIdToStorages` removed, the remote path can be deleted normally.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added ut.