### PR TITLE
Fix Flaky Test: AppBalanceSelectStorageStrategyTest#selectStorageTest

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
@@ -61,6 +61,7 @@ public class ApplicationManager {
   private final Map<String, RankValue> remoteStoragePathRankValue;
   private final Map<String, String> remoteStorageToHost = Maps.newConcurrentMap();
   private final Map<String, RemoteStorageInfo> availableRemoteStorageInfo;
+  private final ScheduledExecutorService detectStorageScheduler;
   private Map<String, Map<String, Long>> currentUserAndApp = Maps.newConcurrentMap();
   private Map<String, String> appIdToUser = Maps.newConcurrentMap();
   private QuotaManager quotaManager;
@@ -97,7 +98,7 @@ public class ApplicationManager {
     scheduledExecutorService.scheduleAtFixedRate(
         this::statusCheck, expired / 2, expired / 2, TimeUnit.MILLISECONDS);
     // the thread for checking if the storage is normal
-    ScheduledExecutorService detectStorageScheduler = Executors.newSingleThreadScheduledExecutor(
+    detectStorageScheduler = Executors.newSingleThreadScheduledExecutor(
         ThreadUtils.getThreadFactory("detectStoragesScheduler-%d"));
     // should init later than the refreshRemoteStorage init
     detectStorageScheduler.scheduleAtFixedRate(selectStorageStrategy::detectStorage, 1000,
@@ -253,6 +254,12 @@ public class ApplicationManager {
   @VisibleForTesting
   public boolean hasErrorInStatusCheck() {
     return hasErrorInStatusCheck;
+  }
+
+  @VisibleForTesting
+  public void closeDetectStorageScheduler() {
+    // this method can only be used during testing
+    detectStorageScheduler.shutdownNow();
   }
 
   private void statusCheck() {

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategyTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategyTest.java
@@ -58,12 +58,15 @@ public class AppBalanceSelectStorageStrategyTest {
     conf.set(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_SELECT_STRATEGY, APP_BALANCE);
     conf.setLong(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_SCHEDULE_TIME, 1000);
     applicationManager = new ApplicationManager(conf);
+    // to ensure that the reading and writing of hdfs can be controlled
+    applicationManager.closeDetectStorageScheduler();
   }
 
   @Test
   public void selectStorageTest() throws Exception {
     String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
     applicationManager.refreshRemoteStorage(remoteStoragePath, "");
+    applicationManager.getSelectStorageStrategy().detectStorage();
     assertEquals(0, applicationManager.getRemoteStoragePathRankValue().get(remotePath1).getAppNum().get());
     assertEquals(0, applicationManager.getRemoteStoragePathRankValue().get(remotePath2).getAppNum().get());
     String storageHost1 = "path1";
@@ -123,6 +126,7 @@ public class AppBalanceSelectStorageStrategyTest {
     String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2
         + Constants.COMMA_SPLIT_CHAR + remotePath3;
     applicationManager.refreshRemoteStorage(remoteStoragePath, "");
+    applicationManager.getSelectStorageStrategy().detectStorage();
     String testApp1 = "application_testAppId";
     // init detectStorageScheduler
     Thread.sleep(2000);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When testing, close the scheduler thread detectStorageScheduler.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When testing, in order to ensure that multiple paths are normal, the method of manually scheduling `detectStorage` is used.
```
applicationManager.getRemoteStoragePathRankValue().get(remotePath1).getCostTime().set(0);
applicationManager.getRemoteStoragePathRankValue().get(remotePath2).getCostTime().set(0); 
```
The original repair may still fail to write the hdfs file later.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
origin uts.