### PR TITLE
Bound underlying concrete storage manager into event self

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.server.buffer.ShuffleBuffer;
+import org.apache.uniffle.server.storage.StorageManager;
 import org.apache.uniffle.storage.common.Storage;
 
 public class ShuffleDataFlushEvent {
@@ -44,7 +45,8 @@ public class ShuffleDataFlushEvent {
   private final AtomicInteger retryTimes = new AtomicInteger();
 
   private boolean isPended = false;
-  private Storage underStorage;
+  private StorageManager underlyingStorageManager;
+  private Storage underlyingStorage;
   private final List<Runnable> cleanupCallbackChains;
 
   public ShuffleDataFlushEvent(
@@ -124,12 +126,20 @@ public class ShuffleDataFlushEvent {
     isPended = true;
   }
 
-  public Storage getUnderStorage() {
-    return underStorage;
+  public StorageManager getUnderlyingStorageManager() {
+    return underlyingStorageManager;
   }
 
-  public void setUnderStorage(Storage underStorage) {
-    this.underStorage = underStorage;
+  public void setUnderlyingStorageManager(StorageManager underlyingStorageManager) {
+    this.underlyingStorageManager = underlyingStorageManager;
+  }
+
+  public Storage getUnderlyingStorage() {
+    return underlyingStorage;
+  }
+
+  public void setUnderlyingStorage(Storage underlyingStorage) {
+    this.underlyingStorage = underlyingStorage;
   }
 
   public boolean doCleanup() {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -224,8 +224,8 @@ public class ShuffleFlushManager {
 
     if (event.getRetryTimes() > retryMax) {
       LOG.error("Failed to write data for {} in {} times, shuffle data will be lost", event, retryMax);
-      if (event.getUnderStorage() != null) {
-        ShuffleServerMetrics.incStorageFailedCounter(event.getUnderStorage().getStorageHost());
+      if (event.getUnderlyingStorage() != null) {
+        ShuffleServerMetrics.incStorageFailedCounter(event.getUnderlyingStorage().getStorageHost());
       }
     }
 

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -71,7 +71,7 @@ public class HdfsStorageManager extends SingleStorageManager {
   @Override
   public Storage selectStorage(ShuffleDataFlushEvent event) {
     Storage storage = getStorageByAppId(event.getAppId());
-    event.setUnderStorage(storage);
+    event.setUnderlyingStorage(storage);
     return storage;
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -177,7 +177,7 @@ public class LocalStorageManager extends SingleStorageManager {
           // If this is the first time to select storage or existing storage is corrupted,
           // we should refresh the cache.
           if (localStorage == null || localStorage.isCorrupted()) {
-            event.setUnderStorage(selectedStorage);
+            event.setUnderlyingStorage(selectedStorage);
             return selectedStorage;
           }
           return localStorage;

--- a/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
@@ -104,7 +104,7 @@ public abstract class SingleStorageManager implements StorageManager {
       } else {
         ShuffleServerMetrics.counterEventSizeThresholdLevel4.inc();
       }
-      Storage storage = event.getUnderStorage();
+      Storage storage = event.getUnderlyingStorage();
       if (storage != null) {
         storage.updateWriteMetrics(metrics);
       }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -491,13 +491,13 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     ShuffleDataFlushEvent event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
     Thread.sleep(1000);
-    assertTrue(event.getUnderStorage() instanceof LocalStorage);
+    assertTrue(event.getUnderlyingStorage() instanceof LocalStorage);
 
     // case2: huge event is written to cold storage directly
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100000);
     flushManager.addToFlushQueue(event);
     Thread.sleep(1000);
-    assertTrue(event.getUnderStorage() instanceof HdfsStorage);
+    assertTrue(event.getUnderlyingStorage() instanceof HdfsStorage);
     assertEquals(0, event.getRetryTimes());
 
     // case3: local disk is full or corrupted, fallback to HDFS
@@ -505,13 +505,13 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
         new ShufflePartitionedBlock(100000, 1000, 1, 1, 1L, null)
     );
     ShuffleDataFlushEvent bigEvent = new ShuffleDataFlushEvent(1, "1", 1, 1, 1, 100, blocks, null, null);
-    bigEvent.setUnderStorage(((MultiStorageManager)storageManager).getWarmStorageManager().selectStorage(event));
+    bigEvent.setUnderlyingStorage(((MultiStorageManager)storageManager).getWarmStorageManager().selectStorage(event));
     ((MultiStorageManager)storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
     Thread.sleep(1000);
-    assertTrue(event.getUnderStorage() instanceof HdfsStorage);
+    assertTrue(event.getUnderlyingStorage() instanceof HdfsStorage);
     assertEquals(1, event.getRetryTimes());
   }
 
@@ -537,7 +537,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
 
       List<ShufflePartitionedBlock> blocks = Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, null));
       ShuffleDataFlushEvent bigEvent = new ShuffleDataFlushEvent(1, "1", 1, 1, 1, 100, blocks, null, null);
-      bigEvent.setUnderStorage(storageManager.selectStorage(event));
+      bigEvent.setUnderlyingStorage(storageManager.selectStorage(event));
       storageManager.updateWriteMetrics(bigEvent, 0);
 
       manager.addPendingEvents(event);


### PR DESCRIPTION

### What changes were proposed in this pull request?
Bound underlying concrete storage manager into event self

### Why are the changes needed?

1. Remove the cache to reduce the shuffle-server's state of storage manager
2. The concrete underlying storage manager should be bound to event self, whose lifecycle will be more clear.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
Existing UTs
