### PR TITLE
[Improvement] Task fast fail once blocks fail to send

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -240,7 +240,7 @@ public class SortWriteBufferManager<K, V> {
           for (ShuffleBlockInfo block : shuffleBlocks) {
             size += block.getFreeMemory();
           }
-          SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(appId, shuffleBlocks);
+          SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(appId, shuffleBlocks, () -> true);
           successBlockIds.addAll(result.getSuccessBlockIds());
           failedBlockIds.addAll(result.getFailedBlockIds());
         } catch (Throwable t) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -240,7 +240,7 @@ public class SortWriteBufferManager<K, V> {
           for (ShuffleBlockInfo block : shuffleBlocks) {
             size += block.getFreeMemory();
           }
-          SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(appId, shuffleBlocks, () -> true);
+          SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(appId, shuffleBlocks, () -> false);
           successBlockIds.addAll(result.getSuccessBlockIds());
           failedBlockIds.addAll(result.getFailedBlockIds());
         } catch (Throwable t) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -268,7 +268,7 @@ public class SortWriteBufferManagerTest {
 
     @Override
     public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
-        Supplier<Boolean> isValidTaskId) {
+        Supplier<Boolean> needCancelRequest) {
       if (mode == 0) {
         throw new RssException("send data failed");
       } else if (mode == 1) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -266,7 +267,8 @@ public class SortWriteBufferManagerTest {
     }
 
     @Override
-    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList) {
+    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
+        Supplier<Boolean> isValidTaskId) {
       if (mode == 0) {
         throw new RssException("send data failed");
       } else if (mode == 1) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -352,7 +353,8 @@ public class FetcherTest {
     public List<byte[]> data = new LinkedList<>();
 
     @Override
-    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList) {
+    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
+        Supplier<Boolean> isValid) {
       if (mode == 0) {
         throw new RssException("send data failed");
       } else if (mode == 1) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -354,7 +354,7 @@ public class FetcherTest {
 
     @Override
     public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
-        Supplier<Boolean> isValid) {
+        Supplier<Boolean> needCancelRequest) {
       if (mode == 0) {
         throw new RssException("send data failed");
       } else if (mode == 1) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -105,7 +105,7 @@ public class RssShuffleManager implements ShuffleManager {
         SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(
             appId,
             shuffleDataInfoList,
-            () -> isValidTask(taskId)
+            () -> !isValidTask(taskId)
         );
         putBlockId(taskToSuccessBlockIds, taskId, result.getSuccessBlockIds());
         putBlockId(taskToFailedBlockIds, taskId, result.getFailedBlockIds());

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -358,7 +359,8 @@ public class RssShuffleManager implements ShuffleManager {
       taskToBufferManager.put(taskId, bufferManager);
 
       return new RssShuffleWriter(rssHandle.getAppId(), shuffleId, taskId, context.taskAttemptId(), bufferManager,
-          writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle);
+          writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle,
+          (Function<String, Boolean>) tid -> markFailedTask(tid));
     } else {
       throw new RuntimeException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }
@@ -528,9 +530,10 @@ public class RssShuffleManager implements ShuffleManager {
     this.appId = appId;
   }
 
-  public void markFailedTask(String taskId) {
+  public boolean markFailedTask(String taskId) {
     LOG.info("Mark the task: {} failed.", taskId);
     failedTaskIds.add(taskId);
+    return true;
   }
 
   public boolean isValidTask(String taskId) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -83,7 +83,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private long sendCheckInterval;
   private long sendSizeLimit;
   private boolean isMemoryShuffleEnabled;
-  private final Function<String, Boolean> markFailedTaskFunc;
+  private final Function<String, Boolean> taskFailureCallback;
 
   public RssShuffleWriter(
       String appId,
@@ -122,7 +122,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       SparkConf sparkConf,
       ShuffleWriteClient shuffleWriteClient,
       RssShuffleHandle rssHandle,
-      Function<String, Boolean> markFailedTaskFunc) {
+      Function<String, Boolean> taskFailureCallback) {
     this.appId = appId;
     this.bufferManager = bufferManager;
     this.shuffleId = shuffleId;
@@ -145,7 +145,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     this.partitionToServers = rssHandle.getPartitionToServers();
     this.isMemoryShuffleEnabled = isMemoryShuffleEnabled(
         sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key()));
-    this.markFailedTaskFunc = markFailedTaskFunc;
+    this.taskFailureCallback = taskFailureCallback;
   }
 
   private boolean isMemoryShuffleEnabled(String storageType) {
@@ -166,7 +166,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     try {
       doWrite(records);
     } catch (Exception e) {
-      markFailedTaskFunc.apply(taskId);
+      taskFailureCallback.apply(taskId);
       throw e;
     }
   }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -133,6 +133,15 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
   @Override
   public void write(Iterator<Product2<K, V>> records) {
+    try {
+      doWrite(records);
+    } catch (Exception e) {
+      shuffleManager.markFailedTask(taskId);
+      throw e;
+    }
+  }
+
+  private void doWrite(Iterator<Product2<K,V>> records) {
     List<ShuffleBlockInfo> shuffleBlockInfos = null;
     Set<Long> blockIds = Sets.newConcurrentHashSet();
     while (records.hasNext()) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -164,14 +164,14 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   @Override
   public void write(Iterator<Product2<K, V>> records) {
     try {
-      doWrite(records);
+      writeImpl(records);
     } catch (Exception e) {
       taskFailureCallback.apply(taskId);
       throw e;
     }
   }
 
-  private void doWrite(Iterator<Product2<K,V>> records) {
+  private void writeImpl(Iterator<Product2<K,V>> records) {
     List<ShuffleBlockInfo> shuffleBlockInfos = null;
     Set<Long> blockIds = Sets.newConcurrentHashSet();
     while (records.hasNext()) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -374,7 +375,8 @@ public class RssShuffleManager implements ShuffleManager {
     taskToBufferManager.put(taskId, bufferManager);
     LOG.info("RssHandle appId {} shuffleId {} ", rssHandle.getAppId(), rssHandle.getShuffleId());
     return new RssShuffleWriter(rssHandle.getAppId(), shuffleId, taskId, context.taskAttemptId(), bufferManager,
-        writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle);
+        writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle,
+        (Function<String, Boolean>) tid -> markFailedTask(tid));
   }
 
   @Override
@@ -778,9 +780,10 @@ public class RssShuffleManager implements ShuffleManager {
     return id.get();
   }
 
-  public void markFailedTask(String taskId) {
+  public boolean markFailedTask(String taskId) {
     LOG.info("Mark the task: {} failed.", taskId);
     failedTaskIds.add(taskId);
+    return true;
   }
 
   public boolean isValidTask(String taskId) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -123,7 +123,7 @@ public class RssShuffleManager implements ShuffleManager {
         SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(
             id.get(),
             shuffleDataInfoList,
-            () -> isValidTask(taskId)
+            () -> !isValidTask(taskId)
         );
         putBlockId(taskToSuccessBlockIds, taskId, result.getSuccessBlockIds());
         putBlockId(taskToFailedBlockIds, taskId, result.getFailedBlockIds());

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -83,7 +83,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final Set shuffleServersForData;
   private final long[] partitionLengths;
   private boolean isMemoryShuffleEnabled;
-  private final Function<String, Boolean> markFailedTaskFunc;
+  private final Function<String, Boolean> taskFailureCallback;
 
   public RssShuffleWriter(
       String appId,
@@ -122,7 +122,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       SparkConf sparkConf,
       ShuffleWriteClient shuffleWriteClient,
       RssShuffleHandle rssHandle,
-      Function<String, Boolean> markFailedTaskFunc) {
+      Function<String, Boolean> taskFailureCallback) {
     LOG.warn("RssShuffle start write taskAttemptId data" + taskAttemptId);
     this.shuffleManager = shuffleManager;
     this.appId = appId;
@@ -148,7 +148,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     partitionToServers = rssHandle.getPartitionToServers();
     this.isMemoryShuffleEnabled = isMemoryShuffleEnabled(
         sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key()));
-    this.markFailedTaskFunc = markFailedTaskFunc;
+    this.taskFailureCallback = taskFailureCallback;
   }
 
   private boolean isMemoryShuffleEnabled(String storageType) {
@@ -160,7 +160,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     try {
       doWrite(records);
     } catch (Exception e) {
-      markFailedTaskFunc.apply(taskId);
+      taskFailureCallback.apply(taskId);
       throw e;
     }
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -158,14 +158,14 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   @Override
   public void write(Iterator<Product2<K, V>> records) throws IOException {
     try {
-      doWrite(records);
+      writeImpl(records);
     } catch (Exception e) {
       taskFailureCallback.apply(taskId);
       throw e;
     }
   }
 
-  private void doWrite(Iterator<Product2<K,V>> records) {
+  private void writeImpl(Iterator<Product2<K,V>> records) {
     List<ShuffleBlockInfo> shuffleBlockInfos = null;
     Set<Long> blockIds = Sets.newConcurrentHashSet();
     while (records.hasNext()) {

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -35,7 +35,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 public interface ShuffleWriteClient {
 
   SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
-      Supplier<Boolean> isValidTaskId);
+      Supplier<Boolean> needCancelRequest);
 
   void sendAppHeartbeat(String appId, long timeoutMs);
 

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.client.api;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -33,7 +34,8 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 
 public interface ShuffleWriteClient {
 
-  SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList);
+  SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
+      Supplier<Boolean> isValidTaskId);
 
   void sendAppHeartbeat(String appId, long timeoutMs);
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -285,7 +285,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     // This should be infrequent.
     // Even though the secondary round may send blocks more than replicaWrite replicas,
     // we do not apply complicated skipping logic, because server crash is rare in production environment.
-    if (!isAllSuccess && !secondaryServerToBlocks.isEmpty() && needCancelRequest.get()) {
+    if (!isAllSuccess && !secondaryServerToBlocks.isEmpty() && !needCancelRequest.get()) {
       LOG.info("The sending of primary round is failed partially, so start the secondary round");
       sendShuffleDataAsync(
           appId,

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -159,7 +159,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks = entry.getValue();
           // todo: compact unnecessary blocks that reach replicaWrite
           RssSendShuffleDataRequest request = new RssSendShuffleDataRequest(
-              appId, retryMax, retryIntervalMax, shuffleIdToBlocks, needCancelRequest);
+              appId, retryMax, retryIntervalMax, shuffleIdToBlocks);
           long s = System.currentTimeMillis();
           RssSendShuffleDataResponse response = getShuffleServerClient(ssi).sendShuffleData(request);
 

--- a/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
@@ -17,15 +17,30 @@
 
 package org.apache.uniffle.client;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.util.ClientUtils;
 
+import static org.apache.uniffle.client.util.ClientUtils.waitUntilDoneOrFail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ClientUtilsTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientUtilsTest.class);
+
+  private ExecutorService executorService = Executors.newFixedThreadPool(10);
 
   @Test
   public void getBlockIdTest() {
@@ -47,5 +62,50 @@ public class ClientUtilsTest {
 
     final Throwable e3 = assertThrows(IllegalArgumentException.class, () -> ClientUtils.getBlockId(0, 0, 262144));
     assertTrue(e3.getMessage().contains("Can't support sequence[262144], the max value should be 262143"));
+  }
+
+  private List<CompletableFuture<Boolean>> getFutures(boolean fail) {
+    List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      final int index = i;
+      CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
+        if (index == 2) {
+          try {
+            Thread.sleep(3000);
+          } catch (InterruptedException interruptedException) {
+            LOGGER.info("Capture the InterruptedException");
+            return false;
+          }
+          LOGGER.info("Finished index: " + index);
+          return true;
+        }
+        if (fail && index == 1) {
+          return false;
+        }
+        return true;
+      }, executorService);
+      futures.add(future);
+    }
+    return futures;
+  }
+
+  @Test
+  public void testWaitUntilDoneOrFail() {
+    // case1: enable fail fast
+    List<CompletableFuture<Boolean>> futures1 = getFutures(true);
+    Awaitility.await().timeout(2, TimeUnit.SECONDS).until(() -> !waitUntilDoneOrFail(futures1, true));
+
+    // case2: disable fail fast
+    List<CompletableFuture<Boolean>> futures2 = getFutures(true);
+    try {
+      Awaitility.await().timeout(2, TimeUnit.SECONDS).until(() -> !waitUntilDoneOrFail(futures2, false));
+      fail();
+    } catch (Exception e) {
+      // ignore
+    }
+
+    // case3: all succeed
+    List<CompletableFuture<Boolean>> futures3 = getFutures(false);
+    Awaitility.await().timeout(4, TimeUnit.SECONDS).until(() -> waitUntilDoneOrFail(futures3, true));
   }
 }

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.impl;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -273,7 +273,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     }
 
     public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList) {
-      return super.sendShuffleData(appId, shuffleBlockInfoList, () -> true);
+      return super.sendShuffleData(appId, shuffleBlockInfoList, () -> false);
     }
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -70,7 +70,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   private static ShuffleServerInfo fakedShuffleServerInfo2;
   private static ShuffleServerInfo fakedShuffleServerInfo3;
   private static ShuffleServerInfo fakedShuffleServerInfo4;
-  private ShuffleWriteClientImpl shuffleWriteClientImpl;
+  private MockedShuffleWriteClientImpl shuffleWriteClientImpl;
 
   public static MockedShuffleServer createServer(int id) throws Exception {
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();
@@ -263,10 +263,24 @@ public class QuorumTest extends ShuffleReadWriteBase {
         .disableMockedTimeout();
   }
 
+  static class MockedShuffleWriteClientImpl extends ShuffleWriteClientImpl {
+    MockedShuffleWriteClientImpl(String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
+        int replica, int replicaWrite, int replicaRead, boolean replicaSkipEnabled, int dataTranferPoolSize,
+        int dataCommitPoolSize, int unregisterThreadPoolSize, int unregisterRequestTimeSec) {
+      super(clientType, retryMax, retryIntervalMax, heartBeatThreadNum, replica, replicaWrite, replicaRead,
+          replicaSkipEnabled, dataTranferPoolSize, dataCommitPoolSize, unregisterThreadPoolSize,
+          unregisterRequestTimeSec);
+    }
+
+    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList) {
+      return super.sendShuffleData(appId, shuffleBlockInfoList, () -> true);
+    }
+  }
+
   private void registerShuffleServer(String testAppId,
       int replica, int replicaWrite, int replicaRead, boolean replicaSkip) {
 
-    shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
+    shuffleWriteClientImpl = new MockedShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
       replica, replicaWrite, replicaRead, replicaSkip, 1, 1, 10, 10);
 
     List<ShuffleServerInfo> allServers = Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1,

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
@@ -515,7 +515,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
 
   @Disabled("flaky test")
   @Test
-  public void rpcMetricsTest() {
+  public void rpcMetricsTest() throws Exception {
     String appId = "rpcMetricsTest";
     int shuffleId = 0;
     final double oldGrpcTotal = shuffleServers.get(0).getGrpcMetrics().getCounterGrpcTotal().get();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -122,7 +122,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     List<ShuffleBlockInfo> blocks = createShuffleBlockList(
         0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo1, fakeShuffleServerInfo));
-    SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+    SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> true);
     Roaring64NavigableMap failedBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap succBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     for (Long blockId : result.getFailedBlockIds()) {
@@ -254,7 +254,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     List<ShuffleBlockInfo> blocks = createShuffleBlockList(
         0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2));
-    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> true);
     // send 1st commit, finish commit won't be sent to Shuffle server and data won't be persisted to disk
     boolean commitResult = shuffleWriteClientImpl
         .sendCommit(Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2), testAppId, 0, 2);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -254,7 +254,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     List<ShuffleBlockInfo> blocks = createShuffleBlockList(
         0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2));
-    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> false;
+    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> false);
     // send 1st commit, finish commit won't be sent to Shuffle server and data won't be persisted to disk
     boolean commitResult = shuffleWriteClientImpl
         .sendCommit(Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2), testAppId, 0, 2);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -122,7 +122,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     List<ShuffleBlockInfo> blocks = createShuffleBlockList(
         0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo1, fakeShuffleServerInfo));
