### PR TITLE
[BUGFIX] Fix resource leak when shuffle read

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -34,12 +34,12 @@ import scala.Product2;
 import scala.Tuple2;
 import scala.collection.AbstractIterator;
 import scala.collection.Iterator;
+import scala.runtime.BoxedUnit;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.common.RssShuffleUtils;
 import org.apache.uniffle.common.exception.RssException;
-import scala.runtime.BoxedUnit;
 
 public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C>> {
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.DefaultIdHelper;
@@ -45,6 +46,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
 
@@ -233,6 +239,15 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
         assertTrue(e.getMessage().startsWith("Unexpected crc value"));
       }
     }
+  }
+
+  @Test
+  public void cleanup() throws Exception {
+    ShuffleReadClient mockClient = mock(ShuffleReadClient.class);
+    doNothing().when(mockClient).close();
+    RssShuffleDataIterator dataIterator = new RssShuffleDataIterator(KRYO_SERIALIZER, mockClient, new ShuffleReadMetrics());
+    dataIterator.cleanup();
+    verify(mockClient, times(1)).close();
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `org.apache.spark.TaskContext#addTaskCompletionListener` to clean up resources used by `RssShuffleDataIterator`. This avoids possible resource leaks.


### Why are the changes needed?
Before this PR, `RssShuffleDataIterator` would only clean up used resources after all records read.

When the `Spark Task` fails or cancels, or runs some special logic such as `LocalLimit`, the resource will not be cleaned up. This creates potential resource leaks.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added a UT case