### PR TITLE
[ISSUE-484] Fix accidentally remove the storage of appId when unregistering partial shuffle in HdfsStorageManager

### DIFF
--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHdfsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHdfsTest.java
@@ -90,6 +90,11 @@ public class ShuffleUnregisterWithHdfsTest extends SparkIntegrationTestBase {
       Thread.sleep(1000);
       assertFalse(fs.exists(new Path(shufflePath)));
       assertTrue(fs.exists(new Path(appPath)));
+
+      // After unregistering partial shuffle, newly shuffle could work
+      map = javaPairRDD.collectAsMap();
+      shufflePath = appPath + "/1";
+      assertTrue(fs.exists(new Path(shufflePath)));
     } else {
       runCounter++;
     }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
@@ -92,6 +92,11 @@ public class ShuffleUnregisterWithLocalfileTest extends SparkIntegrationTestBase
       Thread.sleep(1000);
       assertFalse(new File(shufflePath).exists());
       assertTrue(new File(appPath).exists());
+
+      // After unregistering partial shuffle, newly shuffle could work
+      map = javaPairRDD.collectAsMap();
+      shufflePath = appPath + "/1";
+      assertTrue(new File(shufflePath).exists());
     } else {
       runCounter++;
     }

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -84,7 +84,6 @@ public class HdfsStorageManager extends SingleStorageManager {
   @Override
   public void removeResources(PurgeEvent event) {
     String appId = event.getAppId();
-    String user = event.getUser();
     HdfsStorage storage = getStorageByAppId(appId);
     if (storage == null) {
       LOG.warn("Storage gotten is null when removing resources for event: {}", event);
@@ -110,7 +109,7 @@ public class HdfsStorageManager extends SingleStorageManager {
         deletePaths.add(ShuffleStorageUtils.getFullShuffleDataFolder(basicPath, String.valueOf(shuffleId)));
       }
     }
-    deleteHandler.delete(deletePaths.toArray(new String[0]), appId, user);
+    deleteHandler.delete(deletePaths.toArray(new String[0]), appId, event.getUser());
   }
 
   @Override

--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -86,29 +86,31 @@ public class HdfsStorageManager extends SingleStorageManager {
     String appId = event.getAppId();
     String user = event.getUser();
     HdfsStorage storage = getStorageByAppId(appId);
-    if (storage != null) {
-      if (event instanceof AppPurgeEvent) {
-        storage.removeHandlers(appId);
-      }
-      appIdToStorages.remove(appId);
-      ShuffleDeleteHandler deleteHandler = ShuffleHandlerFactory
-          .getInstance()
-          .createShuffleDeleteHandler(
-              new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf())
-          );
-
-      String basicPath = ShuffleStorageUtils.getFullShuffleDataFolder(storage.getStoragePath(), appId);
-      List<String> deletePaths = new ArrayList<>();
-
-      if (event instanceof AppPurgeEvent) {
-        deletePaths.add(basicPath);
-      } else {
-        for (Integer shuffleId : event.getShuffleIds()) {
-          deletePaths.add(ShuffleStorageUtils.getFullShuffleDataFolder(basicPath, String.valueOf(shuffleId)));
-        }
-      }
-      deleteHandler.delete(deletePaths.toArray(new String[0]), appId, user);
+    if (storage == null) {
+      LOG.warn("Storage gotten is null when removing resources for event: {}", event);
+      return;
     }
+    if (event instanceof AppPurgeEvent) {
+      storage.removeHandlers(appId);
+      appIdToStorages.remove(appId);
+    }
+    ShuffleDeleteHandler deleteHandler = ShuffleHandlerFactory
+        .getInstance()
+        .createShuffleDeleteHandler(
+            new CreateShuffleDeleteHandlerRequest(StorageType.HDFS.name(), storage.getConf())
+        );
+
+    String basicPath = ShuffleStorageUtils.getFullShuffleDataFolder(storage.getStoragePath(), appId);
+    List<String> deletePaths = new ArrayList<>();
+
+    if (event instanceof AppPurgeEvent) {
+      deletePaths.add(basicPath);
+    } else {
+      for (Integer shuffleId : event.getShuffleIds()) {
+        deletePaths.add(ShuffleStorageUtils.getFullShuffleDataFolder(basicPath, String.valueOf(shuffleId)));
+      }
+    }
+    deleteHandler.delete(deletePaths.toArray(new String[0]), appId, user);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

When one app's partial shuffles are removed, it will make other shuffle fail of flushing data due to its missing storage referenced from its appId.

### Why are the changes needed?
Fix accidentally remove the storage of appId when unregistering partial shuffle in HdfsStorageManager

### Does this PR introduce _any_ user-facing change?

NO


### How was this patch tested?
1. UTs
