### PR TITLE
[Improvement] ShuffleBufferManager supports triggering flush according to the size of single ShuffleBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ For more details of advanced configuration, please see [Uniffle Coordinator Guid
 |rss.storage.type|-|Supports MEMORY_LOCALFILE, MEMORY_HDFS, MEMORY_LOCALFILE_HDFS|
 |rss.server.flush.cold.storage.threshold.size|64M| The threshold of data size for LOACALFILE and HDFS if MEMORY_LOCALFILE_HDFS is used|
 |rss.server.tags|-|The comma-separated list of tags to indicate the shuffle server's attributes. It will be used as the assignment basis for the coordinator|
-|rss.server.single.buffer.flush.enabled|false|Whether single buffer flush when size exceeded rss.server.single.buffer.flush.enabled|
+|rss.server.single.buffer.flush.enabled|false|Whether single buffer flush when size exceeded rss.server.single.buffer.flush.threshold|
 |rss.server.single.buffer.flush.threshold|64M|The threshold of single shuffle buffer flush|
 
 ### Shuffle Client

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ For more details of advanced configuration, please see [Uniffle Coordinator Guid
 |rss.storage.type|-|Supports MEMORY_LOCALFILE, MEMORY_HDFS, MEMORY_LOCALFILE_HDFS|
 |rss.server.flush.cold.storage.threshold.size|64M| The threshold of data size for LOACALFILE and HDFS if MEMORY_LOCALFILE_HDFS is used|
 |rss.server.tags|-|The comma-separated list of tags to indicate the shuffle server's attributes. It will be used as the assignment basis for the coordinator|
+|rss.server.single.buffer.flush.enabled|false|Whether single buffer flush when size exceeded rss.server.single.buffer.flush.enabled|
+|rss.server.single.buffer.flush.threshold|64M|The threshold of single shuffle buffer flush|
 
 ### Shuffle Client
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -284,6 +284,18 @@ public class ShuffleServerConf extends RssBaseConf {
       .defaultValue(0L)
       .withDescription("For localstorage, it will exit when the failed initialized local storage exceed the number");
 
+  public static final ConfigOption<Boolean> BUFFER_FLUSH_ENABLED = ConfigOptions
+       .key("rss.server.buffer.flush.enabled")
+       .booleanType()
+       .defaultValue(false)
+       .withDescription("Whether buffer flush when size exceeded rss.server.buffer.flush.threshold");
+
+  public static final ConfigOption<Long> BUFFER_FLUSH_THRESHOLD = ConfigOptions
+        .key("rss.server.buffer.flush.threshold")
+        .longType()
+        .defaultValue(32 * 1024 * 1024L)
+        .withDescription("The threshold of shuffle buffer flush");
+
   public ShuffleServerConf() {
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -288,7 +288,7 @@ public class ShuffleServerConf extends RssBaseConf {
        .key("rss.server.single.buffer.flush.enabled")
        .booleanType()
        .defaultValue(false)
-       .withDescription("Whether single buffer flush when size exceeded rss.server.single.buffer.flush.enabled");
+       .withDescription("Whether single buffer flush when size exceeded rss.server.single.buffer.flush.threshold");
 
   public static final ConfigOption<Long> SINGLE_BUFFER_FLUSH_THRESHOLD = ConfigOptions
         .key("rss.server.single.buffer.flush.threshold")

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -284,17 +284,17 @@ public class ShuffleServerConf extends RssBaseConf {
       .defaultValue(0L)
       .withDescription("For localstorage, it will exit when the failed initialized local storage exceed the number");
 
-  public static final ConfigOption<Boolean> BUFFER_FLUSH_ENABLED = ConfigOptions
-       .key("rss.server.buffer.flush.enabled")
+  public static final ConfigOption<Boolean> SINGLE_BUFFER_FLUSH_ENABLED = ConfigOptions
+       .key("rss.server.single.buffer.flush.enabled")
        .booleanType()
        .defaultValue(false)
-       .withDescription("Whether buffer flush when size exceeded rss.server.buffer.flush.threshold");
+       .withDescription("Whether single buffer flush when size exceeded rss.server.single.buffer.flush.enabled");
 
-  public static final ConfigOption<Long> BUFFER_FLUSH_THRESHOLD = ConfigOptions
-        .key("rss.server.buffer.flush.threshold")
+  public static final ConfigOption<Long> SINGLE_BUFFER_FLUSH_THRESHOLD = ConfigOptions
+        .key("rss.server.single.buffer.flush.threshold")
         .longType()
-        .defaultValue(32 * 1024 * 1024L)
-        .withDescription("The threshold of shuffle buffer flush");
+        .defaultValue(64 * 1024 * 1024L)
+        .withDescription("The threshold of single shuffle buffer flush");
 
   public ShuffleServerConf() {
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -78,8 +78,8 @@ public class ShuffleBufferManager {
         * conf.get(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE));
     this.lowWaterMark = (long)(capacity / 100
         * conf.get(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE));
-    this.bufferFlushEnabled = conf.getBoolean(ShuffleServerConf.BUFFER_FLUSH_ENABLED);
-    this.bufferFlushThreshold = conf.getLong(ShuffleServerConf.BUFFER_FLUSH_THRESHOLD);
+    this.bufferFlushEnabled = conf.getBoolean(ShuffleServerConf.SINGLE_BUFFER_FLUSH_ENABLED);
+    this.bufferFlushThreshold = conf.getLong(ShuffleServerConf.SINGLE_BUFFER_FLUSH_THRESHOLD);
   }
 
   public StatusCode registerBuffer(String appId, int shuffleId, int startPartition, int endPartition) {

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -400,8 +400,8 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     shuffleConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
     shuffleConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 80.0);
     shuffleConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
-    shuffleConf.setBoolean(ShuffleServerConf.BUFFER_FLUSH_ENABLED, true);
-    shuffleConf.setSizeAsBytes(ShuffleServerConf.BUFFER_FLUSH_THRESHOLD, 128L);
+    shuffleConf.setBoolean(ShuffleServerConf.SINGLE_BUFFER_FLUSH_ENABLED, true);
+    shuffleConf.setSizeAsBytes(ShuffleServerConf.SINGLE_BUFFER_FLUSH_THRESHOLD, 128L);
 
     ShuffleServer mockShuffleServer = mock(ShuffleServer.class);
     StorageManager storageManager = StorageManagerFactory.getInstance().createStorageManager(shuffleConf);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -389,6 +389,55 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     assertEquals(1, shuffleBufferManager.getBufferPool().keySet().size());
   }
 
+  @Test
+  public void flushSingleBufferTest() throws Exception {
+    ShuffleServerConf shuffleConf = new ShuffleServerConf();
+    File tmpDir = Files.createTempDir();
+    File dataDir = new File(tmpDir, "data");
+    shuffleConf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
+    shuffleConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(dataDir.getAbsolutePath()));
+    shuffleConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 200L);
+    shuffleConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
+    shuffleConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 80.0);
+    shuffleConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
+    shuffleConf.setBoolean(ShuffleServerConf.BUFFER_FLUSH_ENABLED, true);
+    shuffleConf.setSizeAsBytes(ShuffleServerConf.BUFFER_FLUSH_THRESHOLD, 128L);
+
+    ShuffleServer mockShuffleServer = mock(ShuffleServer.class);
+    StorageManager storageManager = StorageManagerFactory.getInstance().createStorageManager(shuffleConf);
+    ShuffleFlushManager shuffleFlushManager = new ShuffleFlushManager(shuffleConf, "serverId", mockShuffleServer, storageManager);
+    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager);
+
+    when(mockShuffleServer
+             .getShuffleFlushManager())
+        .thenReturn(shuffleFlushManager);
+    when(mockShuffleServer
+             .getShuffleBufferManager())
+        .thenReturn(shuffleBufferManager);
+    when(mockShuffleServer
+             .getShuffleTaskManager())
+        .thenReturn(mock(ShuffleTaskManager.class));
+
+    String appId = "bufferSizeTest";
+    int shuffleId = 1;
+
+    shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
+    shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
+    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 64));
+    assertEquals(96, shuffleBufferManager.getUsedMemory());
+    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(2, 64));
+    waitForFlush(shuffleFlushManager, appId, shuffleId, 2);
+    assertEquals(0, shuffleBufferManager.getUsedMemory());
+    assertEquals(0, shuffleBufferManager.getInFlushSize());
+
+    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 32));
+    assertEquals(64, shuffleBufferManager.getUsedMemory());
+    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(1, 32));
+    waitForFlush(shuffleFlushManager, appId, shuffleId, 4);
+    assertEquals(0, shuffleBufferManager.getUsedMemory());
+    assertEquals(0, shuffleBufferManager.getInFlushSize());
+  }
+
   private void waitForFlush(ShuffleFlushManager shuffleFlushManager,
       String appId, int shuffleId, int expectedBlockNum) throws Exception {
     int retry = 0;


### PR DESCRIPTION
### What changes were proposed in this pull request?
for issue https://github.com/apache/incubator-uniffle/issues/173, Add a new flush strategy for ShuffleBufferManager, flush if the size of a single buffer reaches `rss.server.buffer.flush.threshold`, which can make more full use of disk io without waiting for the buffer to reach `(rss.server.buffer.capacity * rss.server.memory.shuffle.highWaterMark.percentage)`


### Why are the changes needed?

### Does this PR introduce any user-facing change?

### How was this patch tested?
Already added