### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@
 Uniffle is a unified remote shuffle service for compute engines.
 It provides the ability to aggregate and store shuffle data on remote servers,
 thus improving the performance and reliability of large jobs.
-Currently it supports [Apache Spark](https://spark.apache.org) and [MapReduce](https://hadoop.apache.org).
+Currently it supports [Apache Spark](https://spark.apache.org) and [Apache Hadoop MapReduce](https://hadoop.apache.org).
 
 [![Build](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml/badge.svg?branch=master&event=push)](https://github.com/apache/incubator-uniffle/actions/workflows/build.yml)
 [![Codecov](https://codecov.io/gh/apache/incubator-uniffle/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-uniffle)
-[![](https://sloc.xyz/github/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle)
 [![License](https://img.shields.io/github/license/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/v/release/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/releases)
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Currently it supports [Apache Spark](https://spark.apache.org) and [Apache Hadoo
 ![Rss Architecture](docs/asset/rss_architecture.png)
 Uniffle contains coordinator cluster, shuffle server cluster and remote storage(eg, HDFS) if necessary.
 
-Coordinator will collect status of shuffle server and do the assignment for the job.
+Coordinator will collect the status of the shuffle server and do the assignment for the job.
 
 Shuffle server will receive the shuffle data, merge them and write to storage.
 
-Depend on different situation, Uniffle supports Memory & Local, Memory & Remote Storage(eg, HDFS), Memory & Local & Remote Storage(recommendation for production environment).
+Depending on different situations, Uniffle supports Memory & Local, Memory & Remote Storage(eg, HDFS), Memory & Local & Remote Storage(recommendation for production environment).
 
 ## Shuffle Process with Uniffle
 
@@ -52,20 +52,20 @@ Depend on different situation, Uniffle supports Memory & Local, Memory & Remote 
    8. After write data, task report all blockId to shuffle server, this step is used for data validation later
    9. Store taskAttemptId in MapStatus to support Spark speculation
 
-* Depend on different storage type, spark task read shuffle data from shuffle server or remote storage or both of them.
+* Depending on different storage types, the spark task reads shuffle data from shuffle server or remote storage or both of them.
 
 ## Shuffle file format
-The shuffle data is stored with index file and data file. Data file has all blocks for specific partition and index file has metadata for every block.
+The shuffle data is stored with index file and data file. Data file has all blocks for a specific partition and the index file has metadata for every block.
 
 ![Rss Shuffle_Write](docs/asset/rss_data_format.png)
 
 ## Supported Spark Version
-Current support Spark 2.3.x, Spark 2.4.x, Spark3.0.x, Spark 3.1.x, Spark 3.2.x
+Currently supports Spark 2.3.x, Spark 2.4.x, Spark 3.0.x, Spark 3.1.x, Spark 3.2.x
 
 Note: To support dynamic allocation, the patch(which is included in client-spark/patch folder) should be applied to Spark
 
 ## Supported MapReduce Version
-Current support Hadoop 2.8.5's MapReduce framework.
+Currently supports Hadoop 2.8.5's MapReduce framework.
 
 ## Building Uniffle
 > note: currently Uniffle requires JDK 1.8 to build, adding later JDK support is on our roadmap.
@@ -75,11 +75,11 @@ To build it, run:
 
     mvn -DskipTests clean package
 
-Build against profile Spark2(2.4.6)
+Build against profile Spark 2 (2.4.6)
 
     mvn -DskipTests clean package -Pspark2
 
-Build against profile Spark3(3.1.2)
+Build against profile Spark 3 (3.1.2)
 
     mvn -DskipTests clean package -Pspark3
 
@@ -132,7 +132,7 @@ rss-xxx.tgz will be generated for deployment
    ```
 4. update <RSS_HOME>/conf/dynamic_client.conf, rss client will get default conf from coordinator eg,
    ```
-    # MEMORY_LOCALFILE_HDFS is recommandation for production environment
+    # MEMORY_LOCALFILE_HDFS is recommended for production environment
     rss.storage.type MEMORY_LOCALFILE_HDFS
     # multiple remote storages are supported, and client will get assignment from coordinator
     rss.coordinator.remote.storage.path hdfs://cluster1/path,hdfs://cluster2/path
@@ -160,7 +160,7 @@ rss-xxx.tgz will be generated for deployment
      rss.rpc.server.port 19999
      rss.jetty.http.port 19998
      rss.rpc.executor.size 2000
-     # it should be configed the same as in coordinator
+     # it should be configured the same as in coordinator
      rss.storage.type MEMORY_LOCALFILE_HDFS
      rss.coordinator.quorum <coordinatorIp1>:19999,<coordinatorIp2>:19999
      # local storage path for shuffle server
@@ -178,7 +178,7 @@ rss-xxx.tgz will be generated for deployment
      rss.server.app.expired.withoutHeartbeat 120000
      # note: the default value of rss.server.flush.cold.storage.threshold.size is 64m
      # there will be no data written to DFS if set it as 100g even rss.storage.type=MEMORY_LOCALFILE_HDFS
-     # please set proper value if DFS is used, eg, 64m, 128m.
+     # please set a proper value if DFS is used, eg, 64m, 128m.
      rss.server.flush.cold.storage.threshold.size 100g
    ```
 4. start Shuffle Server
@@ -231,7 +231,7 @@ and job recovery (i.e., `yarn.app.mapreduce.am.job.recovery.enable=false`)
 
 ### Deploy In Kubernetes
 
-We have provided operator of uniffle used for deploying it in kubernetes environments.
+We have provided an operator for deploying uniffle in kubernetes environments.
 
 For details, see the following document:
 
@@ -239,7 +239,7 @@ For details, see the following document:
 
 ## Configuration
 
-The important configuration is listed as following.
+The important configuration is listed as follows.
 
 |Role|Link|
 |---|---|

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Depending on different situations, Uniffle supports Memory & Local, Memory & Rem
    8. After write data, task report all blockId to shuffle server, this step is used for data validation later
    9. Store taskAttemptId in MapStatus to support Spark speculation
 
-* Depending on different storage types, the spark task reads shuffle data from shuffle server or remote storage or both of them.
+* Depending on different storage types, the spark task will read shuffle data from shuffle server or remote storage or both of them.
 
 ## Shuffle file format
 The shuffle data is stored with index file and data file. Data file has all blocks for a specific partition and the index file has metadata for every block.
@@ -65,7 +65,7 @@ Currently supports Spark 2.3.x, Spark 2.4.x, Spark 3.0.x, Spark 3.1.x, Spark 3.2
 Note: To support dynamic allocation, the patch(which is included in client-spark/patch folder) should be applied to Spark
 
 ## Supported MapReduce Version
-Currently supports Hadoop 2.8.5's MapReduce framework.
+Currently supports the MapReduce framework of Hadoop 2.8.5
 
 ## Building Uniffle
 > note: currently Uniffle requires JDK 1.8 to build, adding later JDK support is on our roadmap.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # Apache Uniffle (Incubating)
 
-Uniffle is a unified remote shuffle service for compute engines.
+Uniffle is a unified remote shuffle service for distributed compute engines.
 It provides the ability to aggregate and store shuffle data on remote servers,
 thus improving the performance and reliability of large jobs.
 Currently it supports [Apache Spark](https://spark.apache.org) and [Apache Hadoop MapReduce](https://hadoop.apache.org).

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Currently it supports [Apache Spark](https://spark.apache.org) and [Apache Hadoo
 
 ## Architecture
 ![Rss Architecture](docs/asset/rss_architecture.png)
-Uniffle contains coordinator cluster, shuffle server cluster and remote storage(eg, HDFS) if necessary.
+Uniffle contains coordinator cluster, shuffle server cluster and remote storage(e.g., HDFS) if necessary.
 
 Coordinator will collect the status of the shuffle server and do the assignment for the job.
 
 Shuffle server will receive the shuffle data, merge them and write to storage.
 
-Depending on different situations, Uniffle supports Memory & Local, Memory & Remote Storage(eg, HDFS), Memory & Local & Remote Storage(recommendation for production environment).
+Depending on different situations, Uniffle supports Memory & Local, Memory & Remote Storage(e.g., HDFS), Memory & Local & Remote Storage(recommendation for production environment).
 
 ## Shuffle Process with Uniffle
 
@@ -110,13 +110,13 @@ rss-xxx.tgz will be generated for deployment
 ### Deploy Coordinator
 
 1. unzip package to RSS_HOME
-2. update RSS_HOME/bin/rss-env.sh, eg,
+2. update RSS_HOME/bin/rss-env.sh, e.g.,
    ```
      JAVA_HOME=<java_home>
      HADOOP_HOME=<hadoop home>
      XMX_SIZE="16g"
    ```
-3. update RSS_HOME/conf/coordinator.conf, eg,
+3. update RSS_HOME/conf/coordinator.conf, e.g.,
    ```
      rss.rpc.server.port 19999
      rss.jetty.http.port 19998
@@ -130,7 +130,7 @@ rss-xxx.tgz will be generated for deployment
      # config the path of excluded shuffle server
      rss.coordinator.exclude.nodes.file.path <RSS_HOME>/conf/exclude_nodes
    ```
-4. update <RSS_HOME>/conf/dynamic_client.conf, rss client will get default conf from coordinator eg,
+4. update <RSS_HOME>/conf/dynamic_client.conf, rss client will get default conf from coordinator e.g.,
    ```
     # MEMORY_LOCALFILE_HDFS is recommended for production environment
     rss.storage.type MEMORY_LOCALFILE_HDFS
@@ -149,13 +149,13 @@ rss-xxx.tgz will be generated for deployment
 ### Deploy Shuffle Server
 
 1. unzip package to RSS_HOME
-2. update RSS_HOME/bin/rss-env.sh, eg,
+2. update RSS_HOME/bin/rss-env.sh, e.g.,
    ```
      JAVA_HOME=<java_home>
      HADOOP_HOME=<hadoop home>
      XMX_SIZE="80g"
    ```
-3. update RSS_HOME/conf/server.conf, eg,
+3. update RSS_HOME/conf/server.conf, e.g.,
    ```
      rss.rpc.server.port 19999
      rss.jetty.http.port 19998
@@ -178,7 +178,7 @@ rss-xxx.tgz will be generated for deployment
      rss.server.app.expired.withoutHeartbeat 120000
      # note: the default value of rss.server.flush.cold.storage.threshold.size is 64m
      # there will be no data written to DFS if set it as 100g even rss.storage.type=MEMORY_LOCALFILE_HDFS
-     # please set a proper value if DFS is used, eg, 64m, 128m.
+     # please set a proper value if DFS is used, e.g., 64m, 128m.
      rss.server.flush.cold.storage.threshold.size 100g
    ```
 4. start Shuffle Server
@@ -187,13 +187,13 @@ rss-xxx.tgz will be generated for deployment
    ```
 
 ### Deploy Spark Client
-1. Add client jar to Spark classpath, eg, SPARK_HOME/jars/
+1. Add client jar to Spark classpath, e.g., SPARK_HOME/jars/
 
    The jar for Spark2 is located in <RSS_HOME>/jars/client/spark2/rss-client-XXXXX-shaded.jar
 
    The jar for Spark3 is located in <RSS_HOME>/jars/client/spark3/rss-client-XXXXX-shaded.jar
 
-2. Update Spark conf to enable Uniffle, eg,
+2. Update Spark conf to enable Uniffle, e.g.,
 
    ```
    spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
@@ -218,7 +218,7 @@ After apply the patch and rebuild spark, add following configuration in spark co
 
 The jar for MapReduce is located in <RSS_HOME>/jars/client/mr/rss-client-mr-XXXXX-shaded.jar
 
-2. Update MapReduce conf to enable Uniffle, eg,
+2. Update MapReduce conf to enable Uniffle, e.g.,
 
    ```
    -Dmapreduce.rss.coordinator.quorum=<coordinatorIp1>:19999,<coordinatorIp2>:19999

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Currently it supports [Apache Spark](https://spark.apache.org) and [Apache Hadoo
 
 ## Architecture
 ![Rss Architecture](docs/asset/rss_architecture.png)
-Uniffle contains coordinator cluster, shuffle server cluster and remote storage(e.g., HDFS) if necessary.
+Uniffle cluster consists of three components, a coordinator cluster, a shuffle server cluster and an optional remote storage (e.g., HDFS).
 
-Coordinator will collect the status of the shuffle server and do the assignment for the job.
+Coordinator will collect the status of shuffle servers and assign jobs based on some strategy.
 
 Shuffle server will receive the shuffle data, merge them and write to storage.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Update the introduction section in README:
    * "compute engines" is changed to "distributed compute engines".
    * "MapReduce" is changed to "Apache Hadoop MapReduce".
    * Remove the "Total lines" badge, see [OSSInsight][1] for better insight.
2. Fix typos.

[1]: https://ossinsight.io/analyze/apache/incubator-uniffle#lines-of-code-changed "apache/incubator-uniffle | OSSInsight"

### Why are the changes needed?

Improve the README.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Preview: https://github.com/kaijchen/incubator-uniffle/tree/readme#apache-uniffle-incubating

