### PR TITLE
[Improvement][LocalOrder] Add tests about keeping consistent with FixedSize when no skew optimization

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
@@ -82,8 +82,9 @@ public class FixedSizeSegmentSplitter implements SegmentSplitter {
         // than the length in the actual data file, and it needs to be returned at this time to avoid EOFException
         if (dataFileLen != -1 && totalLength > dataFileLen) {
           long mask = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
-          LOGGER.warn("Abort inconsistent data, the data length: {}(bytes) recorded in index file is greater than "
-                  + "the real data file length: {}(bytes). Partition id: {}. This should not happen.",
+          LOGGER.info("Abort inconsistent data, the data length: {}(bytes) recorded in index file is greater than "
+                  + "the real data file length: {}(bytes). Partition id: {}. "
+                  + "This may happen when the data is flushing, please ignore.",
               totalLength, dataFileLen, Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask));
           break;
         }

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -109,8 +109,9 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
         // than the length in the actual data file, and it needs to be returned at this time to avoid EOFException
         if (dataFileLen != -1 && totalLen > dataFileLen) {
           long mask = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
-          LOGGER.warn("Abort inconsistent data, the data length: {}(bytes) recorded in index file is greater than "
-                  + "the real data file length: {}(bytes). Partition id: {}. This should not happen.",
+          LOGGER.info("Abort inconsistent data, the data length: {}(bytes) recorded in index file is greater than "
+                  + "the real data file length: {}(bytes). Partition id: {}. This should not happen. "
+                  + "This may happen when the data is flushing, please ignore.",
               totalLen, dataFileLen, Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask));
           break;
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Introduce the data length check in LocalOrder strategy
2. Add tests about keeping consistent with FixedSize Strategy when no skew optimization


### Why are the changes needed?
More stability


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UTs
