### PR TITLE
[ISSUE-137][Improvement][AQE] Sort MapId before the data are flushed

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -76,6 +76,7 @@ import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
@@ -220,10 +221,14 @@ public class RssMRAppMaster extends MRAppMaster {
           }
           LOG.info("Start to register shuffle");
           long start = System.currentTimeMillis();
-          serverToPartitionRanges.entrySet().forEach(entry -> {
-            client.registerShuffle(
-                entry.getKey(), appId, 0, entry.getValue(), remoteStorage);
-          });
+          serverToPartitionRanges.entrySet().forEach(entry -> client.registerShuffle(
+              entry.getKey(),
+              appId,
+              0,
+              entry.getValue(),
+              remoteStorage,
+              ShuffleDataDistributionType.NORMAL
+          ));
           LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
           return shuffleAssignments;
         }, retryInterval, retryTimes);

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
@@ -290,7 +291,8 @@ public class SortWriteBufferManagerTest {
         String appId,
         int shuffleId,
         List<PartitionRange> partitionRanges,
-        RemoteStorageInfo remoteStorage) {
+        RemoteStorageInfo remoteStorage,
+        ShuffleDataDistributionType distributionType) {
     }
 
     @Override

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -67,6 +67,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.compression.Lz4Codec;
@@ -386,7 +387,8 @@ public class FetcherTest {
         String appId,
         int shuffleId,
         List<PartitionRange> partitionRanges,
-        RemoteStorageInfo storageType) {
+        RemoteStorageInfo storageType,
+        ShuffleDataDistributionType distributionType) {
 
     }
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -59,6 +59,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -279,7 +280,13 @@ public class RssShuffleManager implements ShuffleManager {
         .stream()
         .forEach(entry -> {
           shuffleWriteClient.registerShuffle(
-              entry.getKey(), appId, shuffleId, entry.getValue(), remoteStorage);
+              entry.getKey(),
+              appId,
+              shuffleId,
+              entry.getValue(),
+              remoteStorage,
+              ShuffleDataDistributionType.NORMAL
+          );
         });
     LOG.info("Finish register shuffleId[" + shuffleId + "] with " + (System.currentTimeMillis() - start) + " ms");
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -64,7 +64,9 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.RetryUtils;
 import org.apache.uniffle.common.util.RssUtils;
@@ -92,6 +94,7 @@ public class RssShuffleManager implements ShuffleManager {
   private ScheduledExecutorService heartBeatScheduledExecutorService;
   private boolean heartbeatStarted = false;
   private boolean dynamicConfEnabled = false;
+  private final ShuffleDataDistributionType dataDistributionType;
   private final EventLoop eventLoop;
   private final EventLoop defaultEventLoop = new EventLoop<AddBlockEvent>("ShuffleDataQueue") {
 
@@ -155,6 +158,7 @@ public class RssShuffleManager implements ShuffleManager {
     final int retryMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX);
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     this.dynamicConfEnabled = sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED);
+    this.dataDistributionType = RssSparkConfig.toRssConf(sparkConf).get(RssClientConf.DATA_DISTRIBUTION_TYPE);
     long retryIntervalMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_INTERVAL_MAX);
     int heartBeatThreadNum = sparkConf.get(RssSparkConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM);
     this.dataTransferPoolSize = sparkConf.get(RssSparkConfig.RSS_DATA_TRANSFER_POOL_SIZE);
@@ -205,6 +209,7 @@ public class RssShuffleManager implements ShuffleManager {
       Map<String, Set<Long>> taskToFailedBlockIds) {
     this.sparkConf = conf;
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
+    this.dataDistributionType = RssSparkConfig.toRssConf(sparkConf).get(RssClientConf.DATA_DISTRIBUTION_TYPE);
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);
     this.heartbeatTimeout = sparkConf.getLong(RssSparkConfig.RSS_HEARTBEAT_TIMEOUT.key(), heartbeatInterval / 2);
     this.dataReplica = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA);
@@ -460,7 +465,9 @@ public class RssShuffleManager implements ShuffleManager {
         RssUtils.generatePartitionToBitmap(blockIdBitmap, startPartition, endPartition),
         taskIdBitmap,
         readMetrics,
-        RssSparkConfig.toRssConf(sparkConf));
+        RssSparkConfig.toRssConf(sparkConf),
+        dataDistributionType
+    );
   }
 
   private Roaring64NavigableMap getExpectedTasksByExecutorId(
@@ -621,7 +628,9 @@ public class RssShuffleManager implements ShuffleManager {
               appId,
               shuffleId,
               entry.getValue(),
-              remoteStorage);
+              remoteStorage,
+              dataDistributionType
+          );
         });
     LOG.info("Finish register shuffleId[" + shuffleId + "] with " + (System.currentTimeMillis() - start) + " ms");
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -206,7 +206,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
         CreateShuffleReadClientRequest request = new CreateShuffleReadClientRequest(
             appId, shuffleId, partition, storageType, basePath, indexReadLimit, readBufferSize,
             1, partitionNum, partitionToExpectBlocks.get(partition), taskIdBitmap, shuffleServerInfoList,
-            hadoopConf, dataDistributionType, mapStartIndex, mapEndIndex);
+            hadoopConf, dataDistributionType);
         ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
         RssShuffleDataIterator iterator = new RssShuffleDataIterator<K, C>(
             shuffleDependency.serializer(), shuffleReadClient,

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import scala.Option;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.storage.handler.impl.HdfsShuffleWriteHandler;
 import org.apache.uniffle.storage.util.StorageType;
@@ -94,7 +95,10 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
         1,
         partitionToExpectBlocks,
         taskIdBitmap,
-        new ShuffleReadMetrics(), new RssConf()));
+        new ShuffleReadMetrics(),
+        new RssConf(),
+        ShuffleDataDistributionType.NORMAL
+    ));
     validateResult(rssShuffleReaderSpy.read(), expectedData, 10);
 
     writeTestData(writeHandler1, 2, 4, expectedData,
@@ -115,8 +119,10 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
         2,
         partitionToExpectBlocks,
         taskIdBitmap,
-        new ShuffleReadMetrics(), new RssConf())
-    );
+        new ShuffleReadMetrics(),
+        new RssConf(),
+        ShuffleDataDistributionType.NORMAL
+    ));
     validateResult(rssShuffleReaderSpy1.read(), expectedData, 18);
 
     RssShuffleReader rssShuffleReaderSpy2 = spy(new RssShuffleReader<String, String>(
@@ -134,7 +140,10 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
         2,
         partitionToExpectBlocks,
         Roaring64NavigableMap.bitmapOf(),
-        new ShuffleReadMetrics(), new RssConf()));
+        new ShuffleReadMetrics(),
+        new RssConf(),
+        ShuffleDataDistributionType.NORMAL
+    ));
     validateResult(rssShuffleReaderSpy2.read(), Maps.newHashMap(), 0);
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -28,6 +28,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
 public interface ShuffleWriteClient {
@@ -41,7 +42,8 @@ public interface ShuffleWriteClient {
       String appId,
       int shuffleId,
       List<PartitionRange> partitionRanges,
-      RemoteStorageInfo remoteStorage);
+      RemoteStorageInfo remoteStorage,
+      ShuffleDataDistributionType dataDistributionType);
 
   boolean sendCommit(Set<ShuffleServerInfo> shuffleServerInfoSet, String appId, int shuffleId, int numMaps);
 

--- a/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
@@ -70,7 +70,6 @@ public class ShuffleClientFactory {
         request.getPartitionId(), request.getIndexReadLimit(), request.getPartitionNumPerRange(),
         request.getPartitionNum(), request.getReadBufferSize(), request.getBasePath(),
         request.getBlockIdBitmap(), request.getTaskIdBitmap(), request.getShuffleServerInfoList(),
-        request.getHadoopConf(), request.getIdHelper(), request.getShuffleDataDistributionType(),
-        request.getStartMapIdex(), request.getEndMapIndex());
+        request.getHadoopConf(), request.getIdHelper(), request.getShuffleDataDistributionType());
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/org/apache/uniffle/client/factory/ShuffleClientFactory.java
@@ -70,6 +70,7 @@ public class ShuffleClientFactory {
         request.getPartitionId(), request.getIndexReadLimit(), request.getPartitionNumPerRange(),
         request.getPartitionNum(), request.getReadBufferSize(), request.getBasePath(),
         request.getBlockIdBitmap(), request.getTaskIdBitmap(), request.getShuffleServerInfoList(),
-        request.getHadoopConf(), request.getIdHelper());
+        request.getHadoopConf(), request.getIdHelper(), request.getShuffleDataDistributionType(),
+        request.getStartMapIdex(), request.getEndMapIndex());
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -34,6 +34,7 @@ import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.util.IdHelper;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
@@ -60,6 +61,35 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   private AtomicLong crcCheckTime = new AtomicLong(0);
   private ClientReadHandler clientReadHandler;
   private final IdHelper idHelper;
