### PR TITLE
[BUG][AQE][LocalOrder] Remove check of discontinuous map task ids

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -112,15 +112,15 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           break;
         }
 
-        boolean condition1 =
+        boolean conditionOfDiscontinuousBlocks =
             lastExpectedBlockIndex != -1
                 && bufferSegments.size() > 0
                 && expectTaskIds.contains(taskAttemptId)
                 && index - lastExpectedBlockIndex != 1;
 
-        boolean condition2 = bufferOffset >= readBufferSize;
+        boolean conditionOfLimitedBufferSize = bufferOffset >= readBufferSize;
 
-        if (condition1 || condition2) {
+        if (conditionOfDiscontinuousBlocks || conditionOfLimitedBufferSize) {
           ShuffleDataSegment sds = new ShuffleDataSegment(fileOffset, bufferOffset, bufferSegments);
           dataFileSegments.add(sds);
           bufferSegments = Lists.newArrayList();

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -42,7 +42,7 @@ import org.apache.uniffle.common.util.Constants;
  *
  * This strategy will be useful for Spark AQE skew optimization, it will split the single partition into
  * multiple shuffle readers, and each one will fetch partial single partition data which is in the range of
- * [StartMapId, endMapId). And so if one reader uses this, it will skip lots of unnecessary blocks.
+ * [StartMapIndex, endMapIndex). And so if one reader uses this, it will skip lots of unnecessary blocks.
  *
  * Last but not least, this split strategy depends on LOCAL_ORDER of index file, which must be guaranteed by
  * the shuffle server.
@@ -75,7 +75,6 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
     long fileOffset = -1;
     long totalLen = 0;
 
-    long lastTaskAttemptId = -1;
     long lastExpectedBlockIndex = -1;
 
     List<Long> indexTaskIds = new ArrayList<>();
@@ -83,10 +82,11 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
     /**
      * One ShuffleDataSegment should meet following requirements:
      *
-     * 1. taskId in [startMapId, endMapId) taskIds bitmap
+     * 1. taskId in [startMapIndex, endMapIndex) taskIds bitmap.
+     *    Attention: the index in the range is not the map task id, which means the required task ids are not
+     *               continuous.
      * 2. ShuffleDataSegment size should < readBufferSize
-     * 3. ShuffleDataSegment's blocks should be continuous
-     *
+     * 3. Single shuffleDataSegment's blocks should be continuous
      */
     int index = 0;
     while (byteBuffer.hasRemaining()) {
@@ -101,10 +101,6 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
         totalLen += length;
         indexTaskIds.add(taskAttemptId);
 
-        if (lastTaskAttemptId == -1) {
-          lastTaskAttemptId = taskAttemptId;
-        }
-
         // If ShuffleServer is flushing the file at this time, the length in the index file record may be greater
         // than the length in the actual data file, and it needs to be returned at this time to avoid EOFException
         if (dataFileLen != -1 && totalLen > dataFileLen) {
@@ -116,10 +112,15 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           break;
         }
 
-        if ((taskAttemptId < lastTaskAttemptId
-            && bufferSegments.size() > 0
-            && (expectTaskIds.contains(taskAttemptId) ? index - lastExpectedBlockIndex != 1 : true))
-            || bufferOffset >= readBufferSize) {
+        boolean condition1 =
+            lastExpectedBlockIndex != -1
+                && bufferSegments.size() > 0
+                && expectTaskIds.contains(taskAttemptId)
+                && index - lastExpectedBlockIndex != 1;
+
+        boolean condition2 = bufferOffset >= readBufferSize;
+
+        if (condition1 || condition2) {
           ShuffleDataSegment sds = new ShuffleDataSegment(fileOffset, bufferOffset, bufferSegments);
           dataFileSegments.add(sds);
           bufferSegments = Lists.newArrayList();
@@ -128,14 +129,6 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
         }
 
         if (expectTaskIds.contains(taskAttemptId)) {
-          if (bufferOffset != 0 && index - lastExpectedBlockIndex > 1) {
-            List<Long> expectedTaskIds = getExpectedTaskIds(expectTaskIds);
-            LOGGER.error("There are discontinuous blocks, all task ids in index file: {}, all expected task ids: {}, "
-                    + "current expected task id: {}, last unexpected task id: {}, current data segment size: {}",
-                indexTaskIds, expectedTaskIds, taskAttemptId, lastTaskAttemptId, dataFileSegments.size());
-            throw new RssException("There are discontinuous blocks which should not happen when using LOCAL_ORDER.");
-          }
-
           if (fileOffset == -1) {
             fileOffset = offset;
           }
@@ -143,8 +136,6 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           bufferOffset += length;
           lastExpectedBlockIndex = index;
         }
-
-        lastTaskAttemptId = taskAttemptId;
         index++;
       } catch (BufferUnderflowException ue) {
         throw new RssException("Read index data under flow", ue);
@@ -154,6 +145,11 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
     if (bufferOffset > 0) {
       ShuffleDataSegment sds = new ShuffleDataSegment(fileOffset, bufferOffset, bufferSegments);
       dataFileSegments.add(sds);
+    }
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Index file task-ids sequence: {}, expected task-ids: {}",
+          indexTaskIds, getExpectedTaskIds(expectTaskIds));
     }
     return dataFileSegments;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Remove check of discontinuous map task ids

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the [startMapIndex, endMapIndex) sequence, the index is not the map task id, which only indicate the range of the succeed map task ids set. 

So that means. if the range is [0, 5), it only indicate the number of tasks is 5. And the task id list may be as follows:

`[task-1, task-3, task-9, task-15, task-16]`


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1. UTs