### PR TITLE
[Improvement] Add optional environment variables

### DIFF
--- a/bin/restart-coordinator.sh
+++ b/bin/restart-coordinator.sh
@@ -18,14 +18,13 @@
 #
 
 set -o pipefail
-set -e
+set -o nounset   # exit the script if you try to use an uninitialised variable
+set -o errexit   # exit the script if any statement returns a non-true return value
 
-COORDINATOR_HOME="$(
-  cd "$(dirname "$0")/.."
-  pwd
-)"
+source "$(dirname "$0")/utils.sh"
+load_rss_env
 
-cd $COORDINATOR_HOME
+cd "${RSS_HOME}"
 
 bash ./bin/stop-coordinator.sh
 sleep 3

--- a/bin/restart-shuffle-server.sh
+++ b/bin/restart-shuffle-server.sh
@@ -18,14 +18,13 @@
 #
 
 set -o pipefail
-set -e
+set -o nounset   # exit the script if you try to use an uninitialised variable
+set -o errexit   # exit the script if any statement returns a non-true return value
 
-SHUFFLE_SERVER_HOME="$(
-  cd "$(dirname "$0")/.."
-  pwd
-)"
+source "$(dirname "$0")/utils.sh"
+load_rss_env
 
-cd $SHUFFLE_SERVER_HOME
+cd "${RSS_HOME}"
 
 bash ./bin/stop-shuffle-server.sh
 sleep 3

--- a/bin/rss-env.sh
+++ b/bin/rss-env.sh
@@ -24,5 +24,10 @@ JAVA_HOME=<java_home_dir>
 HADOOP_HOME=<hadoop_home_dir>
 XMX_SIZE="80g"
 
+# HADOOP_CONF_DIR, Hadoop configuration files (Default: ${HADOOP_HOME}/etc/hadoop)
+# RSS_PID_DIR, Where the pid file is stored (Default: ${RSS_HOME})
+# RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
+# RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
+
 RUNNER="${JAVA_HOME}/bin/java"
 JPS="${JAVA_HOME}/bin/jps"

--- a/bin/rss-env.sh
+++ b/bin/rss-env.sh
@@ -18,16 +18,16 @@
 #
 
 set -o pipefail
-set -e
+set -o nounset   # exit the script if you try to use an uninitialised variable
+set -o errexit   # exit the script if any statement returns a non-true return value
 
 JAVA_HOME=<java_home_dir>
 HADOOP_HOME=<hadoop_home_dir>
-XMX_SIZE="80g"
+XMX_SIZE="80g" # Shuffle Server JVM XMX size
 
-# HADOOP_CONF_DIR, Hadoop configuration files (Default: ${HADOOP_HOME}/etc/hadoop)
+# RSS_HOME, RSS home directory (Default: parent directory of the script)
+# RSS_CONF_DIR, RSS configuration directory (Default: ${RSS_HOME}/conf)
+# HADOOP_CONF_DIR, Hadoop configuration directory (Default: ${HADOOP_HOME}/etc/hadoop)
 # RSS_PID_DIR, Where the pid file is stored (Default: ${RSS_HOME})
 # RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
 # RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
-
-RUNNER="${JAVA_HOME}/bin/java"
-JPS="${JAVA_HOME}/bin/jps"

--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -24,12 +24,26 @@ COORDINATOR_HOME="$(
   cd "$(dirname "$0")/.."
   pwd
 )"
+
+source "${COORDINATOR_HOME}/bin/rss-env.sh"
+
+if [ -z "$HADOOP_CONF_DIR" ]; then
+  HADOOP_CONF_DIR="${HADOOP_HOME}/etc/hadoop"
+fi
+
+if [ -z "$RSS_LOG_DIR" ]; then
+  RSS_LOG_DIR="${COORDINATOR_HOME}/logs"
+fi
+
+if [ -z "$RSS_PID_DIR" ]; then
+  RSS_PID_DIR="${COORDINATOR_HOME}"
+fi
+
 CONF_FILE="./conf/coordinator.conf "
 MAIN_CLASS="org.apache.uniffle.coordinator.CoordinatorServer"
 
 cd $COORDINATOR_HOME
 
