### PR TITLE
Remove code quality badge and add release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Currently it supports [Apache Spark](https://spark.apache.org) and [MapReduce](h
 [![Build](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml/badge.svg?branch=master&event=push)](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/apache/incubator-uniffle/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-uniffle)
 [![](https://sloc.xyz/github/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle)
-[![Code Quality](https://img.shields.io/lgtm/grade/java/github/apache/incubator-uniffle?label=code%20quality)](https://lgtm.com/projects/g/apache/incubator-uniffle/)
 [![License](https://img.shields.io/github/license/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/blob/master/LICENSE)
+[![Release](https://img.shields.io/github/v/release/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/releases)
 
 ## Architecture
 ![Rss Architecture](docs/asset/rss_architecture.png)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove code quality badge and add release badge in README.

### Why are the changes needed?

1. LGTM.com will shut down in December 2022, and it's replaced by GitHub code scanning.
(Unfortunately I have no idea of how to enable it for this repository.)
2. Uniffle had just released its first version in the incubator. Let's display it in badges.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/tree/badges-2#apache-uniffle-incubating
