### PR TITLE
[BUG] Fix wrong method name

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcMetrics.java
@@ -30,7 +30,7 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
   public static final String REPORT_SHUFFLE_RESULT_METHOD = "reportShuffleResult";
   public static final String GET_SHUFFLE_RESULT_METHOD = "getShuffleResult";
   public static final String GET_SHUFFLE_DATA_METHOD = "getLocalShuffleData";
-  public static final String GET_IN_MEMORY_SHUFFLE_DATA_METHOD = "getInMemoryShuffleData";
+  public static final String GET_MEMORY_SHUFFLE_DATA_METHOD = "getMemoryShuffleData";
   public static final String GET_SHUFFLE_INDEX_METHOD = "getLocalShuffleIndex";
 
   private static final String GRPC_REGISTERED_SHUFFLE = "grpc_registered_shuffle";
@@ -42,7 +42,7 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
   private static final String GRPC_REPORT_SHUFFLE_RESULT = "grpc_report_shuffle_result";
   private static final String GRPC_GET_SHUFFLE_RESULT = "grpc_get_shuffle_result";
   private static final String GRPC_GET_SHUFFLE_DATA = "grpc_get_local_shuffle_data";
-  private static final String GRPC_GET_IN_MEMORY_SHUFFLE_DATA = "grpc_get_in_memory_shuffle_data";
+  private static final String GRPC_GET_MEMORY_SHUFFLE_DATA = "grpc_get_memory_shuffle_data";
   private static final String GRPC_GET_SHUFFLE_INDEX = "grpc_get_local_shuffle_index";
 
   private static final String GRPC_OPEN = "grpc_open";
@@ -56,21 +56,21 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
   private static final String GRPC_REPORT_SHUFFLE_RESULT_TOTAL = "grpc_report_shuffle_result_total";
   private static final String GRPC_GET_SHUFFLE_RESULT_TOTAL = "grpc_get_shuffle_result_total";
   private static final String GRPC_GET_SHUFFLE_DATA_TOTAL = "grpc_get_local_shuffle_data_total";
-  private static final String GRPC_GET_IN_MEMORY_SHUFFLE_DATA_TOTAL =
-      "grpc_get_in_memory_shuffle_data_total";
+  private static final String GRPC_GET_MEMORY_SHUFFLE_DATA_TOTAL =
+      "grpc_get_memory_shuffle_data_total";
   private static final String GRPC_GET_SHUFFLE_INDEX_TOTAL = "grpc_get_local_shuffle_index_total";
 
   private static final String GRPC_SEND_SHUFFLE_DATA_TRANSPORT_LATENCY =
       "grpc_send_shuffle_data_transport_latency";
   private static final String GRPC_GET_SHUFFLE_DATA_TRANSPORT_LATENCY =
       "grpc_get_local_shuffle_data_transport_latency";
-  private static final String GRPC_GET_IN_MEMORY_SHUFFLE_DATA_TRANSPORT_LATENCY =
-      "grpc_get_in_memory_shuffle_data_transport_latency";
+  private static final String GRPC_GET_MEMORY_SHUFFLE_DATA_TRANSPORT_LATENCY =
+      "grpc_get_memory_shuffle_data_transport_latency";
 
   private static final String GRPC_SEND_SHUFFLE_DATA_PROCESS_LATENCY = "grpc_send_shuffle_data_process_latency";
   private static final String GRPC_GET_SHUFFLE_DATA_PROCESS_LATENCY = "grpc_get_local_shuffle_data_process_latency";
-  private static final String GRPC_GET_IN_MEMORY_SHUFFLE_DATA_PROCESS_LATENCY =
-      "grpc_get_in_memory_shuffle_data_process_latency";
+  private static final String GRPC_GET_MEMORY_SHUFFLE_DATA_PROCESS_LATENCY =
+      "grpc_get_memory_shuffle_data_process_latency";
 
   @Override
   public void registerMetrics() {
@@ -95,8 +95,8 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
         metricsManager.addGauge(GRPC_GET_SHUFFLE_RESULT));
     gaugeMap.putIfAbsent(GET_SHUFFLE_DATA_METHOD,
         metricsManager.addGauge(GRPC_GET_SHUFFLE_DATA));
-    gaugeMap.putIfAbsent(GET_IN_MEMORY_SHUFFLE_DATA_METHOD,
-        metricsManager.addGauge(GRPC_GET_IN_MEMORY_SHUFFLE_DATA));
+    gaugeMap.putIfAbsent(GET_MEMORY_SHUFFLE_DATA_METHOD,
+        metricsManager.addGauge(GRPC_GET_MEMORY_SHUFFLE_DATA));
     gaugeMap.putIfAbsent(GET_SHUFFLE_INDEX_METHOD,
         metricsManager.addGauge(GRPC_GET_SHUFFLE_INDEX));
 
@@ -118,8 +118,8 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
         metricsManager.addCounter(GRPC_GET_SHUFFLE_RESULT_TOTAL));
     counterMap.putIfAbsent(GET_SHUFFLE_DATA_METHOD,
         metricsManager.addCounter(GRPC_GET_SHUFFLE_DATA_TOTAL));
