### PR TITLE
[Minor] Move GrpcServerTest to common.rpc package

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.common;
+package org.apache.uniffle.common.rpc;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.metrics.GRPCMetrics;
-import org.apache.uniffle.common.rpc.GrpcServer;
 import org.apache.uniffle.common.util.ThreadUtils;
 
 import static org.apache.uniffle.common.metrics.GRPCMetrics.GRPC_SERVER_EXECUTOR_ACTIVE_THREADS_KEY;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move GrpcServerTest to common.rpc package.

### Why are the changes needed?

GrpcServer is in common.rpc package.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.