+  private ShuffleDataDistributionType dataDistributionType = ShuffleDataDistributionType.NORMAL;
+  private int mapStartIndex = 0;
+  private int mapEndIndex = Integer.MAX_VALUE;
+
+  public ShuffleReadClientImpl(
+      String storageType,
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int indexReadLimit,
+      int partitionNumPerRange,
+      int partitionNum,
+      int readBufferSize,
+      String storageBasePath,
+      Roaring64NavigableMap blockIdBitmap,
+      Roaring64NavigableMap taskIdBitmap,
+      List<ShuffleServerInfo> shuffleServerInfoList,
+      Configuration hadoopConf,
+      IdHelper idHelper,
+      ShuffleDataDistributionType dataDistributionType,
+      int startMapIndex,
+      int endMapIndex) {
+    this(storageType, appId, shuffleId, partitionId, indexReadLimit,
+        partitionNumPerRange, partitionNum, readBufferSize, storageBasePath,
+        blockIdBitmap, taskIdBitmap, shuffleServerInfoList, hadoopConf, idHelper);
+    this.dataDistributionType = dataDistributionType;
+    this.mapStartIndex = startMapIndex;
+    this.mapEndIndex = endMapIndex;
+  }
 
   public ShuffleReadClientImpl(
       String storageType,
@@ -96,6 +126,9 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     request.setHadoopConf(hadoopConf);
     request.setExpectBlockIds(blockIdBitmap);
     request.setProcessBlockIds(processedBlockIds);
+    request.setDistributionType(dataDistributionType);
+    request.setStartMapIndex(mapStartIndex);
+    request.setEndMapIndex(mapEndIndex);
 
     List<Long> removeBlockIds = Lists.newArrayList();
     blockIdBitmap.forEach(bid -> {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -62,8 +62,6 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   private ClientReadHandler clientReadHandler;
   private final IdHelper idHelper;
   private ShuffleDataDistributionType dataDistributionType = ShuffleDataDistributionType.NORMAL;
-  private int mapStartIndex = 0;
-  private int mapEndIndex = Integer.MAX_VALUE;
 
   public ShuffleReadClientImpl(
       String storageType,
@@ -80,15 +78,11 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
       List<ShuffleServerInfo> shuffleServerInfoList,
       Configuration hadoopConf,
       IdHelper idHelper,
-      ShuffleDataDistributionType dataDistributionType,
-      int startMapIndex,
-      int endMapIndex) {
+      ShuffleDataDistributionType dataDistributionType) {
     this(storageType, appId, shuffleId, partitionId, indexReadLimit,
         partitionNumPerRange, partitionNum, readBufferSize, storageBasePath,
         blockIdBitmap, taskIdBitmap, shuffleServerInfoList, hadoopConf, idHelper);
     this.dataDistributionType = dataDistributionType;
-    this.mapStartIndex = startMapIndex;
-    this.mapEndIndex = endMapIndex;
   }
 
   public ShuffleReadClientImpl(
@@ -127,8 +121,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     request.setExpectBlockIds(blockIdBitmap);
     request.setProcessBlockIds(processedBlockIds);
     request.setDistributionType(dataDistributionType);
-    request.setStartMapIndex(mapStartIndex);
-    request.setEndMapIndex(mapEndIndex);
+    request.setExpectTaskIds(taskIdBitmap);
 
     List<Long> removeBlockIds = Lists.newArrayList();
     blockIdBitmap.forEach(bid -> {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -73,6 +73,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.ThreadUtils;
@@ -332,7 +333,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       String appId,
       int shuffleId,
       List<PartitionRange> partitionRanges,
-      RemoteStorageInfo remoteStorage) {
+      RemoteStorageInfo remoteStorage,
+      ShuffleDataDistributionType dataDistributionType) {
     String user = null;
     try {
       user = UserGroupInformation.getCurrentUser().getShortUserName();
@@ -342,7 +344,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     LOG.info("User: {}", user);
 
     RssRegisterShuffleRequest request =
-        new RssRegisterShuffleRequest(appId, shuffleId, partitionRanges, remoteStorage, user);
+        new RssRegisterShuffleRequest(appId, shuffleId, partitionRanges, remoteStorage, user, dataDistributionType);
     RssRegisterShuffleResponse response = getShuffleServerClient(shuffleServerInfo).registerShuffle(request);
 
     String msg = "Error happened when registerShuffle with appId[" + appId + "], shuffleId[" + shuffleId

--- a/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
@@ -44,8 +44,6 @@ public class CreateShuffleReadClientRequest {
   private Configuration hadoopConf;
   private IdHelper idHelper;
   private ShuffleDataDistributionType shuffleDataDistributionType = ShuffleDataDistributionType.NORMAL;
-  private int startMapIdex = 0;
-  private int endMapIndex = Integer.MAX_VALUE;
 
   public CreateShuffleReadClientRequest(
       String appId,
@@ -61,14 +59,10 @@ public class CreateShuffleReadClientRequest {
       Roaring64NavigableMap taskIdBitmap,
       List<ShuffleServerInfo> shuffleServerInfoList,
       Configuration hadoopConf,
-      ShuffleDataDistributionType dataDistributionType,
-      int startMapIdex,
-      int endMapIndex) {
+      ShuffleDataDistributionType dataDistributionType) {
     this(appId, shuffleId, partitionId, storageType, basePath, indexReadLimit, readBufferSize,
         partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
         hadoopConf, new DefaultIdHelper());
-    this.startMapIdex = startMapIdex;
-    this.endMapIndex = endMapIndex;
     this.shuffleDataDistributionType = dataDistributionType;
   }
 
@@ -180,13 +174,5 @@ public class CreateShuffleReadClientRequest {
 
   public ShuffleDataDistributionType getShuffleDataDistributionType() {
     return shuffleDataDistributionType;
-  }
-
-  public int getStartMapIdex() {
-    return startMapIdex;
-  }
-
-  public int getEndMapIndex() {
-    return endMapIndex;
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
@@ -24,6 +24,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.client.util.IdHelper;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
 public class CreateShuffleReadClientRequest {
@@ -42,6 +43,34 @@ public class CreateShuffleReadClientRequest {
   private List<ShuffleServerInfo> shuffleServerInfoList;
   private Configuration hadoopConf;
   private IdHelper idHelper;
+  private ShuffleDataDistributionType shuffleDataDistributionType = ShuffleDataDistributionType.NORMAL;
+  private int startMapIdex = 0;
+  private int endMapIndex = Integer.MAX_VALUE;
+
+  public CreateShuffleReadClientRequest(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      String storageType,
+      String basePath,
+      int indexReadLimit,
+      int readBufferSize,
+      int partitionNumPerRange,
+      int partitionNum,
+      Roaring64NavigableMap blockIdBitmap,
+      Roaring64NavigableMap taskIdBitmap,
+      List<ShuffleServerInfo> shuffleServerInfoList,
+      Configuration hadoopConf,
+      ShuffleDataDistributionType dataDistributionType,
+      int startMapIdex,
+      int endMapIndex) {
+    this(appId, shuffleId, partitionId, storageType, basePath, indexReadLimit, readBufferSize,
+        partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
+        hadoopConf, new DefaultIdHelper());
+    this.startMapIdex = startMapIdex;
+    this.endMapIndex = endMapIndex;
+    this.shuffleDataDistributionType = dataDistributionType;
+  }
 
   public CreateShuffleReadClientRequest(
       String appId,
@@ -147,5 +176,17 @@ public class CreateShuffleReadClientRequest {
 
   public IdHelper getIdHelper() {
     return idHelper;
+  }
+
+  public ShuffleDataDistributionType getShuffleDataDistributionType() {
+    return shuffleDataDistributionType;
+  }
+
+  public int getStartMapIdex() {
+    return startMapIdex;
+  }
+
+  public int getEndMapIndex() {
+    return endMapIndex;
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataDistributionType.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataDistributionType.java
@@ -1,0 +1,9 @@
+package org.apache.uniffle.common;
+
+/**
+ * The type of shuffle data distribution of a single partition.
+ */
+public enum ShuffleDataDistributionType {
+  NORMAL,
+  LOCAL_ORDER
+}

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataDistributionType.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataDistributionType.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common;
 
 /**

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.common.config;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.compression.Codec;
 
 import static org.apache.uniffle.common.compression.Codec.Type.LZ4;
@@ -35,4 +36,11 @@ public class RssClientConf {
       .intType()
       .defaultValue(3)
       .withDescription("The zstd compression level, the default level is 3");
+
+  public static final ConfigOption<ShuffleDataDistributionType> DATA_DISTRIBUTION_TYPE = ConfigOptions
+      .key("rss.client.shuffle.data.distribution.type")
+      .enumType(ShuffleDataDistributionType.class)
+      .defaultValue(ShuffleDataDistributionType.NORMAL)
+      .withDescription("The type of partition shuffle data distribution, including normal and local_order. "
+          + "The default value is normal. This config is only valid in Spark3.x");
 }

--- a/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+import java.util.List;
+
+import org.apache.uniffle.common.ShuffleDataSegment;
+import org.apache.uniffle.common.ShuffleIndexResult;
+import org.apache.uniffle.common.util.RssUtils;
+
+public class FixedSizeSegmentSplitter implements SegmentSplitter {
+
+  private int readBufferSize;
+
+  public FixedSizeSegmentSplitter(int readBufferSize) {
+    this.readBufferSize = readBufferSize;
+  }
+
+  @Override
+  public List<ShuffleDataSegment> split(ShuffleIndexResult shuffleIndexResult) {
+    return RssUtils.transIndexDataToSegments(shuffleIndexResult, readBufferSize);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -61,7 +61,7 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
     /**
      * One ShuffleDataSegment should meet following requirements:
      *
-     * 1. taskId in [startMapId, endMapId]
+     * 1. taskId in [startMapId, endMapId) taskIds bitmap
      * 2. ShuffleDataSegment size should < readBufferSize
      * 3. ShuffleDataSegment's blocks should be continuous
      *

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataSegment;
+import org.apache.uniffle.common.ShuffleIndexResult;
+import org.apache.uniffle.common.exception.RssException;
+
+public class LocalOrderSegmentSplitter implements SegmentSplitter {
+
+  private int startMapId;
+  private int endMapId;
+  private int readBufferSize;
+
+  public LocalOrderSegmentSplitter(int startMapId, int endMapId, int readBufferSize) {
+    this.startMapId = startMapId;
+    this.endMapId = endMapId;
+    this.readBufferSize = readBufferSize;
+  }
+
+  @Override
+  public List<ShuffleDataSegment> split(ShuffleIndexResult shuffleIndexResult) {
+    if (shuffleIndexResult == null || shuffleIndexResult.isEmpty()) {
+      return Lists.newArrayList();
+    }
+
+    byte[] indexData = shuffleIndexResult.getIndexData();
+    long dataFileLen = shuffleIndexResult.getDataFileLen();
+
+    ByteBuffer byteBuffer = ByteBuffer.wrap(indexData);
+    List<BufferSegment> bufferSegments = Lists.newArrayList();
+
+    List<ShuffleDataSegment> dataFileSegments = Lists.newArrayList();
+    int bufferOffset = 0;
+    long fileOffset = -1;
+    long totalLen = 0;
+
+    long lastTaskAttemptId = -1;
+
+    /**
+     * One ShuffleDataSegment should meet following requirements:
+     *
+     * 1. taskId in [startMapId, endMapId]
+     * 2. ShuffleDataSegment size should < readBufferSize
+     * 3. ShuffleDataSegment's blocks should be continuous
+     *
+     */
+    while (byteBuffer.hasRemaining()) {
+      try {
+        long offset = byteBuffer.getLong();
+        int length = byteBuffer.getInt();
+        int uncompressLength = byteBuffer.getInt();
+        long crc = byteBuffer.getLong();
+        long blockId = byteBuffer.getLong();
+        long taskAttemptId = byteBuffer.getLong();
+
+        if (lastTaskAttemptId == -1) {
+          lastTaskAttemptId = taskAttemptId;
+        }
+
+        // If ShuffleServer is flushing the file at this time, the length in the index file record may be greater
+        // than the length in the actual data file, and it needs to be returned at this time to avoid EOFException
+        if (dataFileLen != -1 && totalLen >= dataFileLen) {
+          break;
+        }
+
+        if ((taskAttemptId < lastTaskAttemptId && bufferSegments.size() > 0) || bufferOffset >= readBufferSize) {
+          ShuffleDataSegment sds = new ShuffleDataSegment(fileOffset, bufferOffset, bufferSegments);
+          dataFileSegments.add(sds);
+          bufferSegments = Lists.newArrayList();
+          bufferOffset = 0;
+          fileOffset = -1;
+        }
+
+        if (taskAttemptId >= startMapId && taskAttemptId <= endMapId) {
+          if (fileOffset == -1) {
+            fileOffset = offset;
+          }
+          bufferSegments.add(new BufferSegment(blockId, bufferOffset, length, uncompressLength, crc, taskAttemptId));
+          bufferOffset += length;
+        }
+
+        lastTaskAttemptId = taskAttemptId;
+      } catch (BufferUnderflowException ue) {
+        throw new RssException("Read index data under flow", ue);
+      }
+    }
+
+    if (bufferOffset > 0) {
+      ShuffleDataSegment sds = new ShuffleDataSegment(fileOffset, bufferOffset, bufferSegments);
+      dataFileSegments.add(sds);
+    }
+
+    return dataFileSegments;
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -94,7 +94,7 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           fileOffset = -1;
         }
 
-        if (taskAttemptId >= startMapId && taskAttemptId <= endMapId) {
+        if (taskAttemptId >= startMapId && taskAttemptId < endMapId) {
           if (fileOffset == -1) {
             fileOffset = offset;
           }

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataSegment;
@@ -30,13 +31,11 @@ import org.apache.uniffle.common.exception.RssException;
 
 public class LocalOrderSegmentSplitter implements SegmentSplitter {
 
-  private int startMapId;
-  private int endMapId;
+  private Roaring64NavigableMap expectTaskIds;
   private int readBufferSize;
 
-  public LocalOrderSegmentSplitter(int startMapId, int endMapId, int readBufferSize) {
-    this.startMapId = startMapId;
-    this.endMapId = endMapId;
+  public LocalOrderSegmentSplitter(Roaring64NavigableMap expectTaskIds, int readBufferSize) {
+    this.expectTaskIds = expectTaskIds;
     this.readBufferSize = readBufferSize;
   }
 
@@ -94,7 +93,7 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           fileOffset = -1;
         }
 
-        if (taskAttemptId >= startMapId && taskAttemptId < endMapId) {
+        if (expectTaskIds.contains(taskAttemptId)) {
           if (fileOffset == -1) {
             fileOffset = offset;
           }

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -29,6 +29,19 @@ import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.exception.RssException;
 
+/**
+ * {@class LocalOrderSegmentSplitter} will be initialized only when the {@class ShuffleDataDistributionType}
+ * is LOCAL_ORDER, which means the index file will be split into several segments according to its
+ * locally ordered properties. And it will skip some blocks, but the remaining blocks in a segment
+ * are continuous.
+ *
+ * This strategy will be useful for Spark AQE skew optimization, it will split the single partition into
+ * multiple shuffle readers, and each one will fetch partial single partition data which is in the range of
+ * [StartMapId, endMapId). And so if one reader uses this, it will skip lots of unnecessary blocks.
+ *
+ * Last but not least, this split strategy depends on LOCAL_ORDER of index file, which must be guaranteed by
+ * the shuffle server.
+ */
 public class LocalOrderSegmentSplitter implements SegmentSplitter {
 
   private Roaring64NavigableMap expectTaskIds;

--- a/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+import java.util.List;
+
+import org.apache.uniffle.common.ShuffleDataSegment;
+import org.apache.uniffle.common.ShuffleIndexResult;
+
+public interface SegmentSplitter {
+
+  List<ShuffleDataSegment> split(ShuffleIndexResult shuffleIndexResult);
+
+}

--- a/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.uniffle.common.segment;
 
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 
 public class SegmentSplitterFactory {
@@ -31,12 +33,11 @@ public class SegmentSplitterFactory {
 
   public SegmentSplitter get(
       ShuffleDataDistributionType distributionType,
-      int startMapId,
-      int endMapId,
+      Roaring64NavigableMap expectTaskIds,
       int readBufferSize) {
     switch (distributionType) {
       case LOCAL_ORDER:
-        return new LocalOrderSegmentSplitter(startMapId, endMapId, readBufferSize);
+        return new LocalOrderSegmentSplitter(expectTaskIds, readBufferSize);
       case NORMAL:
       default:
         return new FixedSizeSegmentSplitter(readBufferSize);

--- a/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+public class SegmentSplitterFactory {
+
+  private SegmentSplitterFactory() {
+    // ignore
+  }
+
+  private static class LazyHolder {
+    static final SegmentSplitterFactory INSTANCE = new SegmentSplitterFactory();
+  }
+
+  public SegmentSplitter get(boolean aqeEnabled, int startMapId, int endMapId, int readBufferSize) {
+    if (aqeEnabled) {
+      return new LocalOrderSegmentSplitter(startMapId, endMapId, readBufferSize);
+    }
+    return new FixedSizeSegmentSplitter(readBufferSize);
+  }
+
+  public static SegmentSplitterFactory getInstance() {
+    return LazyHolder.INSTANCE;
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/SegmentSplitterFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.uniffle.common.segment;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
+
 public class SegmentSplitterFactory {
 
   private SegmentSplitterFactory() {
@@ -27,11 +29,18 @@ public class SegmentSplitterFactory {
     static final SegmentSplitterFactory INSTANCE = new SegmentSplitterFactory();
   }
 
-  public SegmentSplitter get(boolean aqeEnabled, int startMapId, int endMapId, int readBufferSize) {
-    if (aqeEnabled) {
-      return new LocalOrderSegmentSplitter(startMapId, endMapId, readBufferSize);
+  public SegmentSplitter get(
+      ShuffleDataDistributionType distributionType,
+      int startMapId,
+      int endMapId,
+      int readBufferSize) {
+    switch (distributionType) {
+      case LOCAL_ORDER:
+        return new LocalOrderSegmentSplitter(startMapId, endMapId, readBufferSize);
+      case NORMAL:
+      default:
+        return new FixedSizeSegmentSplitter(readBufferSize);
     }
-    return new FixedSizeSegmentSplitter(readBufferSize);
   }
 
   public static SegmentSplitterFactory getInstance() {

--- a/common/src/test/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.common.ShuffleDataSegment;
+import org.apache.uniffle.common.ShuffleIndexResult;
+
+import static org.apache.uniffle.common.segment.LocalOrderSegmentSplitterTest.generateData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class FixedSizeSegmentSplitterTest {
+
+  @Test
+  public void testSplit() {
+    SegmentSplitter splitter = new FixedSizeSegmentSplitter(100);
+    ShuffleIndexResult shuffleIndexResult = new ShuffleIndexResult();
+    List<ShuffleDataSegment> shuffleDataSegments = splitter.split(shuffleIndexResult);
+    assertTrue(shuffleDataSegments.isEmpty());
+
+    int readBufferSize = 32;
+    splitter = new FixedSizeSegmentSplitter(32);
+
+    // those 5 segment's data length are [32, 16, 10, 32, 6] so the index should be
+    // split into 3 ShuffleDataSegment, which are [32, 16 + 10 + 32, 6]
+    byte[] data = generateData(
+        Pair.of(32, 0),
+        Pair.of(16, 0),
+        Pair.of(10, 0),
+        Pair.of(32, 6),
+        Pair.of(6, 0)
+    );
+    shuffleDataSegments = splitter.split(new ShuffleIndexResult(data, -1));
+    assertEquals(3, shuffleDataSegments.size());
+
+    assertEquals(0, shuffleDataSegments.get(0).getOffset());
+    assertEquals(32, shuffleDataSegments.get(0).getLength());
+    assertEquals(1, shuffleDataSegments.get(0).getBufferSegments().size());
+
+    assertEquals(32, shuffleDataSegments.get(1).getOffset());
+    assertEquals(58, shuffleDataSegments.get(1).getLength());
+    assertEquals(3,shuffleDataSegments.get(1).getBufferSegments().size());
+
+    assertEquals(90, shuffleDataSegments.get(2).getOffset());
+    assertEquals(6, shuffleDataSegments.get(2).getLength());
+    assertEquals(1, shuffleDataSegments.get(2).getBufferSegments().size());
+
+    ByteBuffer incompleteByteBuffer = ByteBuffer.allocate(12);
+    incompleteByteBuffer.putLong(1L);
+    incompleteByteBuffer.putInt(2);
+    data = incompleteByteBuffer.array();
+    // It should throw exception
+    try {
+      splitter.split(new ShuffleIndexResult(data, -1));
+      fail();
+    } catch (Exception e) {
+      // ignore
+      assertTrue(e.getMessage().contains("Read index data under flow"));
+    }
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
@@ -33,10 +33,10 @@ public class LocalOrderSegmentSplitterTest {
 
   @Test
   public void testSplit() {
-    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(1, 1, 1000);
+    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(1, 2, 1000);
     assertTrue(splitter.split(new ShuffleIndexResult()).isEmpty());
 
-    splitter = new LocalOrderSegmentSplitter(1, 1, 32);
+    splitter = new LocalOrderSegmentSplitter(1, 2, 32);
 
     /**
      * (length, taskId)
@@ -89,7 +89,7 @@ public class LocalOrderSegmentSplitterTest {
      *
      *        (32, 5) will be dropped
      */
-    splitter = new LocalOrderSegmentSplitter(1, 4, 32);
+    splitter = new LocalOrderSegmentSplitter(1, 5, 32);
     data = generateData(
         Pair.of(32, 5),
         Pair.of(16, 1),

--- a/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
@@ -107,7 +107,7 @@ public class LocalOrderSegmentSplitterTest {
     assertEquals(6, dataSegments.get(1).getLength());
   }
 
-  private byte[] generateData(Pair<Integer, Integer>... configEntries) {
+  public static byte[] generateData(Pair<Integer, Integer>... configEntries) {
     ByteBuffer byteBuffer = ByteBuffer.allocate(configEntries.length * 40);
     int total = 0;
     for (Pair<Integer, Integer> entry : configEntries) {

--- a/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.segment;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.common.ShuffleDataSegment;
+import org.apache.uniffle.common.ShuffleIndexResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LocalOrderSegmentSplitterTest {
+
+  @Test
+  public void testSplit() {
+    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(1, 1, 1000);
+    assertTrue(splitter.split(new ShuffleIndexResult()).isEmpty());
+
+    splitter = new LocalOrderSegmentSplitter(1, 1, 32);
+
+    /**
+     * case1: (32, 1) (16, 1) (10, 2) (16, 1) (6, 1)
+     *
+     *        (10, 2) will be dropped
+     */
+    List<MockedIndexBlock> mockedBlocks = generateBlocks(
+        Pair.of(32, 1),
+        Pair.of(16, 1),
+        Pair.of(10, 2),
+        Pair.of(16, 1),
+        Pair.of(6, 1)
+    );
+    byte[] data = generateData(mockedBlocks);
+    List<ShuffleDataSegment> dataSegments = splitter.split(new ShuffleIndexResult(data, -1));
+    assertEquals(3, dataSegments.size());
+
+    assertEquals(0, dataSegments.get(0).getOffset());
+    assertEquals(32, dataSegments.get(0).getLength());
+
+    assertEquals(32, dataSegments.get(1).getOffset());
+    assertEquals(16, dataSegments.get(1).getLength());
+
+    assertEquals(58, dataSegments.get(2).getOffset());
+    assertEquals(22, dataSegments.get(2).getLength());
+
+    /**
+     * case2: (32, 2) (16, 1) (10, 1) (16, 2) (6, 1)
+     *
+     *        (32, 2) (16, 2) will be dropped
+     */
+    data = generateData(
+        generateBlocks(
+            Pair.of(32, 2),
+            Pair.of(16, 1),
+            Pair.of(10, 1),
+            Pair.of(16, 2),
+            Pair.of(6, 1)
+        )
+    );
+    dataSegments = splitter.split(new ShuffleIndexResult(data, -1));
+    assertEquals(2, dataSegments.size());
+
+    assertEquals(32, dataSegments.get(0).getOffset());
+    assertEquals(26, dataSegments.get(0).getLength());
+
+    assertEquals(74, dataSegments.get(1).getOffset());
+    assertEquals(6, dataSegments.get(1).getLength());
+
+    /**
+     * case3: (32, 5) (16, 1) (10, 3) (16, 4) (6, 1)
+     *
+     *        (32, 5) will be dropped
+     */
+    splitter = new LocalOrderSegmentSplitter(1, 4, 32);
+    data = generateData(
+        generateBlocks(
+            Pair.of(32, 5),
+            Pair.of(16, 1),
+            Pair.of(10, 3),
+            Pair.of(16, 4),
+            Pair.of(6, 1)
+        )
+    );
+    dataSegments = splitter.split(new ShuffleIndexResult(data, -1));
+    assertEquals(2, dataSegments.size());
+
+    assertEquals(32, dataSegments.get(0).getOffset());
+    assertEquals(42, dataSegments.get(0).getLength());
+
+    assertEquals(74, dataSegments.get(1).getOffset());
+    assertEquals(6, dataSegments.get(1).getLength());
+  }
+
+  private byte[] generateData(List<MockedIndexBlock> mockedBlocks) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(mockedBlocks.size() * 40);
+    int total = 0;
+    for (MockedIndexBlock block : mockedBlocks) {
+      byteBuffer.putLong(total);
+      byteBuffer.putInt(block.getLength());
+      byteBuffer.putInt(1);
+      byteBuffer.putLong(1);
+      byteBuffer.putLong(1);
+      byteBuffer.putLong(block.getTaskId());
+
+      total += block.getLength();
+    }
+    return byteBuffer.array();
+  }
+
+  static class MockedIndexBlock {
+    private int length;
+    private int taskId;
+
+    public int getLength() {
+      return length;
+    }
+
+    public int getTaskId() {
+      return taskId;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    static class Builder {
+      private MockedIndexBlock mockedIndexBlock;
+
+      public Builder() {
+        this.mockedIndexBlock = new MockedIndexBlock();
+      }
+
+      public Builder length(int length) {
+        this.mockedIndexBlock.length = length;
+        return this;
+      }
+
+      public Builder taskId(int taskId) {
+        this.mockedIndexBlock.taskId = taskId;
+        return this;
+      }
+
+      public MockedIndexBlock build() {
+        return mockedIndexBlock;
+      }
+    }
+  }
+
+  private List<MockedIndexBlock> generateBlocks(Pair<Integer, Integer>... configEntries) {
+    List<MockedIndexBlock> blocks = new ArrayList<>();
+    for (Pair<Integer, Integer> entry : configEntries) {
+      blocks.add(
+          MockedIndexBlock.builder().length(entry.getLeft()).taskId(entry.getRight()).build()
+      );
+    }
+    return blocks;
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
@@ -33,10 +34,11 @@ public class LocalOrderSegmentSplitterTest {
 
   @Test
   public void testSplit() {
-    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(1, 2, 1000);
+    Roaring64NavigableMap taskIds = Roaring64NavigableMap.bitmapOf(1);
+    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(taskIds, 1000);
     assertTrue(splitter.split(new ShuffleIndexResult()).isEmpty());
 
-    splitter = new LocalOrderSegmentSplitter(1, 2, 32);
+    splitter = new LocalOrderSegmentSplitter(taskIds, 32);
 
     /**
      * (length, taskId)
@@ -89,7 +91,8 @@ public class LocalOrderSegmentSplitterTest {
      *
      *        (32, 5) will be dropped
      */
-    splitter = new LocalOrderSegmentSplitter(1, 5, 32);
+    taskIds = Roaring64NavigableMap.bitmapOf(1, 2, 3, 4);
+    splitter = new LocalOrderSegmentSplitter(taskIds, 32);
     data = generateData(
         Pair.of(32, 5),
         Pair.of(16, 1),

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -54,6 +54,17 @@ After apply the patch and rebuild spark, add following configuration in spark co
   spark.dynamicAllocation.enabled true
   ```
 
+### Support Spark AQE
+
+To improve performance of AQE skew optimization, uniffle introduces the LOCAL_ORDER shuffle-data distribution mechanism
+to filter the lots of data to reduce network bandwidth and shuffle-server local-disk pressure.
+
+It can be enabled by the following config
+  ```bash
+  # Default value is NORMAL, it will directly append to file when the memory data is flushed to external storage 
+  spark.rss.client.shuffle.data.distribution.type LOCAL_ORDER
+  ```
+
 ### Deploy MapReduce Client Plugin
 
 1. Add client jar to the classpath of each NodeManager, e.g., <HADOOP>/share/hadoop/mapreduce/
@@ -91,6 +102,7 @@ These configurations are shared by all types of clients.
 |<client_type>.rss.client.assignment.shuffle.nodes.max|-1|The number of required assignment shuffle servers. If it is less than 0 or equals to 0 or greater than the coordinator's config of "rss.coordinator.shuffle.nodes.max", it will use the size of "rss.coordinator.shuffle.nodes.max" default|
 |<client_type>.rss.client.io.compression.codec|lz4|The compression codec is used to compress the shuffle data. Default codec is `lz4`, `zstd` also can be used.|
 |<client_type>.rss.client.io.compression.zstd.level|3|The zstd compression level, the default level is 3|
+|<client_type>.rss.client.shuffle.data.distribution.type|NORMAL|The type of partition shuffle data distribution, including normal and local_order. The default value is normal. Now this config is only valid in Spark3.x|
 Notice:
 
 1. `<client_type>` should be `spark` or `mapreduce`

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -42,6 +42,7 @@ import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -272,8 +273,14 @@ public class QuorumTest extends ShuffleReadWriteBase {
         shuffleServerInfo2, shuffleServerInfo3, shuffleServerInfo4);
 
     for (int i = 0; i < replica; i++) {
-      shuffleWriteClientImpl.registerShuffle(allServers.get(i),
-          testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), new RemoteStorageInfo(""));
+      shuffleWriteClientImpl.registerShuffle(
+          allServers.get(i),
+          testAppId,
+          0,
+          Lists.newArrayList(new PartitionRange(0, 0)),
+          new RemoteStorageInfo(""),
+          ShuffleDataDistributionType.NORMAL
+      );
     }
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
@@ -39,9 +39,9 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.segment.FixedSizeSegmentSplitter;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.common.util.Constants;
-import org.apache.uniffle.common.util.RssUtils;
 
 
 public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
@@ -131,8 +131,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
     RssGetShuffleIndexRequest rgsir = new RssGetShuffleIndexRequest(
         appId, shuffleId, partitionId, partitionNumPerRange, partitionNum);
     ShuffleIndexResult shuffleIndexResult = shuffleServerClient.getShuffleIndex(rgsir).getShuffleIndexResult();
-    return RssUtils.transIndexDataToSegments(shuffleIndexResult, readBufferSize);
-
+    return new FixedSizeSegmentSplitter(readBufferSize).split(shuffleIndexResult);
   }
 
   public static ShuffleDataResult readShuffleData(
@@ -175,7 +174,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
     if (shuffleIndexResult == null) {
       return new ShuffleDataResult();
     }
-    List<ShuffleDataSegment> sds = RssUtils.transIndexDataToSegments(shuffleIndexResult, readBufferSize);
+    List<ShuffleDataSegment> sds = new FixedSizeSegmentSplitter(readBufferSize).split(shuffleIndexResult);
 
     if (segmentIndex >= sds.size()) {
       return new ShuffleDataResult();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
@@ -54,6 +54,7 @@ import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.util.Constants;
@@ -112,7 +113,10 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
         new ShuffleServerInfo("127.0.0.1-20001", "127.0.0.1", 20001),
         "clearResourceTest1",
         0,
-        Lists.newArrayList(new PartitionRange(0, 1)), new RemoteStorageInfo(""));
+        Lists.newArrayList(new PartitionRange(0, 1)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
 
     shuffleWriteClient.sendAppHeartbeat("clearResourceTest1", 1000L);
     shuffleWriteClient.sendAppHeartbeat("clearResourceTest2", 1000L);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHdfsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHdfsTest.java
@@ -46,6 +46,7 @@ import org.apache.uniffle.common.KerberizedHdfsBase;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
 import org.apache.uniffle.server.ShuffleServer;
@@ -178,7 +179,8 @@ public class ShuffleServerWithKerberizedHdfsTest extends KerberizedHdfsBase {
         0,
         Lists.newArrayList(new PartitionRange(0, 1)),
         remoteStorageInfo,
-        user
+        user,
+        ShuffleDataDistributionType.NORMAL
     );
     shuffleServerClient.registerShuffle(rrsr);
 
@@ -187,7 +189,8 @@ public class ShuffleServerWithKerberizedHdfsTest extends KerberizedHdfsBase {
         0,
         Lists.newArrayList(new PartitionRange(2, 3)),
         remoteStorageInfo,
-        user
+        user,
+        ShuffleDataDistributionType.NORMAL
     );
     shuffleServerClient.registerShuffle(rrsr);
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.request.RssFinishShuffleRequest;
+import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
+import org.apache.uniffle.client.request.RssSendCommitRequest;
+import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.segment.LocalOrderSegmentSplitter;
+import org.apache.uniffle.common.util.ChecksumUtils;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.storage.util.StorageType;
+
+import static org.apache.uniffle.common.ShuffleDataDistributionType.LOCAL_ORDER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This class is to test the local_order shuffle-data distribution
+ */
+public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase {
+
+  private ShuffleServerGrpcClient shuffleServerClient;
+
+  @BeforeAll
+  public static void setupServers() throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    File tmpDir = Files.createTempDir();
+    File dataDir1 = new File(tmpDir, "data1");
+    File dataDir2 = new File(tmpDir, "data2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
+    shuffleServerConf.setString("rss.storage.basePath", basePath);
+    shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
+  @BeforeEach
+  public void createClient() {
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  }
+
+  @AfterEach
+  public void closeClient() {
+    shuffleServerClient.close();
+  }
+
+  public static Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> createTestDataWithMultiMapIdx(
+      Roaring64NavigableMap[] bitmaps,
+      Map<Long, byte[]> expectedData) {
+    for (int i = 0; i < 4; i++) {
+      bitmaps[i] = Roaring64NavigableMap.bitmapOf();
+    }
+
+    // key: mapIdx
+    Map<Integer, List<ShuffleBlockInfo>> p0 = new HashMap<>();
+    List<ShuffleBlockInfo> blocks1 = createShuffleBlockList(
+        0, 0, 0, 3, 25, bitmaps[0], expectedData, mockSSI);
+    List<ShuffleBlockInfo> blocks2 = createShuffleBlockList(
+        0, 0, 1, 3, 25, bitmaps[0], expectedData, mockSSI);
+    List<ShuffleBlockInfo> blocks3 = createShuffleBlockList(
+        0, 0, 2, 3, 25, bitmaps[0], expectedData, mockSSI);
+    p0.put(0, blocks1);
+    p0.put(1, blocks2);
+    p0.put(2, blocks3);
+
+    List<ShuffleBlockInfo> blocks4 = createShuffleBlockList(
+        0, 1, 1, 5, 25, bitmaps[1], expectedData, mockSSI);
+    Map<Integer, List<ShuffleBlockInfo>> p1 = new HashMap<>();
+    p1.put(1, blocks4);
+
+    List<ShuffleBlockInfo> blocks5 = createShuffleBlockList(
+        0, 2, 2, 4, 25, bitmaps[2], expectedData, mockSSI);
+    Map<Integer, List<ShuffleBlockInfo>> p2 = new HashMap<>();
+    p2.put(2, blocks5);
+
+    List<ShuffleBlockInfo> blocks6 = createShuffleBlockList(
+        0, 3, 3, 1, 25, bitmaps[3], expectedData, mockSSI);
+    Map<Integer, List<ShuffleBlockInfo>> p3 = new HashMap<>();
+    p1.put(3, blocks6);
+
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(0, p0);
+    partitionToBlocks.put(1, p1);
+    partitionToBlocks.put(2, p2);
+    partitionToBlocks.put(3, p3);
+    return partitionToBlocks;
+  }
+
+  @Test
+  public void testWriteAndReadWithSpecifiedMapRange() throws Exception {
+    String testAppId = "testWriteAndReadWithSpecifiedMapRange";
+
+    for (int i = 0; i < 4; i++) {
+      RssRegisterShuffleRequest rrsr = new RssRegisterShuffleRequest(testAppId, 0,
+          Lists.newArrayList(new PartitionRange(i, i)), new RemoteStorageInfo(""), "", LOCAL_ORDER);
+      shuffleServerClient.registerShuffle(rrsr);
+    }
+
+    /**
+     * Write the data to shuffle-servers
+     */
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap[] bitMaps = new Roaring64NavigableMap[4];
+
+    // Create the shuffle block with the mapIdx
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> partitionToBlocksWithMapIdx =
+        createTestDataWithMultiMapIdx(bitMaps, expectedData);
+
+    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = partitionToBlocksWithMapIdx.entrySet()
+        .stream()
+        .map(x ->
+            Pair.of(x.getKey(), x.getValue().values().stream().flatMap(a -> a.stream()).collect(Collectors.toList()))
+        )
+        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(0, partitionToBlocks);
+
+    RssSendShuffleDataRequest rssdr = new RssSendShuffleDataRequest(
+        testAppId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rssdr);
+
+    // Flush the data to file
+    RssSendCommitRequest rscr = new RssSendCommitRequest(testAppId, 0);
+    shuffleServerClient.sendCommit(rscr);
+    RssFinishShuffleRequest rfsr = new RssFinishShuffleRequest(testAppId, 0);
+    shuffleServerClient.finishShuffle(rfsr);
+
+    /**
+     * Read the single partition data by specified [startMapIdx, endMapIdx)
+     */
+    // case1: get the mapIdx range [0, 1) of partition0
+    final Set<Long> expectedBlockIds1 = partitionToBlocksWithMapIdx.get(0).get(0).stream()
+        .map(x -> x.getBlockId())
+        .collect(Collectors.toSet());
+    final Map<Long, byte[]> expectedData1 = expectedData.entrySet().stream()
+        .filter(x -> expectedBlockIds1.contains(x.getKey()))
+        .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+
+    ShuffleDataResult sdr  = readShuffleData(
+        shuffleServerClient,
+        testAppId,
+        0,
+        0,
+        1,
+        10,
+        1000,
+        0,
+        new LocalOrderSegmentSplitter(0, 1, 1000)
+    );
+    validate(
+        sdr,
+        expectedBlockIds1,
+        expectedData1,
+        new HashSet<>(Arrays.asList(0L))
+    );
+
+    // case2: get the mapIdx range [0, 2) of partition0
+    final Set<Long> expectedBlockIds2 = partitionToBlocksWithMapIdx.get(0).get(1).stream()
+        .map(x -> x.getBlockId())
+        .collect(Collectors.toSet());
+    expectedBlockIds2.addAll(expectedBlockIds1);
+    final Map<Long, byte[]> expectedData2 = expectedData.entrySet().stream()
+        .filter(x -> expectedBlockIds2.contains(x.getKey()))
+        .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+    sdr  = readShuffleData(
+        shuffleServerClient,
+        testAppId,
+        0,
+        0,
+        1,
+        10,
+        1000,
+        0,
+        new LocalOrderSegmentSplitter(0, 2, 1000)
+    );
+    validate(
+        sdr,
+        expectedBlockIds2,
+        expectedData2,
+        new HashSet<>(Arrays.asList(0L, 1L))
+    );
+
+    // case2: get the mapIdx range [1, 3) of partition0
+    final Set<Long> expectedBlockIds3 = partitionToBlocksWithMapIdx.get(0).get(1).stream()
+        .map(x -> x.getBlockId())
+        .collect(Collectors.toSet());
+    expectedBlockIds3.addAll(
+        partitionToBlocksWithMapIdx.get(0).get(2).stream()
+            .map(x -> x.getBlockId())
+            .collect(Collectors.toSet())
+    );
+    expectedBlockIds2.addAll(expectedBlockIds1);
+    final Map<Long, byte[]> expectedData3 = expectedData.entrySet().stream()
+        .filter(x -> expectedBlockIds3.contains(x.getKey()))
+        .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+    sdr  = readShuffleData(
+        shuffleServerClient,
+        testAppId,
+        0,
+        0,
+        1,
+        10,
+        1000,
+        0,
+        new LocalOrderSegmentSplitter(1, 3, 1000)
+    );
+    validate(
+        sdr,
+        expectedBlockIds3,
+        expectedData3,
+        new HashSet<>(Arrays.asList(1L, 2L))
+    );
+
+    // case3: get the mapIdx range [0, Integer.MAX_VALUE) of partition0, it should always return all data
+    final Set<Long> expectedBlockIds4 = partitionToBlocks.get(0).stream()
+        .map(x -> x.getBlockId())
+        .collect(Collectors.toSet());
+    final Map<Long, byte[]> expectedData4 = expectedData.entrySet().stream()
+        .filter(x -> expectedBlockIds4.contains(x.getKey()))
+        .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+    sdr  = readShuffleData(
+        shuffleServerClient,
+        testAppId,
+        0,
+        0,
+        1,
+        10,
+        10000,
+        0,
+        new LocalOrderSegmentSplitter(0, Integer.MAX_VALUE, 100000)
+    );
+    validate(
+        sdr,
+        expectedBlockIds4,
+        expectedData4,
+        new HashSet<>(Arrays.asList(0L, 1L, 2L))
+    );
+  }
+
+  private void validate(ShuffleDataResult sdr, Set<Long> expectedBlockIds,
+      Map<Long, byte[]> expectedData, Set<Long> expectedTaskAttemptIds) {
+    byte[] buffer = sdr.getData();
+    List<BufferSegment> bufferSegments = sdr.getBufferSegments();
+    int matched = 0;
+    for (BufferSegment bs : bufferSegments) {
+      if (expectedBlockIds.contains(bs.getBlockId())) {
+        byte[] data = new byte[bs.getLength()];
+        System.arraycopy(buffer, bs.getOffset(), data, 0, bs.getLength());
+        assertEquals(bs.getCrc(), ChecksumUtils.getCrc32(data));
+        assertTrue(Arrays.equals(data, expectedData.get(bs.getBlockId())));
+        assertTrue(expectedBlockIds.contains(bs.getBlockId()));
+        assertTrue(expectedTaskAttemptIds.contains(bs.getTaskAttemptId()));
+        matched++;
+      } else {
+        fail();
+      }
+    }
+    assertEquals(expectedBlockIds.size(), matched);
+  }
+}

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
@@ -109,19 +109,19 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
     p0.put(1, blocks2);
     p0.put(2, blocks3);
 
-    List<ShuffleBlockInfo> blocks4 = createShuffleBlockList(
+    final List<ShuffleBlockInfo> blocks4 = createShuffleBlockList(
         0, 1, 1, 5, 25, bitmaps[1], expectedData, mockSSI);
-    Map<Integer, List<ShuffleBlockInfo>> p1 = new HashMap<>();
+    final Map<Integer, List<ShuffleBlockInfo>> p1 = new HashMap<>();
     p1.put(1, blocks4);
 
-    List<ShuffleBlockInfo> blocks5 = createShuffleBlockList(
+    final List<ShuffleBlockInfo> blocks5 = createShuffleBlockList(
         0, 2, 2, 4, 25, bitmaps[2], expectedData, mockSSI);
-    Map<Integer, List<ShuffleBlockInfo>> p2 = new HashMap<>();
+    final Map<Integer, List<ShuffleBlockInfo>> p2 = new HashMap<>();
     p2.put(2, blocks5);
 
-    List<ShuffleBlockInfo> blocks6 = createShuffleBlockList(
+    final List<ShuffleBlockInfo> blocks6 = createShuffleBlockList(
         0, 3, 3, 1, 25, bitmaps[3], expectedData, mockSSI);
-    Map<Integer, List<ShuffleBlockInfo>> p3 = new HashMap<>();
+    final Map<Integer, List<ShuffleBlockInfo>> p3 = new HashMap<>();
     p1.put(3, blocks6);
 
     Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> partitionToBlocks = Maps.newHashMap();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -58,7 +58,7 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
   private ShuffleServerGrpcClient shuffleServerClient;
 
   @BeforeAll
-  public static void setupServers() throws Exception {
+  private static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -42,6 +42,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -104,8 +105,14 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   @Test
   public void rpcFailTest() throws Exception {
     String testAppId = "rpcFailTest";
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo1,
-        testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), new RemoteStorageInfo(""));
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo1,
+        testAppId,
+        0,
+        Lists.newArrayList(new PartitionRange(0, 0)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
 
@@ -149,11 +156,23 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   public void reportMultipleServerTest() throws Exception {
     String testAppId = "reportMultipleServerTest";
 
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo1,
-        testAppId, 1, Lists.newArrayList(new PartitionRange(1, 1)), new RemoteStorageInfo(""));
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo1,
+        testAppId,
+        1,
+        Lists.newArrayList(new PartitionRange(1, 1)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
 
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo2,
-        testAppId, 1, Lists.newArrayList(new PartitionRange(2, 2)), new RemoteStorageInfo(""));
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo2,
+        testAppId,
+        1,
+        Lists.newArrayList(new PartitionRange(2, 2)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
 
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = Maps.newHashMap();
     partitionToServers.putIfAbsent(1, Lists.newArrayList(shuffleServerInfo1));
@@ -212,10 +231,22 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   @Test
   public void writeReadTest() throws Exception {
     String testAppId = "writeReadTest";
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo1,
-        testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), new RemoteStorageInfo(""));
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo2,
-        testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), new RemoteStorageInfo(""));
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo1,
+        testAppId,
+        0,
+        Lists.newArrayList(new PartitionRange(0, 0)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo2,
+        testAppId,
+        0,
+        Lists.newArrayList(new PartitionRange(0, 0)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
@@ -263,8 +294,14 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   @Test
   public void emptyTaskTest() {
     String testAppId = "emptyTaskTest";
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo1,
-        testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), new RemoteStorageInfo(""));
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo1,
+        testAppId,
+        0,
+        Lists.newArrayList(new PartitionRange(0, 0)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
     boolean commitResult = shuffleWriteClientImpl
         .sendCommit(Sets.newHashSet(shuffleServerInfo1), testAppId, 0, 2);
     assertTrue(commitResult);
@@ -306,7 +343,13 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
           });
         }
         shuffleWriteClientImpl.registerShuffle(
-            entry.getKey(), appId, 0, entry.getValue(), remoteStorage);
+            entry.getKey(),
+            appId,
+            0,
+            entry.getValue(),
+            remoteStorage,
+            ShuffleDataDistributionType.NORMAL
+        );
       });
       return shuffleAssignments;
     }, heartbeatTimeout, maxTryTime);

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AQESkewedJoinTest extends SparkIntegrationTestBase {
 
   @BeforeAll
-  public static void setupServers() throws Exception {
+  private static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();
     dynamicConf.put(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinWithLocalOrderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinWithLocalOrderTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.uniffle.test;
 
-import java.util.Map;
-
-import com.google.common.collect.Maps;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,21 +32,17 @@ public class AQESkewedJoinWithLocalOrderTest extends AQESkewedJoinTest {
   @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
-    Map<String, String> dynamicConf = Maps.newHashMap();
-    // Use the HDFS storage type to ensure the data will be flushed by local_order mechanism
-    dynamicConf.put(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");
-    dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.HDFS.name());
-    addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    // Use the LOCALFILE storage type to ensure the data will be flushed by local_order mechanism
+    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     createShuffleServer(shuffleServerConf);
     startServers();
   }
 
   @Override
   public void updateSparkConfCustomer(SparkConf sparkConf) {
-    sparkConf.set(RssSparkConfig.RSS_STORAGE_TYPE.key(), "HDFS");
-    sparkConf.set(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");
+    sparkConf.set(RssSparkConfig.RSS_STORAGE_TYPE.key(), "LOCALFILE");
     sparkConf.set("spark." + RssClientConf.DATA_DISTRIBUTION_TYPE.key(),
         ShuffleDataDistributionType.LOCAL_ORDER.name());
   }

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinWithLocalOrderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinWithLocalOrderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssSparkConfig;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.apache.uniffle.common.ShuffleDataDistributionType;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.storage.util.StorageType;
+
+public class AQESkewedJoinWithLocalOrderTest extends AQESkewedJoinTest {
+
+  @BeforeAll
+  public static void setupServers() throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    Map<String, String> dynamicConf = Maps.newHashMap();
+    // Use the HDFS storage type to ensure the data will be flushed by local_order mechanism
+    dynamicConf.put(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");
+    dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.HDFS.name());
+    addDynamicConf(coordinatorConf, dynamicConf);
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
+  @Override
+  public void updateSparkConfCustomer(SparkConf sparkConf) {
+    sparkConf.set(RssSparkConfig.RSS_STORAGE_TYPE.key(), "HDFS");
+    sparkConf.set(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");
+    sparkConf.set("spark." + RssClientConf.DATA_DISTRIBUTION_TYPE.key(),
+        ShuffleDataDistributionType.LOCAL_ORDER.name());
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -132,7 +132,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
-      String user, ShuffleDataDistributionType dataDistributionType) {
+      String user,
+      ShuffleDataDistributionType dataDistributionType) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -57,6 +57,7 @@ import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.exception.NotRetryException;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -131,12 +132,13 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
-      String user) {
+      String user, ShuffleDataDistributionType dataDistributionType) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)
         .setShuffleId(shuffleId)
         .setUser(user)
+        .setShuffleDataDistribution(RssProtos.DataDistribution.valueOf(dataDistributionType.name()))
         .addAllPartitionRanges(toShufflePartitionRanges(partitionRanges));
     RemoteStorage.Builder rsBuilder = RemoteStorage.newBuilder();
     rsBuilder.setPath(remoteStorageInfo.getPath());
@@ -245,7 +247,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         request.getShuffleId(),
         request.getPartitionRanges(),
         request.getRemoteStorageInfo(),
-        request.getUser()
+        request.getUser(),
+        request.getDataDistributionType()
     );
 
     RssRegisterShuffleResponse response;

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 
 public class RssRegisterShuffleRequest {
 
@@ -31,18 +32,21 @@ public class RssRegisterShuffleRequest {
   private List<PartitionRange> partitionRanges;
   private RemoteStorageInfo remoteStorageInfo;
   private String user;
+  private ShuffleDataDistributionType dataDistributionType;
 
   public RssRegisterShuffleRequest(
       String appId,
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
-      String user) {
+      String user,
+      ShuffleDataDistributionType dataDistributionType) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionRanges = partitionRanges;
     this.remoteStorageInfo = remoteStorageInfo;
     this.user = user;
+    this.dataDistributionType = dataDistributionType;
   }
 
   public RssRegisterShuffleRequest(
@@ -50,7 +54,13 @@ public class RssRegisterShuffleRequest {
       int shuffleId,
       List<PartitionRange> partitionRanges,
       String remoteStoragePath) {
-    this(appId, shuffleId, partitionRanges, new RemoteStorageInfo(remoteStoragePath), StringUtils.EMPTY);
+    this(appId,
+        shuffleId,
+        partitionRanges,
+        new RemoteStorageInfo(remoteStoragePath),
+        StringUtils.EMPTY,
+        ShuffleDataDistributionType.NORMAL
+    );
   }
 
   public String getAppId() {
@@ -71,5 +81,9 @@ public class RssRegisterShuffleRequest {
 
   public String getUser() {
     return user;
+  }
+
+  public ShuffleDataDistributionType getDataDistributionType() {
+    return dataDistributionType;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -167,6 +167,12 @@ message ShuffleRegisterRequest {
   repeated ShufflePartitionRange partitionRanges = 3;
   RemoteStorage remoteStorage = 4;
   string user = 5;
+  DataDistribution shuffleDataDistribution = 6;
+}
+
+enum DataDistribution {
+  NORMAL = 0;
+  LOCAL_ORDER = 1;
 }
 
 message ShuffleUnregisterRequest {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -359,4 +359,8 @@ public class ShuffleFlushManager {
       return createTimeStamp;
     }
   }
+
+  public ShuffleServer getShuffleServer() {
+    return shuffleServer;
+  }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -36,6 +36,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.util.ThreadUtils;
@@ -360,7 +361,7 @@ public class ShuffleFlushManager {
     }
   }
 
-  public ShuffleServer getShuffleServer() {
-    return shuffleServer;
+  public ShuffleDataDistributionType getDataDistributionType(String appId) {
+    return shuffleServer.getShuffleTaskManager().getDataDistributionType(appId);
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.server;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
@@ -138,8 +139,14 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     int shuffleId = req.getShuffleId();
     String remoteStoragePath = req.getRemoteStorage().getPath();
     String user = req.getUser();
+
     ShuffleDataDistributionType shuffleDataDistributionType =
-        ShuffleDataDistributionType.valueOf(req.getShuffleDataDistribution().name());
+            ShuffleDataDistributionType.valueOf(
+                Optional
+                    .ofNullable(req.getShuffleDataDistribution())
+                    .orElse(RssProtos.DataDistribution.NORMAL)
+                    .name()
+            );
 
     Map<String, String> remoteStorageConf = req
         .getRemoteStorage()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
@@ -137,6 +138,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     int shuffleId = req.getShuffleId();
     String remoteStoragePath = req.getRemoteStorage().getPath();
     String user = req.getUser();
+    ShuffleDataDistributionType shuffleDataDistributionType =
+        ShuffleDataDistributionType.valueOf(req.getShuffleDataDistribution().name());
 
     Map<String, String> remoteStorageConf = req
         .getRemoteStorage()
@@ -156,7 +159,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
             shuffleId,
             partitionRanges,
             new RemoteStorageInfo(remoteStoragePath, remoteStorageConf),
-            user
+            user,
+            shuffleDataDistributionType
         );
 
     reply = ShuffleRegisterResponse

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.google.common.collect.Maps;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
+
 /**
  * ShuffleTaskInfo contains the information of submitting the shuffle,
  * the information of the cache block, user and timestamp corresponding to the app
@@ -42,12 +44,15 @@ public class ShuffleTaskInfo {
   private Map<Integer, Roaring64NavigableMap> cachedBlockIds;
   private AtomicReference<String> user;
 
+  private AtomicReference<ShuffleDataDistributionType> dataDistType;
+
   public ShuffleTaskInfo() {
     this.currentTimes = System.currentTimeMillis();
     this.commitCounts = Maps.newConcurrentMap();
     this.commitLocks = Maps.newConcurrentMap();
     this.cachedBlockIds = Maps.newConcurrentMap();
     this.user = new AtomicReference<>();
+    this.dataDistType = new AtomicReference<>();
   }
 
   public Long getCurrentTimes() {
@@ -76,5 +81,14 @@ public class ShuffleTaskInfo {
 
   public void setUser(String user) {
     this.user.set(user);
+  }
+
+  public void setDataDistType(
+      ShuffleDataDistributionType dataDistType) {
+    this.dataDistType.set(dataDistType);
+  }
+
+  public ShuffleDataDistributionType getDataDistType() {
+    return dataDistType.get();
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
@@ -134,14 +135,36 @@ public class ShuffleTaskManager {
     thread.start();
   }
 
+  /**
+   * Only for test
+   */
+  @VisibleForTesting
   public StatusCode registerShuffle(
       String appId,
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
       String user) {
+    return registerShuffle(
+        appId,
+        shuffleId,
+        partitionRanges,
+        remoteStorageInfo,
+        user,
+        ShuffleDataDistributionType.NORMAL
+    );
+  }
+
+  public StatusCode registerShuffle(
+      String appId,
+      int shuffleId,
+      List<PartitionRange> partitionRanges,
+      RemoteStorageInfo remoteStorageInfo,
+      String user,
+      ShuffleDataDistributionType dataDistType) {
     refreshAppId(appId);
     shuffleTaskInfos.get(appId).setUser(user);
+    shuffleTaskInfos.get(appId).setDataDistType(dataDistType);
     partitionsToBlockIds.putIfAbsent(appId, Maps.newConcurrentMap());
     for (PartitionRange partitionRange : partitionRanges) {
       shuffleBufferManager.registerBuffer(appId, shuffleId, partitionRange.getStart(), partitionRange.getEnd());
@@ -501,5 +524,9 @@ public class ShuffleTaskManager {
   @VisibleForTesting
   void removeShuffleDataSync(String appId, int shuffleId) {
     removeResourcesByShuffleIds(appId, Arrays.asList(shuffleId));
+  }
+
+  public ShuffleDataDistributionType getDataDistributionType(String appId) {
+    return shuffleTaskInfos.get(appId).getDataDistType();
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.server.buffer;
 
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
@@ -75,19 +75,16 @@ public class ShuffleBuffer {
       int shuffleId,
       int startPartition,
       int endPartition,
-      Supplier<Boolean> isValid) {
+      Supplier<Boolean> isValid,
+      ShuffleDataDistributionType dataDistributionType) {
     if (blocks.isEmpty()) {
       return null;
     }
     // buffer will be cleared, and new list must be created for async flush
     List<ShufflePartitionedBlock> spBlocks = new LinkedList<>(blocks);
-    // todo: For specific AQE jobs
-    spBlocks.sort(new Comparator<ShufflePartitionedBlock>() {
-      @Override
-      public int compare(ShufflePartitionedBlock o1, ShufflePartitionedBlock o2) {
-        return o1.getTaskAttemptId() - o2.getTaskAttemptId() > 0 ? 1 : -1;
-      }
-    });
+    if (dataDistributionType == ShuffleDataDistributionType.LOCAL_ORDER) {
+      spBlocks.sort((o1, o2) -> o1.getTaskAttemptId() - o2.getTaskAttemptId() > 0 ? 1 : -1);
+    }
     long eventId = ShuffleFlushManager.ATOMIC_EVENT_ID.getAndIncrement();
     final ShuffleDataFlushEvent event = new ShuffleDataFlushEvent(
         eventId,
@@ -103,6 +100,18 @@ public class ShuffleBuffer {
     blocks.clear();
     size = 0;
     return event;
+  }
+
+  /**
+   * Only for test
+   */
+  public synchronized ShuffleDataFlushEvent toFlushEvent(
+      String appId,
+      int shuffleId,
+      int startPartition,
+      int endPartition,
+      Supplier<Boolean> isValid) {
+    return toFlushEvent(appId, shuffleId, startPartition, endPartition, isValid, ShuffleDataDistributionType.NORMAL);
   }
 
   public List<ShufflePartitionedBlock> getBlocks() {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.server.buffer;
 
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,13 @@ public class ShuffleBuffer {
     }
     // buffer will be cleared, and new list must be created for async flush
     List<ShufflePartitionedBlock> spBlocks = new LinkedList<>(blocks);
+    // todo: For specific AQE jobs
+    spBlocks.sort(new Comparator<ShufflePartitionedBlock>() {
+      @Override
+      public int compare(ShufflePartitionedBlock o1, ShufflePartitionedBlock o2) {
+        return o1.getTaskAttemptId() - o2.getTaskAttemptId() > 0 ? 1 : -1;
+      }
+    });
     long eventId = ShuffleFlushManager.ATOMIC_EVENT_ID.getAndIncrement();
     final ShuffleDataFlushEvent event = new ShuffleDataFlushEvent(
         eventId,

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -195,8 +195,14 @@ public class ShuffleBufferManager {
   protected void flushBuffer(ShuffleBuffer buffer, String appId,
       int shuffleId, int startPartition, int endPartition) {
     ShuffleDataFlushEvent event =
-        buffer.toFlushEvent(appId, shuffleId, startPartition, endPartition,
-            () -> bufferPool.containsKey(appId));
+        buffer.toFlushEvent(
+            appId,
+            shuffleId,
+            startPartition,
+            endPartition,
+            () -> bufferPool.containsKey(appId),
+            shuffleFlushManager.getShuffleServer().getShuffleTaskManager().getDataDistributionType(appId)
+        );
     if (event != null) {
       updateShuffleSize(appId, shuffleId, -event.getSize());
       inFlushSize.addAndGet(event.getSize());

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -201,7 +201,7 @@ public class ShuffleBufferManager {
             startPartition,
             endPartition,
             () -> bufferPool.containsKey(appId),
-            shuffleFlushManager.getShuffleServer().getShuffleTaskManager().getDataDistributionType(appId)
+            shuffleFlushManager.getDataDistributionType(appId)
         );
     if (event != null) {
       updateShuffleSize(appId, shuffleId, -event.getSize());

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -82,8 +82,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     conf.set(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 10000L);
     conf.set(ShuffleServerConf.HEALTH_CHECK_ENABLE, false);
     ShuffleServer shuffleServer = new ShuffleServer(conf);
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf,
-        shuffleServer.getShuffleFlushManager(), shuffleServer.getShuffleBufferManager(), null);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
 
     String appId = "registerTest1";
     int shuffleId = 1;
@@ -141,8 +140,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     StorageManager storageManager = shuffleServer.getStorageManager();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(
-        conf, shuffleFlushManager, shuffleBufferManager, storageManager);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
     shuffleTaskManager.registerShuffle(
         appId,
         shuffleId,
@@ -280,10 +278,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     ShuffleServer shuffleServer = new ShuffleServer(conf);
 
     ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
-    ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
-    StorageManager storageManager = shuffleServer.getStorageManager();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(
-        conf, shuffleFlushManager, shuffleBufferManager, storageManager);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
 
     String appId = "removeShuffleDataTest1";
     for (int i = 0; i < 4; i++) {
@@ -351,12 +346,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
         path1.toAbsolutePath().toString() + "," + path2.toAbsolutePath().toString());
 
     ShuffleServer shuffleServer = new ShuffleServer(conf);
-
-    ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
-    ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
-    StorageManager storageManager = shuffleServer.getStorageManager();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(
-        conf, shuffleFlushManager, shuffleBufferManager, storageManager);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
 
     String appId = "removeShuffleDataWithLocalfileTest";
 
@@ -411,11 +401,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     conf.set(ShuffleServerConf.HEALTH_CHECK_ENABLE, false);
 
     ShuffleServer shuffleServer = new ShuffleServer(conf);
-    ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
-    ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
-    StorageManager storageManager = shuffleServer.getStorageManager();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf, shuffleFlushManager,
-        shuffleBufferManager, storageManager);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
     shuffleTaskManager.registerShuffle(
         "clearTest1",
         shuffleId,

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -137,7 +137,6 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     conf.set(ShuffleServerConf.SERVER_PRE_ALLOCATION_EXPIRED, 3000L);
     conf.set(ShuffleServerConf.HEALTH_CHECK_ENABLE, false);
     ShuffleServer shuffleServer = new ShuffleServer(conf);
-    ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
     shuffleTaskManager.registerShuffle(
         appId,
@@ -180,6 +179,8 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     assertEquals(1, bufferIds.size());
     assertEquals(StatusCode.SUCCESS, sc);
     shuffleTaskManager.commitShuffle(appId, shuffleId);
+    
+    ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     assertEquals(1, shuffleFlushManager.getCommittedBlockIds(appId, shuffleId).getLongCardinality());
 
     // flush for partition 1-1

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -179,7 +179,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     assertEquals(1, bufferIds.size());
     assertEquals(StatusCode.SUCCESS, sc);
     shuffleTaskManager.commitShuffle(appId, shuffleId);
-    
+
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     assertEquals(1, shuffleFlushManager.getCommittedBlockIds(appId, shuffleId).getLongCardinality());
 

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -137,9 +137,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     conf.set(ShuffleServerConf.SERVER_PRE_ALLOCATION_EXPIRED, 3000L);
     conf.set(ShuffleServerConf.HEALTH_CHECK_ENABLE, false);
     ShuffleServer shuffleServer = new ShuffleServer(conf);
-    ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
-    StorageManager storageManager = shuffleServer.getStorageManager();
     ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
     shuffleTaskManager.registerShuffle(
         appId,
@@ -277,7 +275,6 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
 
     ShuffleServer shuffleServer = new ShuffleServer(conf);
 
-    ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
     ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
 
     String appId = "removeShuffleDataTest1";
@@ -307,6 +304,7 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
 
     assertEquals(1, shuffleTaskManager.getAppIds().size());
 
+    ShuffleBufferManager shuffleBufferManager = shuffleServer.getShuffleBufferManager();
     RangeMap<Integer, ShuffleBuffer> rangeMap = shuffleBufferManager.getBufferPool().get(appId).get(0);
     assertFalse(rangeMap.asMapOfRanges().isEmpty());
     shuffleTaskManager.commitShuffle(appId, 0);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -54,6 +54,8 @@ import static org.mockito.Mockito.when;
 public class ShuffleBufferManagerTest extends BufferTestBase {
   private ShuffleBufferManager shuffleBufferManager;
   private ShuffleFlushManager mockShuffleFlushManager;
+  private ShuffleServer mockShuffleServer;
+  private ShuffleTaskManager mockShuffleTaskManager;
   private ShuffleServerConf conf;
 
   @BeforeEach
@@ -68,6 +70,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     conf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 80.0);
     conf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
     mockShuffleFlushManager = mock(ShuffleFlushManager.class);
+    mockShuffleServer = mock(ShuffleServer.class);
+    mockShuffleTaskManager = mock(ShuffleTaskManager.class);
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+    when(mockShuffleFlushManager.getShuffleServer()).thenReturn(mockShuffleServer);
     shuffleBufferManager = new ShuffleBufferManager(conf, mockShuffleFlushManager);
   }
 

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -73,7 +73,6 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     mockShuffleServer = mock(ShuffleServer.class);
     mockShuffleTaskManager = mock(ShuffleTaskManager.class);
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
-    when(mockShuffleFlushManager.getShuffleServer()).thenReturn(mockShuffleServer);
     shuffleBufferManager = new ShuffleBufferManager(conf, mockShuffleFlushManager);
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
@@ -122,7 +122,7 @@ public class ShuffleHandlerFactory {
         request.getAppId(), request.getShuffleId(), request.getPartitionId(),
         request.getIndexReadLimit(), request.getPartitionNumPerRange(), request.getPartitionNum(),
         request.getReadBufferSize(), request.getExpectBlockIds(), request.getProcessBlockIds(),
-        shuffleServerClients, request.getDistributionType(), request.getStartMapIndex(), request.getEndMapIndex()
+        shuffleServerClients, request.getDistributionType(), request.getExpectTaskIds()
     );
   }
 
@@ -140,8 +140,7 @@ public class ShuffleHandlerFactory {
         request.getStorageBasePath(),
         request.getHadoopConf(),
         request.getDistributionType(),
-        request.getStartMapIndex(),
-        request.getEndMapIndex()
+        request.getExpectTaskIds()
     );
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
@@ -118,10 +118,12 @@ public class ShuffleHandlerFactory {
     List<ShuffleServerClient> shuffleServerClients = shuffleServerInfoList.stream().map(
         ssi -> ShuffleServerClientFactory.getInstance().getShuffleServerClient(ClientType.GRPC.name(), ssi)).collect(
         Collectors.toList());
-    return new LocalFileQuorumClientReadHandler(request.getAppId(), request.getShuffleId(), request.getPartitionId(),
+    return new LocalFileQuorumClientReadHandler(
+        request.getAppId(), request.getShuffleId(), request.getPartitionId(),
         request.getIndexReadLimit(), request.getPartitionNumPerRange(), request.getPartitionNum(),
         request.getReadBufferSize(), request.getExpectBlockIds(), request.getProcessBlockIds(),
-        shuffleServerClients);
+        shuffleServerClients, request.getDistributionType(), request.getStartMapIndex(), request.getEndMapIndex()
+    );
   }
 
   private ClientReadHandler getHdfsClientReadHandler(CreateShuffleReadHandlerRequest request) {
@@ -136,7 +138,11 @@ public class ShuffleHandlerFactory {
         request.getExpectBlockIds(),
         request.getProcessBlockIds(),
         request.getStorageBasePath(),
-        request.getHadoopConf());
+        request.getHadoopConf(),
+        request.getDistributionType(),
+        request.getStartMapIndex(),
+        request.getEndMapIndex()
+    );
   }
 
   public ShuffleDeleteHandler createShuffleDeleteHandler(CreateShuffleDeleteHandlerRequest request) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
@@ -40,8 +40,7 @@ public abstract class DataSkippableReadHandler extends AbstractClientReadHandler
   protected Roaring64NavigableMap processBlockIds;
 
   protected ShuffleDataDistributionType distributionType;
-  protected int startMapIndex;
-  protected int endMapIndex;
+  protected Roaring64NavigableMap expectTaskIds;
 
   public DataSkippableReadHandler(
       String appId,
@@ -51,8 +50,7 @@ public abstract class DataSkippableReadHandler extends AbstractClientReadHandler
       Roaring64NavigableMap expectBlockIds,
       Roaring64NavigableMap processBlockIds,
       ShuffleDataDistributionType distributionType,
-      int startMapIndex,
-      int endMapIndex) {
+      Roaring64NavigableMap expectTaskIds) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
@@ -60,8 +58,7 @@ public abstract class DataSkippableReadHandler extends AbstractClientReadHandler
     this.expectBlockIds = expectBlockIds;
     this.processBlockIds = processBlockIds;
     this.distributionType = distributionType;
-    this.startMapIndex = startMapIndex;
-    this.endMapIndex = endMapIndex;
+    this.expectTaskIds = expectTaskIds;
   }
 
   protected abstract ShuffleIndexResult readShuffleIndex();
@@ -78,7 +75,7 @@ public abstract class DataSkippableReadHandler extends AbstractClientReadHandler
       shuffleDataSegments =
           SegmentSplitterFactory
               .getInstance()
-              .get(distributionType, startMapIndex, endMapIndex, readBufferSize)
+              .get(distributionType, expectTaskIds, readBufferSize)
               .split(shuffleIndexResult);
     }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.filesystem.HadoopFilesystemProvider;
 import org.apache.uniffle.common.util.Constants;
@@ -53,6 +54,42 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   private long readLength = 0L;
   private long readUncompressLength = 0L;
 
+  private ShuffleDataDistributionType distributionType;
+  private int startMapIndex;
+  private int endMapIndex;
+
+  public HdfsClientReadHandler(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int indexReadLimit,
+      int partitionNumPerRange,
+      int partitionNum,
+      int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
+      String storageBasePath,
+      Configuration hadoopConf,
+      ShuffleDataDistributionType distributionType,
+      int startMapIndex,
+      int endMapIndex) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+    this.partitionId = partitionId;
+    this.partitionNumPerRange = partitionNumPerRange;
+    this.partitionNum = partitionNum;
+    this.readBufferSize = readBufferSize;
+    this.expectBlockIds = expectBlockIds;
+    this.processBlockIds = processBlockIds;
+    this.storageBasePath = storageBasePath;
+    this.hadoopConf = hadoopConf;
+    this.readHandlerIndex = 0;
+    this.distributionType = distributionType;
+    this.startMapIndex = startMapIndex;
+    this.endMapIndex = endMapIndex;
+  }
+
+  // Only for test
   public HdfsClientReadHandler(
       String appId,
       int shuffleId,
@@ -65,17 +102,9 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
       Roaring64NavigableMap processBlockIds,
       String storageBasePath,
       Configuration hadoopConf) {
-    this.appId = appId;
-    this.shuffleId = shuffleId;
-    this.partitionId = partitionId;
-    this.partitionNumPerRange = partitionNumPerRange;
-    this.partitionNum = partitionNum;
-    this.readBufferSize = readBufferSize;
-    this.expectBlockIds = expectBlockIds;
-    this.processBlockIds = processBlockIds;
-    this.storageBasePath = storageBasePath;
-    this.hadoopConf = hadoopConf;
-    this.readHandlerIndex = 0;
+    this(appId, shuffleId, partitionId, indexReadLimit, partitionNumPerRange, partitionNum, readBufferSize,
+        expectBlockIds, processBlockIds, storageBasePath, hadoopConf, ShuffleDataDistributionType.NORMAL, 0,
+        Integer.MAX_VALUE);
   }
 
   protected void init(String fullShufflePath) {
@@ -107,7 +136,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
         try {
           HdfsShuffleReadHandler handler = new HdfsShuffleReadHandler(
               appId, shuffleId, partitionId, filePrefix,
-              readBufferSize, expectBlockIds, processBlockIds, hadoopConf);
+              readBufferSize, expectBlockIds, processBlockIds, hadoopConf,
+              distributionType, startMapIndex, endMapIndex);
           readHandlers.add(handler);
         } catch (Exception e) {
           LOG.warn("Can't create ShuffleReaderHandler for " + filePrefix, e);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -55,8 +55,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   private long readUncompressLength = 0L;
 
   private ShuffleDataDistributionType distributionType;
-  private int startMapIndex;
-  private int endMapIndex;
+  private Roaring64NavigableMap expectTaskIds;
 
   public HdfsClientReadHandler(
       String appId,
@@ -71,8 +70,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
       String storageBasePath,
       Configuration hadoopConf,
       ShuffleDataDistributionType distributionType,
-      int startMapIndex,
-      int endMapIndex) {
+      Roaring64NavigableMap expectTaskIds) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
@@ -85,8 +83,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
     this.hadoopConf = hadoopConf;
     this.readHandlerIndex = 0;
     this.distributionType = distributionType;
-    this.startMapIndex = startMapIndex;
-    this.endMapIndex = endMapIndex;
+    this.expectTaskIds = expectTaskIds;
   }
 
   // Only for test
@@ -103,8 +100,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
       String storageBasePath,
       Configuration hadoopConf) {
     this(appId, shuffleId, partitionId, indexReadLimit, partitionNumPerRange, partitionNum, readBufferSize,
-        expectBlockIds, processBlockIds, storageBasePath, hadoopConf, ShuffleDataDistributionType.NORMAL, 0,
-        Integer.MAX_VALUE);
+        expectBlockIds, processBlockIds, storageBasePath, hadoopConf, ShuffleDataDistributionType.NORMAL,
+        Roaring64NavigableMap.bitmapOf());
   }
 
   protected void init(String fullShufflePath) {
@@ -137,7 +134,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
           HdfsShuffleReadHandler handler = new HdfsShuffleReadHandler(
               appId, shuffleId, partitionId, filePrefix,
               readBufferSize, expectBlockIds, processBlockIds, hadoopConf,
-              distributionType, startMapIndex, endMapIndex);
+              distributionType, expectTaskIds);
           readHandlers.add(handler);
         } catch (Exception e) {
           LOG.warn("Can't create ShuffleReaderHandler for " + filePrefix, e);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
@@ -26,6 +26,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
@@ -51,11 +52,29 @@ public class HdfsShuffleReadHandler extends DataSkippableReadHandler {
       int readBufferSize,
       Roaring64NavigableMap expectBlockIds,
       Roaring64NavigableMap processBlockIds,
-      Configuration conf) throws Exception {
-    super(appId, shuffleId, partitionId, readBufferSize, expectBlockIds, processBlockIds);
+      Configuration conf,
+      ShuffleDataDistributionType distributionType,
+      int startMapIndex,
+      int endMapIndex) throws Exception {
+    super(appId, shuffleId, partitionId, readBufferSize, expectBlockIds, processBlockIds,
+        distributionType, startMapIndex, endMapIndex);
     this.filePrefix = filePrefix;
     this.indexReader = createHdfsReader(ShuffleStorageUtils.generateIndexFileName(filePrefix), conf);
     this.dataReader = createHdfsReader(ShuffleStorageUtils.generateDataFileName(filePrefix), conf);
+  }
+
+  // Only for test
+  public HdfsShuffleReadHandler(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      String filePrefix,
+      int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
+      Configuration conf) throws Exception {
+    this(appId, shuffleId, partitionId, filePrefix, readBufferSize, expectBlockIds,
+        processBlockIds, conf, ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE);
   }
 
   @Override

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
@@ -54,10 +54,9 @@ public class HdfsShuffleReadHandler extends DataSkippableReadHandler {
       Roaring64NavigableMap processBlockIds,
       Configuration conf,
       ShuffleDataDistributionType distributionType,
-      int startMapIndex,
-      int endMapIndex) throws Exception {
+      Roaring64NavigableMap expectTaskIds) throws Exception {
     super(appId, shuffleId, partitionId, readBufferSize, expectBlockIds, processBlockIds,
-        distributionType, startMapIndex, endMapIndex);
+        distributionType, expectTaskIds);
     this.filePrefix = filePrefix;
     this.indexReader = createHdfsReader(ShuffleStorageUtils.generateIndexFileName(filePrefix), conf);
     this.dataReader = createHdfsReader(ShuffleStorageUtils.generateDataFileName(filePrefix), conf);
@@ -74,7 +73,7 @@ public class HdfsShuffleReadHandler extends DataSkippableReadHandler {
       Roaring64NavigableMap processBlockIds,
       Configuration conf) throws Exception {
     this(appId, shuffleId, partitionId, filePrefix, readBufferSize, expectBlockIds,
-        processBlockIds, conf, ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE);
+        processBlockIds, conf, ShuffleDataDistributionType.NORMAL, Roaring64NavigableMap.bitmapOf());
   }
 
   @Override

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
@@ -25,6 +25,7 @@ import org.apache.uniffle.client.api.ShuffleServerClient;
 import org.apache.uniffle.client.request.RssGetShuffleDataRequest;
 import org.apache.uniffle.client.request.RssGetShuffleIndexRequest;
 import org.apache.uniffle.client.response.RssGetShuffleDataResponse;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
@@ -47,8 +48,14 @@ public class LocalFileClientReadHandler extends DataSkippableReadHandler {
       int readBufferSize,
       Roaring64NavigableMap expectBlockIds,
       Roaring64NavigableMap processBlockIds,
-      ShuffleServerClient shuffleServerClient) {
-    super(appId, shuffleId, partitionId, readBufferSize, expectBlockIds, processBlockIds);
+      ShuffleServerClient shuffleServerClient,
+      ShuffleDataDistributionType distributionType,
+      int startMapIndex,
+      int endMapIndex) {
+    super(
+        appId, shuffleId, partitionId, readBufferSize, expectBlockIds,
+        processBlockIds, distributionType, startMapIndex, endMapIndex
+    );
     this.shuffleServerClient = shuffleServerClient;
     this.partitionNumPerRange = partitionNumPerRange;
     this.partitionNum = partitionNum;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
@@ -50,11 +50,10 @@ public class LocalFileClientReadHandler extends DataSkippableReadHandler {
       Roaring64NavigableMap processBlockIds,
       ShuffleServerClient shuffleServerClient,
       ShuffleDataDistributionType distributionType,
-      int startMapIndex,
-      int endMapIndex) {
+      Roaring64NavigableMap expectTaskIds) {
     super(
         appId, shuffleId, partitionId, readBufferSize, expectBlockIds,
-        processBlockIds, distributionType, startMapIndex, endMapIndex
+        processBlockIds, distributionType, expectTaskIds
     );
     this.shuffleServerClient = shuffleServerClient;
     this.partitionNumPerRange = partitionNumPerRange;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileQuorumClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileQuorumClientReadHandler.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleServerClient;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.exception.RssException;
 
@@ -49,7 +50,10 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
       int readBufferSize,
       Roaring64NavigableMap expectBlockIds,
       Roaring64NavigableMap processBlockIds,
-      List<ShuffleServerClient> shuffleServerClients) {
+      List<ShuffleServerClient> shuffleServerClients,
+      ShuffleDataDistributionType distributionType,
+      int startMapIndex,
+      int endMapIndex) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
@@ -65,9 +69,33 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
           readBufferSize,
           expectBlockIds,
           processBlockIds,
-          client
+          client,
+          distributionType,
+          startMapIndex,
+          endMapIndex
       ));
     }
+  }
+
+  /**
+   * Only for test
+   */
+  public LocalFileQuorumClientReadHandler(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int indexReadLimit,
+      int partitionNumPerRange,
+      int partitionNum,
+      int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
+      List<ShuffleServerClient> shuffleServerClients) {
+    this(
+        appId, shuffleId, partitionId, indexReadLimit, partitionNumPerRange,
+        partitionNum, readBufferSize, expectBlockIds, processBlockIds,
+        shuffleServerClients, ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE
+    );
   }
 
   @Override

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileQuorumClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileQuorumClientReadHandler.java
@@ -52,8 +52,7 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
       Roaring64NavigableMap processBlockIds,
       List<ShuffleServerClient> shuffleServerClients,
       ShuffleDataDistributionType distributionType,
-      int startMapIndex,
-      int endMapIndex) {
+      Roaring64NavigableMap expectTaskIds) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
@@ -71,8 +70,7 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
           processBlockIds,
           client,
           distributionType,
-          startMapIndex,
-          endMapIndex
+          expectBlockIds
       ));
     }
   }
@@ -94,7 +92,7 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
     this(
         appId, shuffleId, partitionId, indexReadLimit, partitionNumPerRange,
         partitionNum, readBufferSize, expectBlockIds, processBlockIds,
-        shuffleServerClients, ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE
+        shuffleServerClients, ShuffleDataDistributionType.NORMAL, Roaring64NavigableMap.bitmapOf()
     );
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
@@ -43,8 +43,7 @@ public class CreateShuffleReadHandlerRequest {
   private Roaring64NavigableMap expectBlockIds;
   private Roaring64NavigableMap processBlockIds;
   private ShuffleDataDistributionType distributionType;
-  private int startMapIndex;
-  private int endMapIndex;
+  private Roaring64NavigableMap expectTaskIds;
 
   public CreateShuffleReadHandlerRequest() {
   }
@@ -169,19 +168,11 @@ public class CreateShuffleReadHandlerRequest {
     this.distributionType = distributionType;
   }
 
-  public int getStartMapIndex() {
-    return startMapIndex;
+  public Roaring64NavigableMap getExpectTaskIds() {
+    return expectTaskIds;
   }
 
-  public void setStartMapIndex(int startMapIndex) {
-    this.startMapIndex = startMapIndex;
-  }
-
-  public int getEndMapIndex() {
-    return endMapIndex;
-  }
-
-  public void setEndMapIndex(int endMapIndex) {
-    this.endMapIndex = endMapIndex;
+  public void setExpectTaskIds(Roaring64NavigableMap expectTaskIds) {
+    this.expectTaskIds = expectTaskIds;
   }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 
@@ -41,6 +42,9 @@ public class CreateShuffleReadHandlerRequest {
   private List<ShuffleServerInfo> shuffleServerInfoList;
   private Roaring64NavigableMap expectBlockIds;
   private Roaring64NavigableMap processBlockIds;
+  private ShuffleDataDistributionType distributionType;
+  private int startMapIndex;
+  private int endMapIndex;
 
   public CreateShuffleReadHandlerRequest() {
   }
@@ -155,5 +159,29 @@ public class CreateShuffleReadHandlerRequest {
 
   public Roaring64NavigableMap getProcessBlockIds() {
     return processBlockIds;
+  }
+
+  public ShuffleDataDistributionType getDistributionType() {
+    return distributionType;
+  }
+
+  public void setDistributionType(ShuffleDataDistributionType distributionType) {
+    this.distributionType = distributionType;
+  }
+
+  public int getStartMapIndex() {
+    return startMapIndex;
+  }
+
+  public void setStartMapIndex(int startMapIndex) {
+    this.startMapIndex = startMapIndex;
+  }
+
+  public int getEndMapIndex() {
+    return endMapIndex;
+  }
+
+  public void setEndMapIndex(int endMapIndex) {
+    this.endMapIndex = endMapIndex;
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
@@ -32,8 +32,8 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.segment.FixedSizeSegmentSplitter;
 import org.apache.uniffle.common.util.ChecksumUtils;
-import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.api.ServerReadHandler;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
@@ -97,8 +97,7 @@ public class LocalFileHandlerTestBase {
       return shuffleDataResults;
     }
 
-    List<ShuffleDataSegment> shuffleDataSegments =
-        RssUtils.transIndexDataToSegments(shuffleIndexResult, 32);
+    List<ShuffleDataSegment> shuffleDataSegments = new FixedSizeSegmentSplitter(32).split(shuffleIndexResult);
 
     for (ShuffleDataSegment shuffleDataSegment : shuffleDataSegments) {
       byte[] shuffleData =

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
@@ -33,6 +33,7 @@ import org.apache.uniffle.client.request.RssGetShuffleDataRequest;
 import org.apache.uniffle.client.response.ResponseStatusCode;
 import org.apache.uniffle.client.response.RssGetShuffleDataResponse;
 import org.apache.uniffle.client.response.RssGetShuffleIndexResponse;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
@@ -95,7 +96,8 @@ public class LocalFileServerReadHandlerTest {
 
     Roaring64NavigableMap processBlockIds =  Roaring64NavigableMap.bitmapOf();
     LocalFileClientReadHandler handler = new LocalFileClientReadHandler(appId, partitionId, shuffleId, -1, 1, 1,
-        readBufferSize, expectBlockIds, processBlockIds, mockShuffleServerClient);
+        readBufferSize, expectBlockIds, processBlockIds, mockShuffleServerClient,
+        ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE);
     int totalSegment = ((blockSize * actualWriteDataBlock) / bytesPerSegment) + 1;
     int readBlocks = 0;
     for (int i = 0; i < totalSegment; i++) {

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
@@ -97,7 +97,7 @@ public class LocalFileServerReadHandlerTest {
     Roaring64NavigableMap processBlockIds =  Roaring64NavigableMap.bitmapOf();
     LocalFileClientReadHandler handler = new LocalFileClientReadHandler(appId, partitionId, shuffleId, -1, 1, 1,
         readBufferSize, expectBlockIds, processBlockIds, mockShuffleServerClient,
-        ShuffleDataDistributionType.NORMAL, 0, Integer.MAX_VALUE);
+        ShuffleDataDistributionType.NORMAL, Roaring64NavigableMap.bitmapOf());
     int totalSegment = ((blockSize * actualWriteDataBlock) / bytesPerSegment) + 1;
     int readBlocks = 0;
     for (int i = 0; i < totalSegment; i++) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce a new mechanism to determine  how to write data to file, including directly append or append after sort.

### Why are the changes needed?
In our internal uniffle deployment, 200+ shuffle-servers are in service. A single shuffle-server uses 4 SATA SSDs to be used as the localfile storage, the max network bandwidth is limited to 5G/s. The storageType of the shuffle-server is MEMORY_LOCALFILE.

After monitoring the read_data_rate metric, I found it always will reach the max network bandwidth. However, at that time, the number of apps running was low. And only single disk usage is 100%.

After digging into the shuffle-server’s log, I found almost all requests with the same AppId and the same Partition to get the shuffle data from the same partition data file. This indicates the reason for high disk utilization due to the hotspots of reading.

It was found that this App’s shuffle-read was optimized by AQE skew data split, which causes the Uniffle shuffle-server high-pressure of network and diskIO.

After catching this point, I analyzed the performance of historical tasks using different shuffle-services briefly.

And in current implementation, one partition’s buffer will be flushed to disk once the size reaches the threshold of 64M. And the spark/mr uniffle client will fetch one batch data of 14M size(default value). That means for one buffer of one partition, the client needs to have 5 network interactions with the shuffle-server if the data with MapId is relatively discrete. 

To solve this problem, we could make the 64M buffer’s data sorted by MapId. That means for the uniffle client, ideally it will read one time in a single buffer.

### Does this PR introduce _any_ user-facing change?

1. Introduce the shuffle-data distribution type, NORMAL or LOCAL_ORDER, which can have other implementations, like GLOBAL_ORDER.
2. Make the segment split strategy as a general interface for above different data distribution type.


### How was this patch tested?

1. UTs
2. Spark Tests on offline hadoop cluster

### Benchmark
Table1: 100g,  dtypes: Array[(String, String)] = Array((v1,StringType), (k1,IntegerType)). And all columns of k1 have the same value (value = 10)

Table2: 10 records, dtypes: Array[(String, String)] = Array((k2,IntegerType), (v2,StringType)). And it has the only one record of k2=10

Environment: 100 executors(1core2g) 
SQL: spark.sql("select * from Table1,Table2 where k1 = k2").write.mode("overwrite").parquet("xxxxxx")

- Uniffle without patch: cost 12min
- Uniffle with patch: cost 4min

### Reference
1. Design doc: https://docs.google.com/document/d/1G0cOFVJbYLf2oX1fiadh7zi2M6DlEcjTQTh4kSkb0LA/edit?usp=sharing