### PR TITLE
[ISSUE-475][Improvement] It's unnecessary to use ConcurrentHashMap for "partitionToBlockIds" in RssShuffleWriter

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -140,7 +140,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     this.sendSizeLimit = sparkConf.getSizeAsBytes(RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMIT.key(),
         RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMIT.defaultValue().get());
     this.bitmapSplitNum = sparkConf.get(RssSparkConfig.RSS_CLIENT_BITMAP_SPLIT_NUM);
-    this.partitionToBlockIds = Maps.newConcurrentMap();
+    this.partitionToBlockIds = Maps.newHashMap();
     this.shuffleWriteClient = shuffleWriteClient;
     this.shuffleServersForData = rssHandle.getShuffleServersForData();
     this.partitionLengths = new long[partitioner.numPartitions()];
@@ -223,8 +223,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         blockIds.add(blockId);
         // update [partition, blockIds], it will be sent to shuffle server
         int partitionId = sbi.getPartitionId();
-        partitionToBlockIds.putIfAbsent(partitionId, Sets.newConcurrentHashSet());
-        partitionToBlockIds.get(partitionId).add(blockId);
+        partitionToBlockIds.computeIfAbsent(partitionId, k -> Sets.newHashSet()).add(blockId);
         partitionLengths[partitionId] += sbi.getLength();
       });
       postBlockEvent(shuffleBlockInfoList);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -166,8 +166,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   }
 
   private void writeImpl(Iterator<Product2<K,V>> records) {
-    List<ShuffleBlockInfo> shuffleBlockInfos = null;
-    Set<Long> blockIds = Sets.newConcurrentHashSet();
+    List<ShuffleBlockInfo> shuffleBlockInfos;
+    Set<Long> blockIds = Sets.newHashSet();
     boolean isCombine = shuffleDependency.mapSideCombine();
     Function1 createCombiner = null;
     if (isCombine) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -259,7 +259,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
 
     // maintain the count of blocks that have been sent to the server
-    Map<Long, AtomicInteger> blockIdsTracker = Maps.newConcurrentMap();
+    Map<Long, AtomicInteger> blockIdsTracker = Maps.newHashMap();
     primaryServerToBlockIds.values().forEach(
         blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
     );
@@ -473,8 +473,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       long taskAttemptId,
       Map<Integer, List<Long>> partitionToBlockIds,
       int bitmapNum) {
-    Map<ShuffleServerInfo, List<Integer>> groupedPartitions = Maps.newConcurrentMap();
-    Map<Integer, Integer> partitionReportTracker = Maps.newConcurrentMap();
+    Map<ShuffleServerInfo, List<Integer>> groupedPartitions = Maps.newHashMap();
+    Map<Integer, Integer> partitionReportTracker = Maps.newHashMap();
     for (Map.Entry<Integer, List<ShuffleServerInfo>> entry : partitionToServers.entrySet()) {
       for (ShuffleServerInfo ssi : entry.getValue()) {
         if (!groupedPartitions.containsKey(ssi)) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -259,7 +259,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
 
     // maintain the count of blocks that have been sent to the server
-    Map<Long, AtomicInteger> blockIdsTracker = Maps.newHashMap();
+    Map<Long, AtomicInteger> blockIdsTracker = Maps.newConcurrentMap();
     primaryServerToBlockIds.values().forEach(
         blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
     );

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -259,7 +259,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
 
     // maintain the count of blocks that have been sent to the server
-    Map<Long, AtomicInteger> blockIdsTracker = Maps.newConcurrentMap();
+    // unnecessary to use concurrent hashmap here unless you need to insert or delete entries in other threads
+    // AtomicInteger is enough to reflect value changes in other threads
+    Map<Long, AtomicInteger> blockIdsTracker = Maps.newHashMap();
     primaryServerToBlockIds.values().forEach(
         blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
     );


### PR DESCRIPTION
### What changes were proposed in this pull request?
replaced some unnecessary concurrenthashmp with hashmap

### Why are the changes needed?
improve performance


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested with repartition workload