-    SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> true);
+    SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> false);
     Roaring64NavigableMap failedBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap succBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     for (Long blockId : result.getFailedBlockIds()) {
@@ -254,7 +254,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     List<ShuffleBlockInfo> blocks = createShuffleBlockList(
         0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2));
-    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> true);
+    shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> false;
     // send 1st commit, finish commit won't be sent to Shuffle server and data won't be persisted to disk
     boolean commitResult = shuffleWriteClientImpl
         .sendCommit(Sets.newHashSet(shuffleServerInfo1, shuffleServerInfo2), testAppId, 0, 2);

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -249,7 +249,11 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             + "because upstream task has been failed.");
       }
 
-      Thread.sleep(10);
+      try {
+        future.get(10, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        // ignore
+      }
     }
   }
 
@@ -379,7 +383,11 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
               throw new NotRetryException("The request is invalid. Cancel it.");
             }
 
-            Thread.sleep(10);
+            try {
+              future.get(10, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+              // ignore
+            }
           }
           LOG.info("Do sendShuffleData to {}:{} rpc cost:" + (System.currentTimeMillis() - start)
               + " ms for " + allocateSize + " bytes with " + finalBlockNum + " blocks", host, port);

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -19,11 +19,14 @@ package org.apache.uniffle.client.impl.grpc;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +106,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
   private static final long FAILED_REQUIRE_ID = -1;
   private static final long RPC_TIMEOUT_DEFAULT_MS = 60000;
   private long rpcTimeout = RPC_TIMEOUT_DEFAULT_MS;
