### PR TITLE
Synchronise read access to ShuffleBuffer#size

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -101,11 +101,11 @@ public class ShuffleBuffer {
     return blocks;
   }
 
-  public long getSize() {
+  public synchronized long getSize() {
     return size;
   }
 
-  public boolean isFull() {
+  public synchronized boolean isFull() {
     return size > capacity;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Synchronise read access to ShuffleBuffer#size.

### Why are the changes needed?

To make synchronization consistent.
Because all write accesses to `ShuffleBuffer#size` are synchronised.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.
