### PR TITLE
[ISSUE-173][FOLLOWUP] The size of single buffer flush should reach rss.server.flush.cold.storage.threshold.size

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -165,7 +165,9 @@ public class ShuffleBufferManager {
 
   void flushSingleBufferIfNecessary(ShuffleBuffer buffer, String appId,
       int shuffleId, int startPartition, int endPartition) {
-    if (this.bufferFlushEnabled && buffer.getSize() >= this.bufferFlushThreshold) {
+    // When we use multistorage and trigger single buffer flush, the buffer size should be bigger
+    // than rss.server.flush.cold.storage.threshold.size, otherwise cold storage will be useless.
+    if (this.bufferFlushEnabled && buffer.getSize() > this.bufferFlushThreshold) {
       flushBuffer(buffer, appId, shuffleId, startPartition, endPartition);
     }
   }

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -432,7 +432,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
 
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 32));
     assertEquals(64, shuffleBufferManager.getUsedMemory());
-    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(1, 32));
+    shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(1, 48));
     waitForFlush(shuffleFlushManager, appId, shuffleId, 4);
     assertEquals(0, shuffleBufferManager.getUsedMemory());
     assertEquals(0, shuffleBufferManager.getInFlushSize());


### PR DESCRIPTION
### What changes were proposed in this pull request?
follow https://github.com/apache/incubator-uniffle/issues/173, when single buffer flush is triggered, the buffer size should reach rss.server.flush.cold.storage.threshold.size, we keep the same logic as MultiStorageManager#selectStorageManager

### Why are the changes needed?
Make sure cold storage is valid

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Already added