### PR TITLE
Use the conf of shuffleNodesNumber from jobs to be as checking factor

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -43,4 +43,6 @@ public class Constants {
   public static final String CONF_REMOTE_STORAGE_PATH = ".remote.storage.path";
   public static final String RSS_CLIENT_CONF_REMOTE_STORAGE_PATH =
           RSS_CLIENT_CONF_COMMON_PREFIX + CONF_REMOTE_STORAGE_PATH;
+
+  public static final String ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM = "access_info_required_shuffle_nodes_num";
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/AccessClusterLoadChecker.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/AccessClusterLoadChecker.java
@@ -20,10 +20,13 @@ package org.apache.uniffle.coordinator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.util.Constants;
+
+import static org.apache.uniffle.common.util.Constants.ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM;
 
 /**
  * AccessClusterLoadChecker use the cluster load metrics including memory and healthy to
@@ -35,7 +38,9 @@ public class AccessClusterLoadChecker extends AbstractAccessChecker {
 
   private final ClusterManager clusterManager;
   private final double memoryPercentThreshold;
+  // The hard constraint number of available shuffle servers
   private final int availableServerNumThreshold;
+  private final int defaultRequiredShuffleServerNumber;
 
   public AccessClusterLoadChecker(AccessManager accessManager) throws Exception {
     super(accessManager);
@@ -44,24 +49,40 @@ public class AccessClusterLoadChecker extends AbstractAccessChecker {
     this.memoryPercentThreshold = conf.getDouble(CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_MEMORY_PERCENTAGE);
     this.availableServerNumThreshold = conf.getInteger(
         CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_SERVER_NUM_THRESHOLD,
-        conf.get(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX));
+        -1
+    );
+    this.defaultRequiredShuffleServerNumber = conf.get(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX);
   }
 
   public AccessCheckResult check(AccessInfo accessInfo) {
     Set<String> tags = accessInfo.getTags();
     List<ServerNode> servers = clusterManager.getServerList(tags);
     int size = (int) servers.stream().filter(ServerNode::isHealthy).filter(this::checkMemory).count();
-    if (size >= availableServerNumThreshold) {
+
+    // If the hard constraint number exist, directly check it
+    if (availableServerNumThreshold != -1 && size >= availableServerNumThreshold) {
       return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);
-    } else {
-      String msg = String.format("Denied by AccessClusterLoadChecker accessInfo[%s], "
-              + "total %s nodes, %s available nodes, "
-              + "memory percent threshold %s, available num threshold %s.",
-          accessInfo, servers.size(), size, memoryPercentThreshold, availableServerNumThreshold);
-      LOG.warn(msg);
-      CoordinatorMetrics.counterTotalLoadDeniedRequest.inc();
-      return new AccessCheckResult(false, msg);
     }
+
+    // If the hard constraint is missing, check the available servers number meet the job's required server size
+    if (availableServerNumThreshold == -1) {
+      String requiredNodesNumRaw = accessInfo.getExtraProperties().get(ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM);
+      int requiredNodesNum = defaultRequiredShuffleServerNumber;
+      if (StringUtils.isNotEmpty(requiredNodesNumRaw) && Integer.valueOf(requiredNodesNumRaw) > 0) {
+        requiredNodesNum = Integer.valueOf(requiredNodesNumRaw);
+      }
+      if (size >= requiredNodesNum) {
+        return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);
+      }
+    }
+
+    String msg = String.format("Denied by AccessClusterLoadChecker accessInfo[%s], "
+            + "total %s nodes, %s available nodes, "
+            + "memory percent threshold %s, available num threshold %s.",
+        accessInfo, servers.size(), size, memoryPercentThreshold, availableServerNumThreshold);
+    LOG.warn(msg);
+    CoordinatorMetrics.counterTotalLoadDeniedRequest.inc();
+    return new AccessCheckResult(false, msg);
   }
 
   private boolean checkMemory(ServerNode serverNode) {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/AccessClusterLoadChecker.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/AccessClusterLoadChecker.java
@@ -68,8 +68,8 @@ public class AccessClusterLoadChecker extends AbstractAccessChecker {
     if (availableServerNumThreshold == -1) {
       String requiredNodesNumRaw = accessInfo.getExtraProperties().get(ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM);
       int requiredNodesNum = defaultRequiredShuffleServerNumber;
-      if (StringUtils.isNotEmpty(requiredNodesNumRaw) && Integer.valueOf(requiredNodesNumRaw) > 0) {
-        requiredNodesNum = Integer.valueOf(requiredNodesNumRaw);
+      if (StringUtils.isNotEmpty(requiredNodesNumRaw) && Integer.parseInt(requiredNodesNumRaw) > 0) {
+        requiredNodesNum = Integer.parseInt(requiredNodesNumRaw);
       }
       if (size >= requiredNodesNum) {
         return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -102,7 +102,11 @@ public class CoordinatorConf extends RssBaseConf {
       .intType()
       .checkValue(ConfigUtils.POSITIVE_INTEGER_VALIDATOR_2, "load checker serverNum threshold must be positive")
       .noDefaultValue()
-      .withDescription("The minimal required number of healthy shuffle servers when being accessed by client");
+      .withDescription(
+          "The minimal required number of healthy shuffle servers when being accessed by client. "
+          + "And when not specified, it will use the required shuffle-server number from client as the checking "
+          + "condition. If there is no client shuffle-server number specified, the coordinator conf "
+          + "of rss.coordinator.shuffle.nodes.max will be adopted");
   public static final ConfigOption<Boolean> COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED = ConfigOptions
       .key("rss.coordinator.dynamicClientConf.enabled")
       .booleanType()

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -103,7 +103,7 @@ This document will introduce how to deploy Uniffle coordinators.
 ### AccessClusterLoadChecker settings
 |Property Name|Default|	Description|
 |---|---|---|
-|rss.coordinator.access.loadChecker.serverNum.threshold|-|The minimal required number of healthy shuffle servers when being accessed by client|
+|rss.coordinator.access.loadChecker.serverNum.threshold|-|The minimal required number of healthy shuffle servers when being accessed by client. And when not specified, it will use the required shuffle-server number from client as the checking condition. If there is no client shuffle-server number specified, the coordinator conf of rss.coordinator.shuffle.nodes.max will be adopted|
 
 ### AccessCandidatesChecker settings
 AccessCandidatesChecker is one of the built-in access checker, which will allow user to define the candidates list to use rss.  


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Use the conf of shuffleNodesNumber from jobs to be as checking factor

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In the PR #97 , it allow client to specify the shuffle server numbers, but in clusterLoaderChecker, it dont take this into considering. In this PR, it will use the conf of shuffleNodesNumber from jobs to be as checking factor only when the conf of `rss.coordinator.access.loadChecker.serverNum.threshold` is missed.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
UTs.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