-    counterMap.putIfAbsent(GET_IN_MEMORY_SHUFFLE_DATA_METHOD,
-        metricsManager.addCounter(GRPC_GET_IN_MEMORY_SHUFFLE_DATA_TOTAL));
+    counterMap.putIfAbsent(GET_MEMORY_SHUFFLE_DATA_METHOD,
+        metricsManager.addCounter(GRPC_GET_MEMORY_SHUFFLE_DATA_TOTAL));
     counterMap.putIfAbsent(GET_SHUFFLE_INDEX_METHOD,
         metricsManager.addCounter(GRPC_GET_SHUFFLE_INDEX_TOTAL));
 
@@ -127,15 +127,15 @@ public class ShuffleServerGrpcMetrics extends GRPCMetrics {
         metricsManager.addSummary(GRPC_SEND_SHUFFLE_DATA_TRANSPORT_LATENCY));
     transportTimeSummaryMap.putIfAbsent(GET_SHUFFLE_DATA_METHOD,
         metricsManager.addSummary(GRPC_GET_SHUFFLE_DATA_TRANSPORT_LATENCY));
-    transportTimeSummaryMap.putIfAbsent(GET_IN_MEMORY_SHUFFLE_DATA_METHOD,
-        metricsManager.addSummary(GRPC_GET_IN_MEMORY_SHUFFLE_DATA_TRANSPORT_LATENCY));
+    transportTimeSummaryMap.putIfAbsent(GET_MEMORY_SHUFFLE_DATA_METHOD,
+        metricsManager.addSummary(GRPC_GET_MEMORY_SHUFFLE_DATA_TRANSPORT_LATENCY));
 
     processTimeSummaryMap.putIfAbsent(SEND_SHUFFLE_DATA_METHOD,
         metricsManager.addSummary(GRPC_SEND_SHUFFLE_DATA_PROCESS_LATENCY));
     processTimeSummaryMap.putIfAbsent(GET_SHUFFLE_DATA_METHOD,
         metricsManager.addSummary(GRPC_GET_SHUFFLE_DATA_PROCESS_LATENCY));
-    processTimeSummaryMap.putIfAbsent(GET_IN_MEMORY_SHUFFLE_DATA_METHOD,
-        metricsManager.addSummary(GRPC_GET_IN_MEMORY_SHUFFLE_DATA_PROCESS_LATENCY));
+    processTimeSummaryMap.putIfAbsent(GET_MEMORY_SHUFFLE_DATA_METHOD,
+        metricsManager.addSummary(GRPC_GET_MEMORY_SHUFFLE_DATA_PROCESS_LATENCY));
   }
 
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -639,7 +639,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       long transportTime = System.currentTimeMillis() - timestamp;
       if (transportTime > 0) {
         shuffleServer.getGrpcMetrics().recordTransportTime(
-            ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD, transportTime);
+            ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD, transportTime);
       }
     }
     long start = System.currentTimeMillis();
@@ -664,7 +664,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         }
         long costTime = System.currentTimeMillis() - start;
         shuffleServer.getGrpcMetrics().recordProcessTime(
-            ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD, costTime);
+            ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD, costTime);
         LOG.info("Successfully getInMemoryShuffleData cost {} ms with {} bytes shuffle"
             + " data for {}", costTime, data.length, requestInfo);
 

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerGrpcMetricsTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerGrpcMetricsTest.java
@@ -32,10 +32,10 @@ public class ShuffleServerGrpcMetricsTest {
     metrics.register(new CollectorRegistry(true));
     metrics.recordTransportTime(ShuffleServerGrpcMetrics.SEND_SHUFFLE_DATA_METHOD, 1000);
     metrics.recordTransportTime(ShuffleServerGrpcMetrics.GET_SHUFFLE_DATA_METHOD, 500);
-    metrics.recordTransportTime(ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD, 200);
+    metrics.recordTransportTime(ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD, 200);
     metrics.recordProcessTime(ShuffleServerGrpcMetrics.SEND_SHUFFLE_DATA_METHOD, 1000);
     metrics.recordProcessTime(ShuffleServerGrpcMetrics.GET_SHUFFLE_DATA_METHOD, 500);
-    metrics.recordProcessTime(ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD, 200);
+    metrics.recordProcessTime(ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD, 200);
     Map<String, Summary> sendTimeSummaryTime = metrics.getTransportTimeSummaryMap();
     Map<String, Summary> processTimeSummaryTime = metrics.getProcessTimeSummaryMap();
     assertEquals(3, sendTimeSummaryTime.size());
@@ -46,14 +46,14 @@ public class ShuffleServerGrpcMetricsTest {
     assertEquals(0.5D, sendTimeSummaryTime.get(
         ShuffleServerGrpcMetrics.GET_SHUFFLE_DATA_METHOD).get().sum);
     assertEquals(0.2D, sendTimeSummaryTime.get(
-        ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD).get().sum);
+        ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD).get().sum);
 
     assertEquals(1D, processTimeSummaryTime.get(
         ShuffleServerGrpcMetrics.SEND_SHUFFLE_DATA_METHOD).get().sum);
     assertEquals(0.5D, processTimeSummaryTime.get(
         ShuffleServerGrpcMetrics.GET_SHUFFLE_DATA_METHOD).get().sum);
     assertEquals(0.2D, processTimeSummaryTime.get(
-        ShuffleServerGrpcMetrics.GET_IN_MEMORY_SHUFFLE_DATA_METHOD).get().sum);
+        ShuffleServerGrpcMetrics.GET_MEMORY_SHUFFLE_DATA_METHOD).get().sum);
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix wrong method name.


### Why are the changes needed?
Fix wrong method name cause `grpc_get_in_memory_shuffle_data_total` always 0.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Already exists UT.
