### PR TITLE
[ISSUE-472] Fix Flaky Test: LocalFileServerReadHandlerTest#testDataInconsistent

### DIFF
--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
@@ -44,6 +44,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class LocalFileHandlerTestBase {
   private static AtomicLong ATOMIC_LONG = new AtomicLong(0L);
 
+  public static void reset() {
+    ATOMIC_LONG = new AtomicLong(0L);
+  }
+
   public static void writeTestData(
       ShuffleWriteHandler writeHandler,
       int num, int length,

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
@@ -43,6 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class LocalFileServerReadHandlerTest {
   @Test
   public void testDataInconsistent() throws Exception {
+    LocalFileHandlerTestBase.reset();
+
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     int expectTotalBlockNum = 4;
     int blockSize = 7;


### PR DESCRIPTION


### What changes were proposed in this pull request?
1. Reset the static variable to fix LocalFileServerReadHandlerTest#testDataInconsistent


### Why are the changes needed?
Fix flaky test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
1. Existing UTs
