### PR TITLE
Upgrade Github actions for Node.js 16

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -69,9 +69,9 @@ jobs:
     - name: Set /etc/hosts mapping
       run: sudo hostname "action-host" | sudo echo "127.0.0.1 action-host" | sudo tee -a /etc/hosts
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
@@ -91,7 +91,7 @@ jobs:
       continue-on-error: true
     - name: Upload test reports
       if: ${{ failure() && inputs.reports-path != '' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.reports-name }}-${{ matrix.profile }}
         path: ${{ inputs.reports-path }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -59,9 +59,9 @@ jobs:
     name: java ${{ inputs.java-version }}
     steps:
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
@@ -87,7 +87,7 @@ jobs:
       continue-on-error: true
     - name: Upload test reports
       if: ${{ failure() && inputs.reports-path != '' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.reports-name }}
         path: ${{ inputs.reports-path }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Github actions for Node.js 16

### Why are the changes needed?

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-java, actions/setup-java, actions/checkoutShow less

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/actions/runs/3359652583
