### PR TITLE
Change total lines badge to tokei.rs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently it supports [Apache Spark](https://spark.apache.org) and [MapReduce](h
 
 [![Build](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml/badge.svg?branch=master&event=push)](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/apache/incubator-uniffle/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-uniffle)
-[![Total Lines](https://img.shields.io/tokei/lines/github/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle)
+[![](https://tokei.rs/b1/github/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle)
 [![Code Quality](https://img.shields.io/lgtm/grade/java/github/apache/incubator-uniffle?label=code%20quality)](https://lgtm.com/projects/g/apache/incubator-uniffle/)
 [![License](https://img.shields.io/github/license/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/blob/master/LICENSE)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change "total lines" badge url to tokei.rs
And use empty alt message to display nothing on failure.

See https://github.com/XAMPPRocky/tokei#badges

### Why are the changes needed?

Current badge sometimes show "total lines: invalid".

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/tree/tokei#apache-uniffle-incubating