### PR TITLE
Introduce startup-silent-period mechanism to avoid partial assignments

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -49,4 +49,9 @@ public interface ClusterManager extends Closeable {
   List<ServerNode> list();
 
   int getShuffleNodesMax();
+
+  /**
+   * @return whether to be ready for serving
+   */
+  boolean isReadyForServe();
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -164,7 +164,8 @@ public class CoordinatorConf extends RssBaseConf {
       .booleanType()
       .defaultValue(false)
       .withDescription("Enable the startup-silent-period to reject the assignment requests "
-          + "for avoiding partial assignments");
+          + "for avoiding partial assignments. To avoid service interruption, this mechanism is disabled by default. "
+          + "Especially it's recommended to use in coordinator HA mode when restarting single coordinator.");
   public static final ConfigOption<Long> COORDINATOR_START_SILENT_PERIOD_DURATION = ConfigOptions
       .key("rss.coordinator.startup-silent-period.duration")
       .longType()

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -159,6 +159,18 @@ public class CoordinatorConf extends RssBaseConf {
           .enumType(AbstractAssignmentStrategy.HostAssignmentStrategy.class)
           .defaultValue(AbstractAssignmentStrategy.HostAssignmentStrategy.PREFER_DIFF)
           .withDescription("Strategy for selecting shuffle servers");
+  public static final ConfigOption<Boolean> COORDINATOR_START_SILENT_PERIOD_ENABLED = ConfigOptions
+      .key("rss.coordinator.startup-silent-period.enabled")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("Enable the startup-silent-period to reject the assignment requests "
+          + "for avoiding partial assignments");
+  public static final ConfigOption<Long> COORDINATOR_START_SILENT_PERIOD_DURATION = ConfigOptions
+      .key("rss.coordinator.startup-silent-period.duration")
+      .longType()
+      .defaultValue(20 * 1000L)
+      .withDescription("The waiting duration(ms) when conf of "
+          + COORDINATOR_START_SILENT_PERIOD_ENABLED + " is enabled.");
 
   public CoordinatorConf() {
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
@@ -120,6 +120,10 @@ public class CoordinatorGrpcService extends CoordinatorServerGrpc.CoordinatorSer
 
     GetShuffleAssignmentsResponse response;
     try {
+      if (!coordinatorServer.getClusterManager().isReadyForServe()) {
+        throw new Exception("Coordinator is out-of-service when in starting.");
+      }
+
       final PartitionRangeAssignment pra =
           coordinatorServer
               .getAssignmentStrategy()

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -66,7 +66,7 @@ public class SimpleClusterManager implements ClusterManager {
   private final long periodicOutputIntervalTimes;
 
   private long startTime;
-  private final boolean startupSilentPeriodEnabled;
+  private boolean startupSilentPeriodEnabled;
   private long startupSilentPeriodDurationMs;
   private boolean readyForServe = false;
 
@@ -263,7 +263,17 @@ public class SimpleClusterManager implements ClusterManager {
   }
 
   @VisibleForTesting
-  void setStartTime(long startTime) {
+  public void setStartTime(long startTime) {
     this.startTime = startTime;
+  }
+
+  @VisibleForTesting
+  public void setReadyForServe(boolean readyForServe) {
+    this.readyForServe = readyForServe;
+  }
+
+  @VisibleForTesting
+  public void setStartupSilentPeriodEnabled(boolean startupSilentPeriodEnabled) {
+    this.startupSilentPeriodEnabled = startupSilentPeriodEnabled;
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -65,12 +65,20 @@ public class SimpleClusterManager implements ClusterManager {
   private long outputAliveServerCount = 0;
   private final long periodicOutputIntervalTimes;
 
+  private long startTime;
+  private final boolean startupSilentPeriodEnabled;
+  private long startupSilentPeriodDurationMs;
+  private boolean readyForServe = false;
+
   public SimpleClusterManager(CoordinatorConf conf, Configuration hadoopConf) throws Exception {
     this.shuffleNodesMax = conf.getInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX);
     this.heartbeatTimeout = conf.getLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT);
     // the thread for checking if shuffle server report heartbeat in time
     scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
         ThreadUtils.getThreadFactory("SimpleClusterManager-%d"));
+
+    this.startupSilentPeriodEnabled = conf.get(CoordinatorConf.COORDINATOR_START_SILENT_PERIOD_ENABLED);
+    this.startupSilentPeriodDurationMs = conf.get(CoordinatorConf.COORDINATOR_START_SILENT_PERIOD_DURATION);
 
     periodicOutputIntervalTimes = conf.get(CoordinatorConf.COORDINATOR_NODES_PERIODIC_OUTPUT_INTERVAL_TIMES);
     scheduledExecutorService.scheduleAtFixedRate(
@@ -86,6 +94,8 @@ public class SimpleClusterManager implements ClusterManager {
       checkNodesExecutorService.scheduleAtFixedRate(
           () -> updateExcludeNodes(excludeNodesPath), updateNodesInterval, updateNodesInterval, TimeUnit.MILLISECONDS);
     }
+
+    this.startTime = System.currentTimeMillis();
   }
 
   void nodesCheck() {
@@ -225,6 +235,19 @@ public class SimpleClusterManager implements ClusterManager {
   }
 
   @Override
+  public boolean isReadyForServe() {
+    if (!startupSilentPeriodEnabled) {
+      return true;
+    }
+
+    if (!readyForServe && System.currentTimeMillis() - startTime > startupSilentPeriodDurationMs) {
+      readyForServe = true;
+    }
+
+    return readyForServe;
+  }
+
+  @Override
   public void close() throws IOException {
     if (hadoopFileSystem != null) {
       hadoopFileSystem.close();
@@ -237,5 +260,10 @@ public class SimpleClusterManager implements ClusterManager {
     if (checkNodesExecutorService != null) {
       checkNodesExecutorService.shutdown();
     }
+  }
+
+  @VisibleForTesting
+  void setStartTime(long startTime) {
+    this.startTime = startTime;
   }
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleClusterManagerTest {
@@ -54,6 +55,18 @@ public class SimpleClusterManagerTest {
   @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
+  }
+
+  @Test
+  public void startupSilentPeriodTest() throws Exception {
+    CoordinatorConf coordinatorConf = new CoordinatorConf();
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_START_SILENT_PERIOD_ENABLED, true);
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_START_SILENT_PERIOD_DURATION, 20 * 1000L);
+    SimpleClusterManager manager = new SimpleClusterManager(coordinatorConf, new Configuration());
+    assertFalse(manager.isReadyForServe());
+
+    manager.setStartTime(System.currentTimeMillis() - 30 * 1000L);
+    assertTrue(manager.isReadyForServe());
   }
 
   @Test

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -96,9 +96,11 @@ This document will introduce how to deploy Uniffle coordinators.
 |rss.rpc.server.port|-|RPC port for coordinator|
 |rss.jetty.http.port|-|Http port for coordinator|
 |rss.coordinator.remote.storage.select.strategy|APP_BALANCE|Strategy for selecting the remote path|
-|rss.coordinator.remote.storage.schedule.time|60000|The time of scheduling the read and write time of the paths to obtain different HDFS|
-|rss.coordinator.remote.storage.schedule.file.size|204800000|The size of the file that the scheduled thread reads and writes|
-|rss.coordinator.remote.storage.schedule.access.times|3|The number of times to read and write HDFS files|
+|rss.coordinator.remote.storage.io.sample.schedule.time|60000|The time of scheduling the read and write time of the paths to obtain different HDFS|
+|rss.coordinator.remote.storage.io.sample.file.size|204800000|The size of the file that the scheduled thread reads and writes|
+|rss.coordinator.remote.storage.io.sample.access.times|3|The number of times to read and write HDFS files|
+|rss.coordinator.startup-silent-period.enabled|false|Enable the startup-silent-period to reject the assignment requests for avoiding partial assignments. To avoid service interruption, this mechanism is disabled by default. Especially it's recommended to use in coordinator HA mode when restarting single coordinator.|
+|rss.coordinator.startup-silent-period.duration|20000|The waiting duration(ms) when conf of rss.coordinator.startup-silent-period.enabled is enabled.|
 
 ### AccessClusterLoadChecker settings
 |Property Name|Default|	Description|

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
@@ -34,23 +34,34 @@ import org.apache.uniffle.client.util.ClientType;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.coordinator.SimpleClusterManager;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AssignmentServerNodesNumberTest extends CoordinatorTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(AssignmentServerNodesNumberTest.class);
+public class CoordinatorAssignmentTest extends CoordinatorTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(CoordinatorAssignmentTest.class);
   private static final int SHUFFLE_NODES_MAX = 10;
   private static final int SERVER_NUM = 10;
   private static final HashSet<String> TAGS = Sets.newHashSet("t1");
 
+  private static final String QUORUM =
+      LOCALHOST + ":" + COORDINATOR_PORT_1 + "," + LOCALHOST + ":" + COORDINATOR_PORT_2;
+
   @BeforeAll
   public static void setupServers() throws Exception {
-    CoordinatorConf coordinatorConf = getCoordinatorConf();
-    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
-    coordinatorConf.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
-    createCoordinatorServer(coordinatorConf);
+    CoordinatorConf coordinatorConf1 = getCoordinatorConf();
+    coordinatorConf1.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
+    coordinatorConf1.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
+    createCoordinatorServer(coordinatorConf1);
+
+    CoordinatorConf coordinatorConf2 = getCoordinatorConf();
+    coordinatorConf2.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
+    coordinatorConf2.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, SHUFFLE_NODES_MAX);
+    coordinatorConf2.setInteger(CoordinatorConf.RPC_SERVER_PORT, COORDINATOR_PORT_2);
+    coordinatorConf2.setInteger(CoordinatorConf.JETTY_HTTP_PORT, JETTY_PORT_2);
+    createCoordinatorServer(coordinatorConf2);
 
     for (int i = 0; i < SERVER_NUM; i++) {
       ShuffleServerConf shuffleServerConf = getShuffleServerConf();
@@ -65,11 +76,37 @@ public class AssignmentServerNodesNumberTest extends CoordinatorTestBase {
       shuffleServerConf.setInteger(RssBaseConf.RPC_SERVER_PORT, 18001 + i);
       shuffleServerConf.setInteger(RssBaseConf.JETTY_HTTP_PORT, 19010 + i);
       shuffleServerConf.set(ShuffleServerConf.TAGS, new ArrayList<>(TAGS));
+      shuffleServerConf.setString("rss.coordinator.quorum", QUORUM);
       createShuffleServer(shuffleServerConf);
     }
     startServers();
 
     Thread.sleep(1000 * 5);
+  }
+
+  @Test
+  public void testSilentPeriod() throws Exception {
+    ShuffleWriteClientImpl shuffleWriteClient = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
+        1, 1, 1, true, 1, 1);
+    shuffleWriteClient.registerCoordinators(QUORUM);
+
+    // Case1: Disable silent period
+    ShuffleAssignmentsInfo info = shuffleWriteClient.getShuffleAssignments("app1", 0, 10, 1, TAGS, -1);
+    assertEquals(SHUFFLE_NODES_MAX, info.getServerToPartitionRanges().keySet().size());
+
+    // Case2: Enable silent period mechanism, it should fallback to slave coordinator.
+    SimpleClusterManager clusterManager = (SimpleClusterManager) coordinators.get(0).getClusterManager();
+    clusterManager.setReadyForServe(false);
+    clusterManager.setStartupSilentPeriodEnabled(true);
+    clusterManager.setStartTime(System.currentTimeMillis() - 1);
+
+    if (clusterManager.getNodesNum() < 10) {
+      info = shuffleWriteClient.getShuffleAssignments("app1", 0, 10, 1, TAGS, -1);
+      assertEquals(SHUFFLE_NODES_MAX, info.getServerToPartitionRanges().keySet().size());
+    }
+
+    // recover
+    clusterManager.setReadyForServe(true);
   }
 
   @Test

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -44,6 +44,7 @@ public abstract class IntegrationTestBase extends HdfsTestBase {
   protected static final int COORDINATOR_PORT_1 = 19999;
   protected static final int COORDINATOR_PORT_2 = 20030;
   protected static final int JETTY_PORT_1 = 19998;
+  protected static final int JETTY_PORT_2 = 20040;
   protected static final String COORDINATOR_QUORUM = LOCALHOST + ":" + COORDINATOR_PORT_1;
 
   protected static List<ShuffleServer> shuffleServers = Lists.newArrayList();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Introduce startup-silent-period mechanism to avoid partial assignments
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When changing some coordinator's conf and then restart, coordinator will accept client getAssignment request immediately, but it will serve for jobs request based on the partial registered shuffle-servers, which will make some jobs gotten not enough required shuffle-servers and then slow the running speed.

I think we should make coordinator wait for more than one shuffle-server heartbeat interval before serving for client. During out-of-service, requests from client will fallback to slave coordinator.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UTs