### PR TITLE
[BUG] Fix incorrect spark metrics

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -117,7 +117,6 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
         appId, shuffleId, startPartition, storageType, basePath, indexReadLimit, readBufferSize,
         partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList, hadoopConf);
     ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
-    context.taskMetrics().createTempShuffleReadMetrics();
     RssShuffleDataIterator rssShuffleDataIterator = new RssShuffleDataIterator<K, C>(
         shuffleDependency.serializer(), shuffleReadClient,
         new ReadMetrics(context.taskMetrics().createTempShuffleReadMetrics()), rssConf);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -212,7 +212,10 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
             shuffleDependency.serializer(), shuffleReadClient,
             readMetrics, rssConf);
         CompletionIterator<Product2<K, C>, RssShuffleDataIterator<K, C>> completionIterator =
-            CompletionIterator$.MODULE$.apply(iterator, () -> iterator.cleanup());
+            CompletionIterator$.MODULE$.apply(iterator, () -> {
+              context.taskMetrics().mergeShuffleReadMetrics();
+              return iterator.cleanup();
+            });
         iterators.add(completionIterator);
       }
       iterator = iterators.iterator();

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
@@ -72,9 +72,8 @@ public class WriteAndReadMetricsTest extends SimpleTestBase {
               "stageData",
               int.class,
               boolean.class
-          ).invoke(
-              statestore, stageId, false)).
-          toList().head();
+          ).invoke(statestore, stageId, false))
+          .toList().head();
     } catch (Exception e) {
       return ((Seq<StageData>)statestore
           .getClass()

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.status.api.v1.StageData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WriteAndReadMetricsTest extends SimpleTestBase {
+
+  @Test
+  public void test() throws Exception {
+    run();
+  }
+
+  @Override
+  public Map runTest(SparkSession spark, String fileName) throws Exception {
+    // take a rest to make sure shuffle server is registered
+    Thread.sleep(3000);
+
+    Dataset<Row> df1 = spark.range(0, 100, 1, 10)
+        .select(functions.when(functions.col("id").$less$eq(50), 1)
+            .otherwise(functions.col("id")).as("key1"), functions.col("id").as("value1"));
+    df1.createOrReplaceTempView("table1");
+
+    List list = spark.sql("select count(value1) from table1 group by key1").collectAsList();
+    Map<String, Integer> result = new HashMap<>();
+    result.put("size", list.size());
+
+    List<StageData> stageData =
+        scala.collection.JavaConverters.seqAsJavaList(spark.sparkContext().statusStore().stageData(0, false));
+    long writeRecords = stageData.get(0).shuffleWriteRecords();
+
+    stageData =
+        scala.collection.JavaConverters.seqAsJavaList(spark.sparkContext().statusStore().stageData(1, false));
+    long readRecords = stageData.get(0).shuffleReadRecords();
+
+    assertEquals(writeRecords, readRecords);
+
+    return result;
+  }
+}

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
@@ -64,10 +64,18 @@ public class WriteAndReadMetricsTest extends SimpleTestBase {
 
   private StageData getFirstStageData(SparkSession spark, int stageId)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    AppStatusStore statestore = spark.sparkContext().statusStore();
     try {
-      return spark.sparkContext().statusStore().stageData(stageId, false).toList().head();
+      return ((Seq<StageData>)statestore
+          .getClass()
+          .getDeclaredMethod(
+              "stageData",
+              int.class,
+              boolean.class
+          ).invoke(
+              statestore, stageId, false)).
+          toList().head();
     } catch (Exception e) {
-      AppStatusStore statestore = spark.sparkContext().statusStore();
       return ((Seq<StageData>)statestore
           .getClass()
           .getDeclaredMethod(
@@ -78,7 +86,8 @@ public class WriteAndReadMetricsTest extends SimpleTestBase {
               boolean.class,
               double[].class
           ).invoke(
-              statestore, stageId, true, new ArrayList<>(), false, new double[]{})).toList().head();
+              statestore, stageId, false, new ArrayList<>(), false, new double[]{}))
+          .toList().head();
     }
   }
 }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
@@ -72,8 +72,7 @@ public class WriteAndReadMetricsTest extends SimpleTestBase {
               "stageData",
               int.class,
               boolean.class
-          ).invoke(statestore, stageId, false))
-          .toList().head();
+          ).invoke(statestore, stageId, false)).toList().head();
     } catch (Exception e) {
       return ((Seq<StageData>)statestore
           .getClass()
@@ -85,8 +84,7 @@ public class WriteAndReadMetricsTest extends SimpleTestBase {
               boolean.class,
               double[].class
           ).invoke(
-              statestore, stageId, false, new ArrayList<>(), false, new double[]{}))
-          .toList().head();
+              statestore, stageId, false, new ArrayList<>(), false, new double[]{})).toList().head();
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix incorrect spark metrics

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. The corresponding shuffle-read records number and shuffle-write records number is not consistent in our internal cluster
2. Log wont show the correct fetch bytes, always return 0 like 

`22/11/15 13:54:53 INFO RssShuffleDataIterator: Fetch 0 bytes cost 30791 ms and 53 ms to serialize, 347 ms to decompress with unCompressionLength[274815736]
`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. UTs
2. Online spark3 jobs test