### PR TITLE
Add collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,6 +31,10 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: true
+  collaborators:
+    - smallzhongfeng
+    - xianjingfeng
+    - leixm
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub
Projects may assign external (non-committer) collaborators the triage role for their repository.
The triage role allows people to assign, edit, and close issues and pull requests, without giving them write access to the code.

I add active contributors to the collaborators list.

### Why are the changes needed?
It's convenient for the active contributors to manage issues.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No
