### PR TITLE
[MINOR] Replace HashSet with ImmutableSet in configs

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.mapreduce;
 
 import java.util.Set;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 
 import org.apache.uniffle.client.util.RssClientConfig;
 
@@ -162,6 +162,6 @@ public class RssMRConfig {
   
   public static final String RSS_CONF_FILE = "rss_conf.xml";
 
-  public static final Set<String> RSS_MANDATORY_CLUSTER_CONF = Sets.newHashSet(
-      RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);
+  public static final Set<String> RSS_MANDATORY_CLUSTER_CONF =
+      ImmutableSet.of(RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle;
 
 import java.util.Set;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import org.apache.spark.internal.config.ConfigBuilder;
 import org.apache.spark.internal.config.ConfigEntry;
 import org.apache.spark.internal.config.TypedConfigBuilder;
@@ -231,7 +231,7 @@ public class RssSparkConfig {
       .createWithDefault("");
 
   public static final Set<String> RSS_MANDATORY_CLUSTER_CONF =
-      Sets.newHashSet(RSS_STORAGE_TYPE.key(), RSS_REMOTE_STORAGE_PATH.key());
+      ImmutableSet.of(RSS_STORAGE_TYPE.key(), RSS_REMOTE_STORAGE_PATH.key());
 
   public static final boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace HashSet with ImmutableSet in RssMRConfigs and RssSparkConfigs.

### Why are the changes needed?

It's error prone to use mutable collection in public static fields.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.