+  private ShuffleServerGrpc.ShuffleServerFutureStub futureStub;
   private ShuffleServerBlockingStub blockingStub;
 
   public ShuffleServerGrpcClient(String host, int port) {
@@ -116,10 +120,15 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
   public ShuffleServerGrpcClient(String host, int port, int maxRetryAttempts, boolean usePlaintext) {
     super(host, port, maxRetryAttempts, usePlaintext);
     blockingStub = ShuffleServerGrpc.newBlockingStub(channel);
+    futureStub = ShuffleServerGrpc.newFutureStub(channel);
   }
-  
+
   public ShuffleServerBlockingStub getBlockingStub() {
     return blockingStub.withDeadlineAfter(rpcTimeout, TimeUnit.MILLISECONDS);
+  }
+
+  public ShuffleServerGrpc.ShuffleServerFutureStub getFutureStub() {
+    return futureStub.withDeadlineAfter(rpcTimeout, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -177,39 +186,71 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
     return blockingStub.withDeadlineAfter(timeout, TimeUnit.MILLISECONDS).appHeartbeat(request);
   }
 
-  public long requirePreAllocation(int requireSize, int retryMax, long retryIntervalMax) {
+  /**
+   * Only for tests
+   */
+  @VisibleForTesting
+  public long requirePreAllocation(int requireSize, int retryMax, long retryIntervalMax) throws Exception {
+    return requirePreAllocation(requireSize, retryMax, retryIntervalMax, () -> true);
+  }
+
+  public long requirePreAllocation(int requireSize, int retryMax, long retryIntervalMax, Supplier<Boolean> isValid)
+      throws Exception {
     RequireBufferRequest rpcRequest = RequireBufferRequest.newBuilder().setRequireSize(requireSize).build();
     long start = System.currentTimeMillis();
-    RequireBufferResponse rpcResponse = getBlockingStub().requireBuffer(rpcRequest);
-    int retry = 0;
+
+    int retry = -1;
     long result = FAILED_REQUIRE_ID;
     Random random = new Random();
-    final int backOffBase = 2000;
-    while (rpcResponse.getStatus() == StatusCode.NO_BUFFER) {
-      LOG.info("Can't require " + requireSize + " bytes from " + host + ":" + port + ", sleep and try["
-          + retry + "] again");
-      if (retry >= retryMax) {
-        LOG.warn("ShuffleServer " + host + ":" + port + " is full and can't send shuffle"
-            + " data successfully after retry " + retryMax + " times, cost: {}(ms)",
-            System.currentTimeMillis() - start);
-        return result;
+    final int backoffBase = 2000;
+    RequireBufferResponse rpcResponse;
+
+    do {
+      if (retry != -1) {
+        LOG.info("Can't require " + requireSize + " bytes from " + host + ":" + port + ", sleep and try["
+            + retry + "] again");
+        if (retry >= retryMax) {
+          LOG.warn("ShuffleServer " + host + ":" + port + " is full and can't send shuffle"
+                  + " data successfully after retry " + retryMax + " times, cost: {}(ms)",
+              System.currentTimeMillis() - start);
+          return result;
+        }
+        try {
+          long backoffTime =
+              Math.min(retryIntervalMax, backoffBase * (1L << Math.min(retry, 16)) + random.nextInt(backoffBase));
+          Thread.sleep(backoffTime);
+        } catch (Exception e) {
+          LOG.warn("Exception happened when require pre allocation from " + host + ":" + port, e);
+        }
       }
-      try {
-        long backoffTime =
-            Math.min(retryIntervalMax, backOffBase * (1L << Math.min(retry, 16)) + random.nextInt(backOffBase));
-        Thread.sleep(backoffTime);
-      } catch (Exception e) {
-        LOG.warn("Exception happened when require pre allocation from " + host + ":" + port, e);
-      }
-      rpcResponse = getBlockingStub().requireBuffer(rpcRequest);
+      rpcResponse = doRequirePreAllocation(rpcRequest, isValid);
       retry++;
-    }
+    } while (rpcResponse != null && rpcResponse.getStatus() == StatusCode.NO_BUFFER);
+
     if (rpcResponse.getStatus() == StatusCode.SUCCESS) {
       LOG.info("Require preAllocated size of {} from {}:{}, cost: {}(ms)",
           requireSize, host, port, System.currentTimeMillis() - start);
       result = rpcResponse.getRequireBufferId();
     }
     return result;
+  }
+
+  private RequireBufferResponse doRequirePreAllocation(RequireBufferRequest rpcRequest,
+      Supplier<Boolean> isValid) throws Exception {
+    ListenableFuture<RequireBufferResponse> future = getFutureStub().requireBuffer(rpcRequest);
+    while (true) {
+      if (future.isDone()) {
+        return future.get();
+      }
+
+      if (!isValid.get()) {
+        future.cancel(true);
+        throw new Exception("Abort the request when requiring PreAllocation memory, "
+            + "because upstream task has been failed.");
+      }
+
+      Thread.sleep(10);
+    }
   }
 
   private RssProtos.ShuffleUnregisterResponse doUnregisterShuffle(String appId, int shuffleId) {
@@ -302,7 +343,16 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       final int finalBlockNum = blockNum;
       try {
         RetryUtils.retry(() -> {
-          long requireId = requirePreAllocation(allocateSize, request.getRetryMax(), request.getRetryIntervalMax());
+          Supplier<Boolean> isValid = Optional.ofNullable(request.getIsValid()).orElse(() -> true);
+          if (!isValid.get()) {
+            throw new NotRetryException("Abort retry due to upstream task has been failed.");
+          }
+          long requireId = requirePreAllocation(
+              allocateSize,
+              request.getRetryMax(),
+              request.getRetryIntervalMax(),
+              isValid
+          );
           if (requireId == FAILED_REQUIRE_ID) {
             throw new RssException(String.format(
                 "requirePreAllocation failed! size[%s], host[%s], port[%s]", allocateSize, host, port));
@@ -315,7 +365,22 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
               .addAllShuffleData(shuffleData)
               .setTimestamp(start)
               .build();
-          SendShuffleDataResponse response = getBlockingStub().sendShuffleData(rpcRequest);
+          SendShuffleDataResponse response;
+          ListenableFuture<SendShuffleDataResponse> future = getFutureStub().sendShuffleData(rpcRequest);
+          while (true) {
+            if (future.isDone()) {
+              response = future.get();
+              break;
+            }
+
+            if (!isValid.get()) {
+              LOG.info("The request is invalid. Cancel it.");
+              future.cancel(true);
+              throw new NotRetryException("The request is invalid. Cancel it.");
+            }
+
+            Thread.sleep(10);
+          }
           LOG.info("Do sendShuffleData to {}:{} rpc cost:" + (System.currentTimeMillis() - start)
               + " ms for " + allocateSize + " bytes with " + finalBlockNum + " blocks", host, port);
           if (response.getStatus() != StatusCode.SUCCESS) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.client.request;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
 
@@ -28,13 +29,20 @@ public class RssSendShuffleDataRequest {
   private int retryMax;
   private long retryIntervalMax;
   private Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks;
+  private Supplier<Boolean> isValid;
 
   public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
       Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks) {
+    this(appId, retryMax, retryIntervalMax, shuffleIdToBlocks, () -> true);
+  }
+
+  public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
+      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks, Supplier<Boolean> isValid) {
     this.appId = appId;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.shuffleIdToBlocks = shuffleIdToBlocks;
+    this.isValid = isValid;
   }
 
   public String getAppId() {
@@ -51,5 +59,9 @@ public class RssSendShuffleDataRequest {
 
   public Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> getShuffleIdToBlocks() {
     return shuffleIdToBlocks;
+  }
+
+  public Supplier<Boolean> getIsValid() {
+    return isValid;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.client.request;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
 
@@ -29,20 +28,13 @@ public class RssSendShuffleDataRequest {
   private int retryMax;
   private long retryIntervalMax;
   private Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks;
-  private Supplier<Boolean> needCancelRequest;
 
   public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
       Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks) {
-    this(appId, retryMax, retryIntervalMax, shuffleIdToBlocks, () -> false);
-  }
-
-  public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
-      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks, Supplier<Boolean> needCancelRequest) {
     this.appId = appId;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.shuffleIdToBlocks = shuffleIdToBlocks;
-    this.needCancelRequest = needCancelRequest;
   }
 
   public String getAppId() {
@@ -59,9 +51,5 @@ public class RssSendShuffleDataRequest {
 
   public Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> getShuffleIdToBlocks() {
     return shuffleIdToBlocks;
-  }
-
-  public Supplier<Boolean> getNeedCancelRequest() {
-    return needCancelRequest;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendShuffleDataRequest.java
@@ -29,20 +29,20 @@ public class RssSendShuffleDataRequest {
   private int retryMax;
   private long retryIntervalMax;
   private Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks;
-  private Supplier<Boolean> isValid;
+  private Supplier<Boolean> needCancelRequest;
 
   public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
       Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks) {
-    this(appId, retryMax, retryIntervalMax, shuffleIdToBlocks, () -> true);
+    this(appId, retryMax, retryIntervalMax, shuffleIdToBlocks, () -> false);
   }
 
   public RssSendShuffleDataRequest(String appId, int retryMax, long retryIntervalMax,
-      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks, Supplier<Boolean> isValid) {
+      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks, Supplier<Boolean> needCancelRequest) {
     this.appId = appId;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.shuffleIdToBlocks = shuffleIdToBlocks;
-    this.isValid = isValid;
+    this.needCancelRequest = needCancelRequest;
   }
 
   public String getAppId() {
@@ -61,7 +61,7 @@ public class RssSendShuffleDataRequest {
     return shuffleIdToBlocks;
   }
 
-  public Supplier<Boolean> getIsValid() {
-    return isValid;
+  public Supplier<Boolean> getNeedCancelRequest() {
+    return needCancelRequest;
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
[Improvement] Task fast fail once blocks fail to send

1. In single replica mechanism, single one batch data sent failed should make task fast fail.
2. When some remaining block events in dataTransferPool wait to be sent, we should abandon it.
3. More precisely, we need to interrupt send requests belonged to failed tasks. (Using the `GrpcFuture` to cancel it)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  4. If there is design documentation, please add the link.
  5. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. When shuffle-sever is down, in current codebase, the shuffle-write client will block and retry too much times. Actually, it should fast fail once partial blocks fail to send.
2. When using the custom retry policy in rpc layer like #308 , this PR will solve the potential problem of waiting too long wait time when specifying the  1min  retry time.

After this patch, fail time is limited in 2min. Before, it will be for 10min+

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. UTs
2. Online real tests