-source "${COORDINATOR_HOME}/bin/rss-env.sh"
 source "${COORDINATOR_HOME}/bin/utils.sh"
 
 if [ -z "$HADOOP_HOME" ]; then
@@ -39,7 +53,6 @@ fi
 
 export JAVA_HOME
 
-HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
 HADOOP_DEPENDENCY=`$HADOOP_HOME/bin/hadoop classpath --glob`
 
 echo "Check process existence"
@@ -52,10 +65,8 @@ for file in $(ls ${JAR_DIR}/coordinator/*.jar 2>/dev/null); do
   CLASSPATH=$CLASSPATH:$file
 done
 
-if [ -z "$HADOOP_CONF_DIR" ]; then
-  echo "No env HADOOP_CONF_DIR."
-  exit 1
-fi
+mkdir -p "${RSS_LOG_DIR}"
+mkdir -p "${RSS_PID_DIR}"
 
 echo "Using Hadoop from $HADOOP_HOME"
 
@@ -75,7 +86,7 @@ JVM_ARGS=" -server \
 ARGS=""
 
 LOG_CONF_FILE="./conf/log4j.properties"
-LOG_PATH="./logs/coordinator.log"
+LOG_PATH="${RSS_LOG_DIR}/coordinator.log"
 if [ -f ${LOG_CONF_FILE} ]; then
   ARGS="$ARGS -Dlog4j.configuration=file:${LOG_CONF_FILE} -Dlog.path=${LOG_PATH}"
 else
@@ -86,4 +97,4 @@ fi
 $RUNNER $ARGS $JVM_ARGS -cp $CLASSPATH $MAIN_CLASS --conf $CONF_FILE $@ &
 
 get_pid_file_name coordinator
-echo $! >$COORDINATOR_HOME/${pid_file}
+echo $! >${RSS_PID_DIR}/${pid_file}

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -18,70 +18,50 @@
 #
 
 set -o pipefail
-set -e
+set -o nounset   # exit the script if you try to use an uninitialised variable
+set -o errexit   # exit the script if any statement returns a non-true return value
 
-SHUFFLE_SERVER_HOME="$(
-  cd "$(dirname "$0")/.."
-  pwd
-)"
+source "$(dirname "$0")/utils.sh"
+load_rss_env
 
-source "${SHUFFLE_SERVER_HOME}/bin/rss-env.sh"
+cd "$RSS_HOME"
 
-if [ -z "$HADOOP_CONF_DIR" ]; then
-  HADOOP_CONF_DIR="${HADOOP_HOME}/etc/hadoop"
-fi
+SHUFFLE_SERVER_CONF_FILE="${RSS_CONF_DIR}/server.conf"
+JAR_DIR="${RSS_HOME}/jars"
+LOG_CONF_FILE="${RSS_CONF_DIR}/log4j.properties"
+LOG_PATH="${RSS_LOG_DIR}/shuffle_server.log"
 
-if [ -z "$RSS_LOG_DIR" ]; then
-  RSS_LOG_DIR="${SHUFFLE_SERVER_HOME}/logs"
-fi
-
-if [ -z "$RSS_PID_DIR" ]; then
-  RSS_PID_DIR="${SHUFFLE_SERVER_HOME}"
-fi
-
-if [ -n "$RSS_IP" ]; then
-  export RSS_IP="${RSS_IP}"
-fi
-
-cd $SHUFFLE_SERVER_HOME
-
-source "${SHUFFLE_SERVER_HOME}/bin/utils.sh"
-
-if [ -z "$HADOOP_HOME" ]; then
-  echo "No env HADOOP_HOME."
+set +o nounset
+if [ -z "$XMX_SIZE" ]; then
+  echo "No env XMX_SIZE."
   exit 1
 fi
+echo "Shuffle Server JVM XMX size: ${XMX_SIZE}"
+if [ -n "$RSS_IP" ]; then
+  echo "Shuffle Server RSS_IP: ${RSS_IP}"
+fi
+set -o nounset
 
-export JAVA_HOME
-
-HADOOP_DEPENDENCY=`$HADOOP_HOME/bin/hadoop classpath --glob`
-
-CONF_FILE="./conf/server.conf "
 MAIN_CLASS="org.apache.uniffle.server.ShuffleServer"
 
-echo "Check process existence"
-is_jvm_process_running $JPS $MAIN_CLASS
+HADOOP_DEPENDENCY="$("$HADOOP_HOME/bin/hadoop" classpath --glob)"
 
-JAR_DIR="./jars"
+echo "Check process existence"
+is_jvm_process_running "$JPS" $MAIN_CLASS
+
 CLASSPATH=""
 
 for file in $(ls ${JAR_DIR}/server/*.jar 2>/dev/null); do
   CLASSPATH=$CLASSPATH:$file
 done
 
-
-if [ -z "$XMX_SIZE" ]; then
-  echo "No jvm xmx size"
-  exit 1
-fi
-
 mkdir -p "${RSS_LOG_DIR}"
 mkdir -p "${RSS_PID_DIR}"
 
-echo "Using Hadoop from $HADOOP_HOME"
-
 CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR:$HADOOP_DEPENDENCY
 JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
+
+echo "class path is $CLASSPATH"
 
 JVM_ARGS=" -server \
           -Xmx${XMX_SIZE} \
@@ -103,9 +83,6 @@ JVM_ARGS=" -server \
 
 ARGS=""
 
-LOG_CONF_FILE="./conf/log4j.properties"
-LOG_PATH="${RSS_LOG_DIR}/shuffle_server.log"
-
 if [ -f ${LOG_CONF_FILE} ]; then
   ARGS="$ARGS -Dlog4j.configuration=file:${LOG_CONF_FILE} -Dlog.path=${LOG_PATH}"
 else
@@ -113,7 +90,7 @@ else
   exit 1
 fi
 
-$RUNNER $ARGS $JVM_ARGS $JAVA_LIB_PATH -cp $CLASSPATH $MAIN_CLASS --conf $CONF_FILE $@ &
+$RUNNER $ARGS $JVM_ARGS $JAVA_LIB_PATH -cp $CLASSPATH $MAIN_CLASS --conf "$SHUFFLE_SERVER_CONF_FILE" $@ &
 
 get_pid_file_name shuffle-server
 echo $! >${RSS_PID_DIR}/${pid_file}

--- a/bin/stop-coordinator.sh
+++ b/bin/stop-coordinator.sh
@@ -18,17 +18,10 @@
 #
 
 set -o pipefail
+set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
-set -e
 
-SCRIPT_DIR="$(cd "`dirname "$0"`"; pwd)"
-BASE_DIR="$(cd "`dirname "$0"`/.."; pwd)"
-
-source "$SCRIPT_DIR/rss-env.sh"
-if [ -z "$RSS_PID_DIR" ]; then
-  RSS_PID_DIR="${BASE_DIR}"
-fi
-
-source "$SCRIPT_DIR/utils.sh"
+source "$(dirname "$0")/utils.sh"
+load_rss_env
 
 common_shutdown "coordinator" "${RSS_PID_DIR}"

--- a/bin/stop-coordinator.sh
+++ b/bin/stop-coordinator.sh
@@ -18,12 +18,17 @@
 #
 
 set -o pipefail
-set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
 set -e
 
 SCRIPT_DIR="$(cd "`dirname "$0"`"; pwd)"
 BASE_DIR="$(cd "`dirname "$0"`/.."; pwd)"
 
+source "$SCRIPT_DIR/rss-env.sh"
+if [ -z "$RSS_PID_DIR" ]; then
+  RSS_PID_DIR="${BASE_DIR}"
+fi
+
 source "$SCRIPT_DIR/utils.sh"
-common_shutdown "coordinator" ${BASE_DIR}
+
+common_shutdown "coordinator" "${RSS_PID_DIR}"

--- a/bin/stop-shuffle-server.sh
+++ b/bin/stop-shuffle-server.sh
@@ -18,12 +18,17 @@
 #
 
 set -o pipefail
-set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
 set -e
 
 SCRIPT_DIR="$(cd "`dirname "$0"`"; pwd)"
 BASE_DIR="$(cd "`dirname "$0"`/.."; pwd)"
 
+source "$SCRIPT_DIR/rss-env.sh"
+if [ -z "$RSS_PID_DIR" ]; then
+  RSS_PID_DIR="${BASE_DIR}"
+fi
+
 source "$SCRIPT_DIR/utils.sh"
-common_shutdown "shuffle-server" ${BASE_DIR}
+
+common_shutdown "shuffle-server" "${RSS_PID_DIR}"

--- a/bin/stop-shuffle-server.sh
+++ b/bin/stop-shuffle-server.sh
@@ -18,17 +18,10 @@
 #
 
 set -o pipefail
+set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
-set -e
 
-SCRIPT_DIR="$(cd "`dirname "$0"`"; pwd)"
-BASE_DIR="$(cd "`dirname "$0"`/.."; pwd)"
-
-source "$SCRIPT_DIR/rss-env.sh"
-if [ -z "$RSS_PID_DIR" ]; then
-  RSS_PID_DIR="${BASE_DIR}"
-fi
-
-source "$SCRIPT_DIR/utils.sh"
+source "$(dirname "$0")/utils.sh"
+load_rss_env
 
 common_shutdown "shuffle-server" "${RSS_PID_DIR}"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -132,3 +132,69 @@ function is_jvm_process_running {
   fi
 
 }
+
+#---
+# load_rss_env: Export RSS environment variables
+#---
+function load_rss_env {
+  set -o allexport
+
+  # find rss-env.sh
+  set +o nounset
+  if [ -f "${RSS_CONF_DIR}/rss-env.sh" ]; then
+     RSS_ENV_SH="${RSS_CONF_DIR}/rss-env.sh"
+  elif [ -f "${RSS_HOME}/bin/rss-env.sh" ]; then
+     RSS_ENV_SH="${RSS_HOME}/bin/rss-env.sh"
+  else
+     RSS_ENV_SH="$(cd "$(dirname "$0")"; pwd)/rss-env.sh"
+  fi
+  set -o nounset
+  echo "Using rss_env.sh: ${RSS_ENV_SH}"
+
+  # export rss-env.sh
+  source "${RSS_ENV_SH}"
+
+  # check
+  if [ -z "$JAVA_HOME" ]; then
+    echo "No env JAVA_HOME."
+    exit 1
+  fi
+  if [ -z "$HADOOP_HOME" ]; then
+    echo "No env HADOOP_HOME."
+    exit 1
+  fi
+
+  # export default value
+  set +o nounset
+  if [ -z "$RSS_HOME" ]; then
+    RSS_HOME="$(cd "$(dirname "$0")/.."; pwd)"
+  fi
+  if [ -z "$RSS_CONF_DIR" ]; then
+    RSS_CONF_DIR="${RSS_HOME}/conf"
+  fi
+  if [ -z "$HADOOP_CONF_DIR" ]; then
+    HADOOP_CONF_DIR="${HADOOP_HOME}/etc/hadoop"
+  fi
+  if [ -z "$RSS_LOG_DIR" ]; then
+    RSS_LOG_DIR="${RSS_HOME}/logs"
+  fi
+  if [ -z "$RSS_PID_DIR" ]; then
+    RSS_PID_DIR="${RSS_HOME}"
+  fi
+  set -o nounset
+
+  RUNNER="${JAVA_HOME}/bin/java"
+  JPS="${JAVA_HOME}/bin/jps"
+
+  # print
+  echo "Using Java from ${JAVA_HOME}"
+  echo "Using Hadoop from ${HADOOP_HOME}"
+  echo "Using RSS from ${RSS_HOME}"
+  echo "Using RSS conf from ${RSS_CONF_DIR}"
+  echo "Using Hadoop conf from ${HADOOP_CONF_DIR}"
+  echo "Write log file to ${RSS_LOG_DIR}"
+  echo "Write pid file to ${RSS_PID_DIR}"
+
+  set +o allexport
+}
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added six optional environment variables:

```
# RSS_HOME, RSS home directory (Default: parent directory of the script)
# RSS_CONF_DIR, RSS configuration directory (Default: ${RSS_HOME}/conf)
# HADOOP_CONF_DIR, Hadoop configuration directory (Default: ${HADOOP_HOME}/etc/hadoop)
# RSS_PID_DIR, Where the pid file is stored (Default: ${RSS_HOME})
# RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
# RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
```

### Why are the changes needed?

Simplify service deployment

### Does this PR introduce _any_ user-facing change?

Added six optional environment variables.

 With the default environment variables, the behavior is the same as before this PR.


### How was this patch tested?

local test
