### PR TITLE
[ISSUE-301][Subtask][Improvement][AQE] Merge continuous ShuffleDataSegment into single one

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitterTest.java
@@ -24,13 +24,101 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LocalOrderSegmentSplitterTest {
+
+  @Test
+  public void testSplitWithDiscontinuousBlocksShouldThrowException() {
+    Roaring64NavigableMap taskIds = Roaring64NavigableMap.bitmapOf(1, 2, 4);
+    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(taskIds, 32);
+    byte[] data = generateData(
+        Pair.of(1, 1),
+        Pair.of(1, 2),
+        Pair.of(1, 3),
+        Pair.of(1, 4)
+    );
+    try {
+      splitter.split(new ShuffleIndexResult(data, -1));
+      fail();
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testSplitForMergeContinuousSegments() {
+    /**
+     * case1: (32, 5) (16, 1) (10, 1) (16, 2) (6, 1) (8, 1) (10, 3) (9, 1)
+     *
+     * It will skip the (32, 5) and merge others into one dataSegment when no exceeding the
+     * read buffer size.
+     */
+    Roaring64NavigableMap taskIds = Roaring64NavigableMap.bitmapOf(1, 2);
+    LocalOrderSegmentSplitter splitter = new LocalOrderSegmentSplitter(taskIds, 1000);
+    byte[] data = generateData(
+        Pair.of(32, 5),
+        Pair.of(16, 1),
+        Pair.of(10, 1),
+        Pair.of(16, 2),
+        Pair.of(6, 1),
+        Pair.of(8, 1),
+        Pair.of(10, 3),
+        Pair.of(9, 1)
+    );
+    List<ShuffleDataSegment> dataSegments = splitter.split(new ShuffleIndexResult(data, -1));
+    assertEquals(2, dataSegments.size());
+    assertEquals(32, dataSegments.get(0).getOffset());
+    assertEquals(56, dataSegments.get(0).getLength());
+
+    List<BufferSegment> bufferSegments = dataSegments.get(0).getBufferSegments();
+    assertEquals(0, bufferSegments.get(0).getOffset());
+    assertEquals(16, bufferSegments.get(0).getLength());
+
+    assertEquals(16, bufferSegments.get(1).getOffset());
+    assertEquals(10, bufferSegments.get(1).getLength());
+
+    assertEquals(26, bufferSegments.get(2).getOffset());
+    assertEquals(16, bufferSegments.get(2).getLength());
+
+    assertEquals(42, bufferSegments.get(3).getOffset());
+    assertEquals(6, bufferSegments.get(3).getLength());
+
+    assertEquals(48, bufferSegments.get(4).getOffset());
+    assertEquals(8, bufferSegments.get(4).getLength());
+
+    assertEquals(98, dataSegments.get(1).getOffset());
+    assertEquals(9, dataSegments.get(1).getLength());
+    bufferSegments = dataSegments.get(1).getBufferSegments();
+    assertEquals(1, bufferSegments.size());
+    assertEquals(0, bufferSegments.get(0).getOffset());
+    assertEquals(9, bufferSegments.get(0).getLength());
+
+    /**
+     * case2: (16, 1) (16, 2) (6, 1)
+     *
+     * It will skip merging into one dataSegment when exceeding the
+     * read buffer size.
+     */
+    data = generateData(
+        Pair.of(16, 1),
+        Pair.of(15, 2),
+        Pair.of(1, 1),
+        Pair.of(6, 1)
+    );
+    dataSegments = new LocalOrderSegmentSplitter(taskIds, 32).split(new ShuffleIndexResult(data, -1));
+    assertEquals(2, dataSegments.size());
+    assertEquals(0, dataSegments.get(0).getOffset());
+    assertEquals(32, dataSegments.get(0).getLength());
+    assertEquals(32, dataSegments.get(1).getOffset());
+    assertEquals(6, dataSegments.get(1).getLength());
+  }
 
   @Test
   public void testSplit() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Merge continuous ShuffleDataSegment into single one
2. Throw exception when reading the discontinuous blocks into segments directly

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Currently, the LocalOrderSegmentSplitter will split the index file into 
multiple shuffleDataSegments. But the split scope is limited in the range of local order.

For example:
The blocks are as follow
```
block-a (taskId-1)
block-b (taskId-2)
block-c (taskId-1)
block-d (taskId-2)
```

When the reader want to get  the range of taskIds: [1, 3), the strategy will return
 two shuffleDataSegments. But we'd better to merge them into single one to 
reduce the network interaction times, because they are continuous.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. UTs
