### PR TITLE
[ISSUE-342][Improvement] Check Spark Serializer type

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -203,6 +203,7 @@ public class RssShuffleManager implements ShuffleManager {
   // pass that ShuffleHandle to executors (getWriter/getReader).
   @Override
   public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+
     //Spark have three kinds of serializer:
     //org.apache.spark.serializer.JavaSerializer
     //org.apache.spark.sql.execution.UnsafeRowSerializer
@@ -210,9 +211,11 @@ public class RssShuffleManager implements ShuffleManager {
     //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
     //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
     if (!SparkEnv.get().serializer().supportsRelocationOfSerializedObjects()) {
-      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle " + shuffleId + ", because the serializer: " +
-              SparkEnv.get().serializer().getClass().getName() + " does not support object relocation.");
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffleId: " + shuffleId + ", because the"
+              + " serializer: " + SparkEnv.get().serializer().getClass().getName() + " does not support object "
+              + "relocation.");
     }
+
     // If yarn enable retry ApplicationMaster, appId will be not unique and shuffle data will be incorrect,
     // appId + timestamp can avoid such problem,
     // can't get appId in construct because SparkEnv is not created yet,

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -209,9 +209,9 @@ public class RssShuffleManager implements ShuffleManager {
     //org.apache.spark.serializer.KryoSerializer,
     //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
     //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
-    if (!dependency.serializer.supportsRelocationOfSerializedObjects) {
-      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle "+ shuffleId +", because the serializer: " +
-              dependency.serializer.getClass.getName+" does not support object relocation.");
+    if (!SparkEnv.get().serializer().supportsRelocationOfSerializedObjects()) {
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle " + shuffleId + ", because the serializer: " +
+              SparkEnv.get().serializer().getClass().getName() + " does not support object relocation.");
     }
     // If yarn enable retry ApplicationMaster, appId will be not unique and shuffle data will be incorrect,
     // appId + timestamp can avoid such problem,

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -203,6 +203,16 @@ public class RssShuffleManager implements ShuffleManager {
   // pass that ShuffleHandle to executors (getWriter/getReader).
   @Override
   public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+    //Spark have three kinds of serializer:
+    //org.apache.spark.serializer.JavaSerializer
+    //org.apache.spark.sql.execution.UnsafeRowSerializer
+    //org.apache.spark.serializer.KryoSerializer,
+    //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
+    //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
+    if (!dependency.serializer.supportsRelocationOfSerializedObjects) {
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle "+ shuffleId +", because the serializer: " +
+              dependency.serializer.getClass.getName+" does not support object relocation.");
+    }
     // If yarn enable retry ApplicationMaster, appId will be not unique and shuffle data will be incorrect,
     // appId + timestamp can avoid such problem,
     // can't get appId in construct because SparkEnv is not created yet,

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -264,6 +264,7 @@ public class RssShuffleManager implements ShuffleManager {
   // pass that ShuffleHandle to executors (getWriter/getReader)
   @Override
   public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, ShuffleDependency<K, V, C> dependency) {
+
     //Spark have three kinds of serializer:
     //org.apache.spark.serializer.JavaSerializer
     //org.apache.spark.sql.execution.UnsafeRowSerializer
@@ -271,8 +272,9 @@ public class RssShuffleManager implements ShuffleManager {
     //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
     //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
     if (!SparkEnv.get().serializer().supportsRelocationOfSerializedObjects()) {
-      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle " + shuffleId + ", because the serializer: " +
-              SparkEnv.get().serializer().getClass().getName() + " does not support object relocation.");
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffleId: " + shuffleId + ", because the"
+              + " serializer: " + SparkEnv.get().serializer().getClass().getName() + " does not support object "
+              + "relocation.");
     }
 
     if (id.get() == null) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -270,9 +270,9 @@ public class RssShuffleManager implements ShuffleManager {
     //org.apache.spark.serializer.KryoSerializer,
     //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
     //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
-    if (!dependency.serializer.supportsRelocationOfSerializedObjects) {
-      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle "+ shuffleId +", because the serializer: " +
-              dependency.serializer.getClass.getName+" does not support object relocation.");
+    if (!SparkEnv.get().serializer().supportsRelocationOfSerializedObjects()) {
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle " + shuffleId + ", because the serializer: " +
+              SparkEnv.get().serializer().getClass().getName() + " does not support object relocation.");
     }
 
     if (id.get() == null) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -264,6 +264,16 @@ public class RssShuffleManager implements ShuffleManager {
   // pass that ShuffleHandle to executors (getWriter/getReader)
   @Override
   public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, ShuffleDependency<K, V, C> dependency) {
+    //Spark have three kinds of serializer:
+    //org.apache.spark.serializer.JavaSerializer
+    //org.apache.spark.sql.execution.UnsafeRowSerializer
+    //org.apache.spark.serializer.KryoSerializer,
+    //Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.
+    //So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception
+    if (!dependency.serializer.supportsRelocationOfSerializedObjects) {
+      throw new IllegalArgumentException("Can't use serialized shuffle for shuffle "+ shuffleId +", because the serializer: " +
+              dependency.serializer.getClass.getName+" does not support object relocation.");
+    }
 
     if (id.get() == null) {
       id.compareAndSet(null, SparkEnv.get().conf().getAppId() + "_" + System.currentTimeMillis());

--- a/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -55,6 +55,7 @@ public class GetReaderTest extends IntegrationTestBase {
   public void test() throws Exception {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.RssShuffleManager");
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
     sparkConf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), COORDINATOR_QUORUM);
     sparkConf.setMaster("local[4]");
     final String remoteStorage1 = "hdfs://h1/p1";

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -68,6 +68,7 @@ public class GetReaderTest extends IntegrationTestBase {
   public void test() throws Exception {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.RssShuffleManager");
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
     sparkConf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), COORDINATOR_QUORUM);
     sparkConf.setMaster("local[4]");
     final String remoteStorage1 = "hdfs://h1/p1";


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark have multiple serializers. We support the spark serializer which supportsRelocationOfSerializedObjects.
You can see https://github.com/apache/spark/blob/25849684b78cca6651e25d6efc9644a576e7e20f/core/src/main/scala/org/apache/spark/serializer/Serializer.scala#L98

Spark have three kinds of serializer
org.apache.spark.serializer.JavaSerializer
org.apache.spark.sql.execution.UnsafeRowSerializer
org.apache.spark.serializer.KryoSerializer
Only org.apache.spark.serializer.JavaSerializer don't support RelocationOfSerializedObjects.


### Why are the changes needed?
So when we find the parameters to use org.apache.spark.serializer.JavaSerializer, We should throw an exception.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test locally
