### PR TITLE
[Deps] Bump slf4j to fix vulnerability in slf4j-log4j12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <roaring.bitmap.version>0.9.15</roaring.bitmap.version>
     <rss.shade.packageName>org.apache.uniffle</rss.shade.packageName>
     <skipDeploy>false</skipDeploy>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <spotbugs.version>4.7.0</spotbugs.version>
     <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
     <system-rules.version>1.19.0</system-rules.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump slf4j to 1.7.36 to fix vulnerability in slf4j-log4j12.

### Why are the changes needed?

slf4j-log4j12:1.7.25 provides transitive vulnerable dependency log4j:1.2.17

* CVE-2019-17571 9.8 Deserialization of Untrusted Data vulnerability pending CVSS allocation
* CVE-2021-4104 7.5 Deserialization of Untrusted Data vulnerability with medium severity found
* CVE-2022-23302 8.8 Deserialization of Untrusted Data vulnerability pending CVSS allocation
* CVE-2022-23305 9.8 Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') vulnerability pending CVSS allocation
* CVE-2022-23307 8.8 Deserialization of Untrusted Data vulnerability pending CVSS allocation

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.