### PR TITLE
[ISSUE-228] Fix the problem of protobuf-java incorrect dependency at compile time

### DIFF
--- a/client-spark/spark3/pom.xml
+++ b/client-spark/spark3/pom.xml
@@ -35,6 +35,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. We specified the version number of `protobuf-java` in the `client-spark/spark3/pom.xml` file.

### Why are the changes needed?
More reasonable. https://github.com/apache/incubator-uniffle/issues/228

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
We compiled in the test environment and verified the correctness of the `rss-client-spark3-0.6.0-shaded.jar` package.