### PR TITLE
[Improvement] Add more logs about data flush

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
@@ -158,6 +158,9 @@ public class ShuffleDataFlushEvent {
         + ", appId=" + appId
         + ", shuffleId=" + shuffleId
         + ", startPartition=" + startPartition
-        + ", endPartition=" + endPartition;
+        + ", endPartition=" + endPartition
+        + ", retryTimes=" + retryTimes
+        + ", underStorage=" + underStorage.getClass().getSimpleName()
+        + ", isPended=" + isPended;
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -165,6 +165,7 @@ public class ShuffleFlushManager {
 
         Storage storage = storageManager.selectStorage(event);
         if (storage == null) {
+          LOG.error("Storage selected is null and this should not happen. event: {}", event);
           break;
         }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

1. Exposing more info for DataFlushEvent when logging
2. Add logs when storage selected is null

### Why are the changes needed?

1. I found sometimes some events are flushed failed but have no related logs, maybe this is caused by the null storage selected. So let's add some logs firstly.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Don't need
