### PR TITLE
[Issue-194][Feature] Support spark 3.2.0

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -61,6 +61,7 @@ jobs:
           - spark3.0
           - spark3
           - spark3.2
+          - spark3.2.0
           - mr
       fail-fast: false
     name: -P${{ matrix.profile }}

--- a/README.md
+++ b/README.md
@@ -81,17 +81,25 @@ Build against profile Spark3(3.1.2)
 
     mvn -DskipTests clean package -Pspark3
 
-Build against Spark 3.2.x
+Build against Spark 3.2.x, Except 3.2.0
 
     mvn -DskipTests clean package -Pspark3.2
+
+Build against Spark 3.2.0
+
+    mvn -DskipTests clean package -Pspark3.2.0
 
 To package the Uniffle, run:
 
     ./build_distribution.sh
 
-Package against Spark 3.2.x, run:
+Package against Spark 3.2.x, Except 3.2.0, run:
 
     ./build_distribution.sh --spark3-profile 'spark3.2'
+
+Package against Spark 3.2.0, run:
+
+    ./build_distribution.sh --spark3-profile 'spark3.2.0'
 
 rss-xxx.tgz will be generated for deployment
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -487,6 +487,10 @@ public class RssShuffleManager implements ShuffleManager {
       } catch (Exception ignored1) {
         try {
           // attempt to use Spark 3.2.0's API
+          // Each Spark release will be versioned: [MAJOR].[FEATURE].[MAINTENANCE].
+          // Usually we only need to adapt [MAJOR].[FEATURE] . Unfortunately,
+          // some interfaces were removed wrongly in Spark 3.2.0. And they were added by Spark 3.2.1.
+          // So we need to adapt Spark 3.2.0 here
           mapStatusIter = (Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>>)
               MapOutputTracker.class.getDeclaredMethod("getMapSizesByExecutorId",
                   int.class, int.class, int.class, int.class, int.class)

--- a/pom.xml
+++ b/pom.xml
@@ -1290,6 +1290,95 @@
     </profile>
 
     <profile>
+      <id>spark3.2.0</id>
+      <properties>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.2.0</spark.version>
+        <client.type>3</client.type>
+        <jackson.version>2.12.0</jackson.version>
+      </properties>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark3</module>
+        <module>integration-test/spark-common</module>
+        <module>integration-test/spark3</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark3</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-spark-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
+    <profile>
       <id>spark3.0</id>
       <properties>
         <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
support spark 3.2.0

### Why are the changes needed?
After SPARK-36892, MapOutputTrackerWorker#getMapSizesByExecutorId has been modified to include method names and return parameter types, Java.lang.NoSuchMethodException will be thrown when the RssShuffleManager#getExpectedTasksByExecutorId method is called, The version of our production environment is 3.2.0.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
reused intergration-test
