### PR TITLE
[MINOR] Fix flaky test

### DIFF
--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
@@ -175,7 +175,8 @@ public class GetShuffleReportForMultiPartTest extends SparkIntegrationTestBase {
       i++;
     }
     SparkConf conf = spark.sparkContext().conf();
-    if (!conf.get("spark.shuffle.manager", "").isEmpty()) {
+    if (conf.get("spark.shuffle.manager", "")
+        .equals("org.apache.uniffle.test.GetShuffleReportForMultiPartTest$RssShuffleManagerWrapper")) {
       RssShuffleManagerWrapper mockRssShuffleManager =
           (RssShuffleManagerWrapper) spark.sparkContext().env().shuffleManager();
       int expectRequestNum = mockRssShuffleManager.getShuffleIdToPartitionNum().values().stream()


### PR DESCRIPTION
### What changes were proposed in this pull request?
`org.apache.uniffle.test.GetShuffleReportForMultiPartTest` is flaky
 throws Exception:
ava.lang.ClassCastException: org.apache.spark.shuffle.RssShuffleManager cannot be cast to org.apache.uniffle.test.GetShuffleReportForMultiPartTest$RssShuffleManagerWrapper
	at org.apache.uniffle.test.GetShuffleReportForMultiPartTest.runTest(GetShuffleReportForMultiPartTest.java:180)
	at org.apache.uniffle.test.SparkIntegrationTestBase.runSparkApp(SparkIntegrationTestBase.java:74)
	at org.apache.uniffle.test.SparkIntegrationTestBase.run(SparkIntegrationTestBase.java:52)
	at org.apache.uniffle.test.GetShuffleReportForMultiPartTest.resultCompareTest(GetShuffleReportForMultiPartTest.java:141)

### Why are the changes needed?
Fix flaky test


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GA passed