### PR TITLE
[ISSUE-451][Improvement] Read HDFS data files with random sequence to distribute pressure

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -144,6 +145,9 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
         }
       }
       Collections.shuffle(readHandlers);
+      LOG.info("Reading order of HDFS files with name prefix: {}",
+          readHandlers.stream().map(x -> x.filePrefix).collect(Collectors.toList())
+      );
     }
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandler.java
@@ -18,7 +18,7 @@
 package org.apache.uniffle.storage.handler.impl;
 
 import java.io.FileNotFoundException;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -143,7 +143,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
           LOG.warn("Can't create ShuffleReaderHandler for " + filePrefix, e);
         }
       }
-      readHandlers.sort(Comparator.comparing(HdfsShuffleReadHandler::getFilePrefix));
+      Collections.shuffle(readHandlers);
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
[Improvement] Read HDFS data files with random sequence to distribute pressure #452

### Why are the changes needed?
In PR https://github.com/apache/incubator-uniffle/pull/396 to support concurrently writing single partition's data into multiple HDFS files, it's better to randomly read HDFS data files to distribute stress in client side.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Existing UTs