### PR TITLE
[ISSUE-378][HugePartition][Part-2] Introduce memory usage limit and data flush

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/TripleFunction.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/TripleFunction.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+@FunctionalInterface
+public interface TripleFunction<T, U, E, R> {
+
+  R accept(T t, U u, E e);
+
+}

--- a/docs/server_guide.md
+++ b/docs/server_guide.md
@@ -86,6 +86,8 @@ This document will introduce how to deploy Uniffle shuffle servers.
 |rss.server.leak.shuffledata.check.interval|3600000|The interval of leak shuffle data check (ms)|
 |rss.server.max.concurrency.of.single.partition.writer|1|The max concurrency of single partition writer, the data partition file number is equal to this value. Default value is 1. This config could improve the writing speed, especially for huge partition.|
 |rss.metrics.reporter.class|-|The class of metrics reporter.|
+|rss.server.huge-partition.size.threshold|20g|Threshold of huge partition size, once exceeding threshold, memory usage limitation and huge partition buffer flushing will be triggered.|
+|rss.server.huge-partition.memory.limit.ratio|0.2|The memory usage limit ratio for huge partition, it will only triggered when partition's size exceeds the threshold of 'rss.server.huge-partition.size.threshold'|
 
 ### Advanced Configurations
 |Property Name|Default| Description                                                                                                                                                                                 |

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -51,6 +51,9 @@ message FinishShuffleResponse {
 
 message RequireBufferRequest {
   int32 requireSize = 1;
+  string appId = 2;
+  int32 shuffleId = 3;
+  repeated int32 partitionIds = 4;
 }
 
 message RequireBufferResponse {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -356,13 +356,6 @@ public class ShuffleServerConf extends RssBaseConf {
       .withDescription("The memory usage limit ratio for huge partition, it will only triggered when partition's "
           + "size exceeds the threshold of '" + HUGE_PARTITION_SIZE_THRESHOLD.key() + "'");
 
-  public static final ConfigOption<Long> HUGE_PARTITION_BUFFER_FLUSH_THRESHOLD = ConfigOptions
-      .key("rss.server.huge-partition.buffer.flush.threshold")
-      .longType()
-      .defaultValue(128 * 1024 * 1024L)
-      .withDescription("The single buffer flush threshold for huge partition, it will only triggered when partition's "
-          + "size exceeds the threshold of '" + HUGE_PARTITION_SIZE_THRESHOLD.key() + "'");
-
   public ShuffleServerConf() {
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -356,6 +356,13 @@ public class ShuffleServerConf extends RssBaseConf {
       .withDescription("The memory usage limit ratio for huge partition, it will only triggered when partition's "
           + "size exceeds the threshold of '" + HUGE_PARTITION_SIZE_THRESHOLD.key() + "'");
 
+  public static final ConfigOption<Long> HUGE_PARTITION_BUFFER_FLUSH_THRESHOLD = ConfigOptions
+      .key("rss.server.huge-partition.buffer.flush.threshold")
+      .longType()
+      .defaultValue(128 * 1024 * 1024L)
+      .withDescription("The single buffer flush threshold for huge partition, it will only triggered when partition's "
+          + "size exceeds the threshold of '" + HUGE_PARTITION_SIZE_THRESHOLD.key() + "'");
+
   public ShuffleServerConf() {
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -342,6 +342,20 @@ public class ShuffleServerConf extends RssBaseConf {
       .noDefaultValue()
       .withDescription("The env key to get json source of local storage media provider");
 
+  public static final ConfigOption<Long> HUGE_PARTITION_SIZE_THRESHOLD = ConfigOptions
+      .key("rss.server.huge-partition.size.threshold")
+      .longType()
+      .defaultValue(20 * 1024 * 1024 * 1024L)
+      .withDescription("Threshold of huge partition size, once exceeding threshold, memory usage limitation and "
+          + "huge partition buffer flushing will be triggered.");
+
+  public static final ConfigOption<Double> HUGE_PARTITION_MEMORY_USAGE_LIMITATION_RATIO = ConfigOptions
+      .key("rss.server.huge-partition.memory.limit.ratio")
+      .doubleType()
+      .defaultValue(0.2)
+      .withDescription("The memory usage limit ratio for huge partition, it will only triggered when partition's "
+          + "size exceeds the threshold of '" + HUGE_PARTITION_SIZE_THRESHOLD.key() + "'");
+
   public ShuffleServerConf() {
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -30,6 +30,7 @@ import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.apache.commons.lang3.StringUtils;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -355,7 +356,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       StreamObserver<RequireBufferResponse> responseObserver) {
     String appId = request.getAppId();
     long requireBufferId;
-    if (appId == null) {
+    if (StringUtils.isEmpty(appId)) {
       // To be compatible with older client version
       requireBufferId = shuffleServer.getShuffleTaskManager().requireBuffer(
           request.getRequireSize()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -353,7 +353,22 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
   @Override
   public void requireBuffer(RequireBufferRequest request,
       StreamObserver<RequireBufferResponse> responseObserver) {
-    long requireBufferId = shuffleServer.getShuffleTaskManager().requireBuffer(request.getRequireSize());
+    String appId = request.getAppId();
+    long requireBufferId;
+    if (appId == null) {
+      // To be compatible with older client version
+      requireBufferId = shuffleServer.getShuffleTaskManager().requireBuffer(
+          request.getRequireSize()
+      );
+    } else {
+      requireBufferId = shuffleServer.getShuffleTaskManager().requireBuffer(
+          appId,
+          request.getShuffleId(),
+          request.getPartitionIdsList(),
+          request.getRequireSize()
+      );
+    }
+
     StatusCode status = StatusCode.SUCCESS;
     if (requireBufferId == -1) {
       status = StatusCode.NO_BUFFER;

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -204,7 +204,7 @@ public class ShuffleTaskManager {
         shuffleId,
         isPreAllocated,
         spd,
-        (appIdx, shuffleIdx, partitionIdx) -> getPartitionDataSize(appIdx, shuffleIdx, partitionIdx)
+        this::getPartitionDataSize
     );
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -41,6 +41,7 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.RssUtils;
+import org.apache.uniffle.common.util.TripleFunction;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleFlushManager;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -65,6 +66,7 @@ public class ShuffleBufferManager {
   // Huge partition vars
   private long hugePartitionSizeThreshold;
   private long hugePartitionMemoryLimitSize;
+  private long hugePartitionBufferFlushThreshold;
 
   protected long bufferSize = 0;
   protected AtomicLong preAllocatedSize = new AtomicLong(0L);
@@ -93,6 +95,7 @@ public class ShuffleBufferManager {
     this.hugePartitionMemoryLimitSize = Math.round(
         capacity * conf.get(ShuffleServerConf.HUGE_PARTITION_MEMORY_USAGE_LIMITATION_RATIO)
     );
+    this.hugePartitionBufferFlushThreshold = conf.get(ShuffleServerConf.HUGE_PARTITION_BUFFER_FLUSH_THRESHOLD);
   }
 
   public StatusCode registerBuffer(String appId, int shuffleId, int startPartition, int endPartition) {
@@ -111,8 +114,27 @@ public class ShuffleBufferManager {
     return StatusCode.SUCCESS;
   }
 
-  public StatusCode cacheShuffleData(String appId, int shuffleId,
-      boolean isPreAllocated, ShufflePartitionedData spd) {
+  // Only for tests
+  public StatusCode cacheShuffleData(
+      String appId,
+      int shuffleId,
+      boolean isPreAllocated,
+      ShufflePartitionedData spd) {
+    return cacheShuffleData(
+        appId,
+        shuffleId,
+        isPreAllocated,
+        spd,
+        null
+    );
+  }
+
+  public StatusCode cacheShuffleData(
+      String appId,
+      int shuffleId,
+      boolean isPreAllocated,
+      ShufflePartitionedData spd,
+      TripleFunction<String, Integer, Integer, Long> getPartitionDataSizeFunc) {
     if (!isPreAllocated && isFull()) {
       LOG.warn("Got unexpected data, can't cache it because the space is full");
       return StatusCode.NO_BUFFER;
@@ -131,8 +153,15 @@ public class ShuffleBufferManager {
     }
     updateShuffleSize(appId, shuffleId, size);
     synchronized (this) {
-      flushSingleBufferIfNecessary(buffer, appId, shuffleId,
-          entry.getKey().lowerEndpoint(), entry.getKey().upperEndpoint());
+      flushSingleBufferIfNecessary(
+          buffer,
+          appId,
+          shuffleId,
+          spd.getPartitionId(),
+          entry.getKey().lowerEndpoint(),
+          entry.getKey().upperEndpoint(),
+          getPartitionDataSizeFunc
+      );
       flushIfNecessary();
     }
     return StatusCode.SUCCESS;
@@ -191,11 +220,23 @@ public class ShuffleBufferManager {
     return buffer.getShuffleData(blockId, readBufferSize, expectedTaskIds);
   }
 
-  void flushSingleBufferIfNecessary(ShuffleBuffer buffer, String appId,
-      int shuffleId, int startPartition, int endPartition) {
+  void flushSingleBufferIfNecessary(
+      ShuffleBuffer buffer,
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int startPartition,
+      int endPartition,
+      TripleFunction<String, Integer, Integer, Long> getPartitionDataSizeFunc) {
     // When we use multi storage and trigger single buffer flush, the buffer size should be bigger
     // than rss.server.flush.cold.storage.threshold.size, otherwise cold storage will be useless.
     if (this.bufferFlushEnabled && buffer.getSize() > this.bufferFlushThreshold) {
+      flushBuffer(buffer, appId, shuffleId, startPartition, endPartition);
+      return;
+    }
+
+    if (getPartitionDataSizeFunc != null &&
+        getPartitionDataSizeFunc.accept(appId, shuffleId, partitionId) > hugePartitionSizeThreshold) {
       flushBuffer(buffer, appId, shuffleId, startPartition, endPartition);
       return;
     }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -235,8 +235,8 @@ public class ShuffleBufferManager {
       return;
     }
 
-    if (getPartitionDataSizeFunc != null &&
-        getPartitionDataSizeFunc.accept(appId, shuffleId, partitionId) > hugePartitionSizeThreshold) {
+    if (getPartitionDataSizeFunc != null
+        && getPartitionDataSizeFunc.accept(appId, shuffleId, partitionId) > hugePartitionSizeThreshold) {
       flushBuffer(buffer, appId, shuffleId, startPartition, endPartition);
       return;
     }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -66,7 +66,6 @@ public class ShuffleBufferManager {
   // Huge partition vars
   private long hugePartitionSizeThreshold;
   private long hugePartitionMemoryLimitSize;
-  private long hugePartitionBufferFlushThreshold;
 
   protected long bufferSize = 0;
   protected AtomicLong preAllocatedSize = new AtomicLong(0L);
@@ -95,7 +94,6 @@ public class ShuffleBufferManager {
     this.hugePartitionMemoryLimitSize = Math.round(
         capacity * conf.get(ShuffleServerConf.HUGE_PARTITION_MEMORY_USAGE_LIMITATION_RATIO)
     );
-    this.hugePartitionBufferFlushThreshold = conf.get(ShuffleServerConf.HUGE_PARTITION_BUFFER_FLUSH_THRESHOLD);
   }
 
   public StatusCode registerBuffer(String appId, int shuffleId, int startPartition, int endPartition) {
@@ -236,7 +234,8 @@ public class ShuffleBufferManager {
     }
 
     if (getPartitionDataSizeFunc != null
-        && getPartitionDataSizeFunc.accept(appId, shuffleId, partitionId) > hugePartitionSizeThreshold) {
+        && getPartitionDataSizeFunc.accept(appId, shuffleId, partitionId) > hugePartitionSizeThreshold
+        && buffer.getSize() > this.bufferFlushThreshold) {
       flushBuffer(buffer, appId, shuffleId, startPartition, endPartition);
       return;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Introduce memory usage limit for huge partition to keep the regular partition writing stable
2. Once partition is marked as huge-partition, when its buffer size is greater than `rss.server.single.buffer.flush.threshold` value,  single-buffer flush will be triggered whatever the single buffer flush is enabled or not

### Why are the changes needed?
1. To solve the problems mentioned by #378 

### Does this PR introduce _any_ user-facing change?

Yes. 


### How was this patch tested?
1. UTs
