### PR TITLE
[MINOR]  If there is no data flush to hdfs, return directly instead of throw exception

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -119,8 +119,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
             file -> file.getName().endsWith(Constants.SHUFFLE_INDEX_FILE_SUFFIX)
                 && (shuffleServerId == null || file.getName().startsWith(shuffleServerId)));
       } else {
-        LOG.info("Directory[" + baseFolder +
-            "] not found. The data may not be flushed to this directory. Nothing will be read.");
+        LOG.info("Directory[" + baseFolder
+            + "] not found. The data may not be flushed to this directory. Nothing will be read.");
         return;
       }
     } catch (Exception e) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -110,15 +110,21 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
       throw new RuntimeException("Can't get FileSystem for " + baseFolder);
     }
 
-    FileStatus[] indexFiles;
-    String failedGetIndexFileMsg = "Can't list index file in  " + baseFolder;
+    FileStatus[] indexFiles = null;
 
     try {
       // get all index files
-      indexFiles = fs.listStatus(baseFolder,
-          file -> file.getName().endsWith(Constants.SHUFFLE_INDEX_FILE_SUFFIX)
-              && (shuffleServerId == null || file.getName().startsWith(shuffleServerId)));
+      if (fs.exists(baseFolder)) {
+        indexFiles = fs.listStatus(baseFolder,
+            file -> file.getName().endsWith(Constants.SHUFFLE_INDEX_FILE_SUFFIX)
+                && (shuffleServerId == null || file.getName().startsWith(shuffleServerId)));
+      } else {
+        LOG.info("Directory[" + baseFolder +
+            "] not found. The data may not be flushed to this directory. Nothing will be read.");
+        return;
+      }
     } catch (Exception e) {
+      String failedGetIndexFileMsg = "Can't list index file in  " + baseFolder;
       LOG.error(failedGetIndexFileMsg, e);
       return;
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
If there is no data flush to hdfs, return directly instead of throw exception as follow:

```shell
22/12/12 17:03:34 ERROR HdfsClientReadHandler: Can't list index file in  hdfs://xxx/application_1668750926041_8177885_1670835601240/0/155-155
java.io.FileNotFoundException: File hdfs://xxx/application_1668750926041_8177885_1670835601240/0/155-155 does not exist.
	at org.apache.hadoop.hdfs.DistributedFileSystem.listStatusInternal(DistributedFileSystem.java:795)
	at org.apache.hadoop.hdfs.DistributedFileSystem.access$700(DistributedFileSystem.java:106)
	at org.apache.hadoop.hdfs.DistributedFileSystem$18.doCall(DistributedFileSystem.java:853)
	at org.apache.hadoop.hdfs.DistributedFileSystem$18.doCall(DistributedFileSystem.java:849)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.listStatus(DistributedFileSystem.java:860)
	at org.apache.hadoop.fs.FileSystem.listStatus(FileSystem.java:1517)
	at org.apache.hadoop.fs.FileSystem.listStatus(FileSystem.java:1557)
	at org.apache.uniffle.storage.handler.impl.HdfsClientReadHandler.init(HdfsClientReadHandler.java:118)
	at org.apache.uniffle.storage.handler.impl.HdfsClientReadHandler.readShuffleData(HdfsClientReadHandler.java:152)
	at org.apache.uniffle.storage.handler.impl.ComposedClientReadHandler.readShuffleData(ComposedClientReadHandler.java:93)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
More friendly, and may become a bug in the future

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No need