### PR TITLE
[Improvement] Refactor getPartitionRange to calculate range directly

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
@@ -167,15 +167,11 @@ public class ShuffleStorageUtils {
 
   public static int[] getPartitionRange(int partitionId, int partitionNumPerRange, int partitionNum) {
     int[] range = null;
-    int prNum = partitionNum % partitionNumPerRange == 0
-        ? partitionNum / partitionNumPerRange : partitionNum / partitionNumPerRange + 1;
-    for (int i = 0; i < prNum; i++) {
-      int start = i * partitionNumPerRange;
-      int end = (i + 1) * partitionNumPerRange - 1;
-      if (partitionId >= start && partitionId <= end) {
-        range = new int[]{start, end};
-        break;
-      }
+    int prNum = (partitionId < partitionNumPerRange || partitionId % partitionNumPerRange == 0) ? partitionId / partitionNumPerRange : partitionId / partitionNumPerRange + 1;
+    if (partitionId < 0 || partitionId > partitionNum) {
+      LOG.warn("Invalid partitionId. partitionId:{} ,partitionNumPerRange: {}, partitionNum: {}", partitionId, partitionNumPerRange, partitionNum);
+    } else {
+      range = new int[]{partitionNumPerRange * prNum, partitionNumPerRange * (prNum + 1) - 1};
     }
     return range;
   }

--- a/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleStorageUtilsTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleStorageUtilsTest.java
@@ -266,5 +266,9 @@ public class ShuffleStorageUtilsTest {
     range = ShuffleStorageUtils.getPartitionRange(2, 3, 5);
     assertEquals(0, range[0]);
     assertEquals(2, range[1]);
+    range = ShuffleStorageUtils.getPartitionRange(-1, 3, 5);
+    assertEquals(null, range);
+    range = ShuffleStorageUtils.getPartitionRange(1, 3, 0);
+    assertEquals(null, range);
   }
 }


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
 1. Refactor ShuffleStorageUtils.getPartitionRange to calculate range directly.
 2. The runtime of the function will be O(1) as opposed to O(n) in the original implementation.

### Why are the changes needed?
For issue #443 
The current implementation of ShuffleStorageUtils.getPartitionRange is O(n) which is not performant and can be done in O(1) by directly computing it using the partionId.

 ### Does this PR introduce _any_ user-facing change?
 No

 ### How was this patch tested?
 1. existing UTs + new UTs

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
