### PR TITLE
[ISSUE-378][HugePartition][Part-3] Introduce more metrics about huge partition

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -71,6 +71,10 @@ public class ShuffleServerMetrics {
   private static final String TOTAL_HDFS_WRITE_DATA = "total_hdfs_write_data";
   private static final String TOTAL_LOCALFILE_WRITE_DATA = "total_localfile_write_data";
   private static final String TOTAL_REQUIRE_BUFFER_FAILED = "total_require_buffer_failed";
+  private static final String TOTAL_REQUIRE_BUFFER_FAILED_FOR_HUGE_PARTITION =
+      "total_require_buffer_failed_for_huge_partition";
+  private static final String TOTAL_REQUIRE_BUFFER_FAILED_FOR_REGULAR_PARTITION =
+      "total_require_buffer_failed_for_regular_partition";
   private static final String STORAGE_TOTAL_WRITE_LOCAL = "storage_total_write_local";
   private static final String STORAGE_RETRY_WRITE_LOCAL = "storage_retry_write_local";
   private static final String STORAGE_FAILED_WRITE_LOCAL = "storage_failed_write_local";
@@ -79,6 +83,19 @@ public class ShuffleServerMetrics {
   public static final String STORAGE_RETRY_WRITE_REMOTE_PREFIX = "storage_retry_write_remote_";
   public static final String STORAGE_FAILED_WRITE_REMOTE_PREFIX = "storage_failed_write_remote_";
   public static final String STORAGE_SUCCESS_WRITE_REMOTE_PREFIX = "storage_success_write_remote_";
+
+  private static final String TOTAL_APP_NUM = "total_app_num";
+  private static final String TOTAL_APP_WITH_HUGE_PARTITION_NUM = "total_app_with_huge_partition_num";
+  private static final String TOTAL_PARTITION_NUM = "total_partition_num";
+  private static final String TOTAL_HUGE_PARTITION_NUM = "total_huge_partition_num";
+
+  private static final String HUGE_PARTITION_NUM = "huge_partition_num";
+  private static final String APP_WITH_HUGE_PARTITION_NUM = "app_with_huge_partition_num";
+
+  public static Counter counterTotalAppNum;
+  public static Counter counterTotalAppWithHugePartitionNum;
+  public static Counter counterTotalPartitionNum;
+  public static Counter counterTotalHugePartitionNum;
 
   public static Counter counterTotalReceivedDataSize;
   public static Counter counterTotalWriteDataSize;
@@ -101,6 +118,9 @@ public class ShuffleServerMetrics {
   public static Counter counterTotalHdfsWriteDataSize;
   public static Counter counterTotalLocalFileWriteDataSize;
   public static Counter counterTotalRequireBufferFailed;
+  public static Counter counterTotalRequireBufferFailedForHugePartition;
+  public static Counter counterTotalRequireBufferFailedForRegularPartition;
+
   public static Counter counterLocalStorageTotalWrite;
   public static Counter counterLocalStorageRetryWrite;
   public static Counter counterLocalStorageFailedWrite;
@@ -108,6 +128,9 @@ public class ShuffleServerMetrics {
   public static Counter counterTotalRequireReadMemoryNum;
   public static Counter counterTotalRequireReadMemoryRetryNum;
   public static Counter counterTotalRequireReadMemoryFailedNum;
+
+  public static Gauge gaugeHugePartitionNum;
+  public static Gauge gaugeAppWithHugePartitionNum;
 
   public static Gauge gaugeLocalStorageTotalDirsNum;
   public static Gauge gaugeLocalStorageCorruptedDirsNum;
@@ -245,6 +268,10 @@ public class ShuffleServerMetrics {
     counterTotalHdfsWriteDataSize = metricsManager.addCounter(TOTAL_HDFS_WRITE_DATA);
     counterTotalLocalFileWriteDataSize = metricsManager.addCounter(TOTAL_LOCALFILE_WRITE_DATA);
     counterTotalRequireBufferFailed = metricsManager.addCounter(TOTAL_REQUIRE_BUFFER_FAILED);
+    counterTotalRequireBufferFailedForRegularPartition =
+        metricsManager.addCounter(TOTAL_REQUIRE_BUFFER_FAILED_FOR_REGULAR_PARTITION);
+    counterTotalRequireBufferFailedForHugePartition =
+        metricsManager.addCounter(TOTAL_REQUIRE_BUFFER_FAILED_FOR_HUGE_PARTITION);
     counterLocalStorageTotalWrite = metricsManager.addCounter(STORAGE_TOTAL_WRITE_LOCAL);
     counterLocalStorageRetryWrite = metricsManager.addCounter(STORAGE_RETRY_WRITE_LOCAL);
     counterLocalStorageFailedWrite = metricsManager.addCounter(STORAGE_FAILED_WRITE_LOCAL);
@@ -252,6 +279,11 @@ public class ShuffleServerMetrics {
     counterTotalRequireReadMemoryNum = metricsManager.addCounter(TOTAL_REQUIRE_READ_MEMORY);
     counterTotalRequireReadMemoryRetryNum = metricsManager.addCounter(TOTAL_REQUIRE_READ_MEMORY_RETRY);
     counterTotalRequireReadMemoryFailedNum = metricsManager.addCounter(TOTAL_REQUIRE_READ_MEMORY_FAILED);
+
+    counterTotalAppNum = metricsManager.addCounter(TOTAL_APP_NUM);
+    counterTotalAppWithHugePartitionNum = metricsManager.addCounter(TOTAL_APP_WITH_HUGE_PARTITION_NUM);
+    counterTotalPartitionNum = metricsManager.addCounter(TOTAL_PARTITION_NUM);
+    counterTotalHugePartitionNum = metricsManager.addCounter(TOTAL_HUGE_PARTITION_NUM);
 
     gaugeLocalStorageTotalDirsNum = metricsManager.addGauge(LOCAL_STORAGE_TOTAL_DIRS_NUM);
     gaugeLocalStorageCorruptedDirsNum = metricsManager.addGauge(LOCAL_STORAGE_CORRUPTED_DIRS_NUM);
@@ -267,6 +299,9 @@ public class ShuffleServerMetrics {
     gaugeEventQueueSize = metricsManager.addGauge(EVENT_QUEUE_SIZE);
     gaugeAppNum = metricsManager.addGauge(APP_NUM_WITH_NODE);
     gaugeTotalPartitionNum = metricsManager.addGauge(PARTITION_NUM_WITH_NODE);
+
+    gaugeHugePartitionNum = metricsManager.addGauge(HUGE_PARTITION_NUM);
+    gaugeAppWithHugePartitionNum = metricsManager.addGauge(APP_WITH_HUGE_PARTITION_NUM);
   }
 
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -137,7 +137,7 @@ public class ShuffleTaskInfo {
   }
 
   public boolean hasHugePartition() {
-    return !hugePartitionTags.isEmpty();
+    return existHugePartition;
   }
 
   public int getHugePartitionSize() {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -102,6 +102,7 @@ public class ShuffleBufferManager {
     shuffleIdToBuffers.putIfAbsent(shuffleId, TreeRangeMap.create());
     RangeMap<Integer, ShuffleBuffer> bufferRangeMap = shuffleIdToBuffers.get(shuffleId);
     if (bufferRangeMap.get(startPartition) == null) {
+      ShuffleServerMetrics.counterTotalPartitionNum.inc();
       ShuffleServerMetrics.gaugeTotalPartitionNum.inc();
       bufferRangeMap.put(Range.closed(startPartition, endPartition), new ShuffleBuffer(bufferSize));
     } else {
@@ -562,6 +563,10 @@ public class ShuffleBufferManager {
       }
       shuffleIdToBuffers.remove(shuffleId);
     }
+  }
+
+  public boolean isHugePartition(long usedPartitionDataSize) {
+    return usedPartitionDataSize > hugePartitionSizeThreshold;
   }
 
   public boolean limitHugePartition(String appId, int shuffleId, int partitionId, long usedPartitionDataSize) {

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
@@ -51,6 +51,8 @@ public class ShuffleTaskInfoTest {
     shuffleTaskInfo.markHugePartition(2, 2);
     assertTrue(shuffleTaskInfo.hasHugePartition());
     assertEquals(3, shuffleTaskInfo.getHugePartitionSize());
+    assertEquals(1, ShuffleServerMetrics.gaugeAppWithHugePartitionNum.get());
+    assertEquals(1, ShuffleServerMetrics.counterTotalAppWithHugePartitionNum.get());
   }
 
   @Test

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
@@ -69,11 +69,11 @@ public class ShuffleTaskInfoTest {
     assertEquals(n, ShuffleServerMetrics.gaugeHugePartitionNum.get());
 
     // case2
-    ShuffleTaskInfo taskInfo = new ShuffleTaskInfo("hugePartitionConcurrentTest_appId");
     ShuffleServerMetrics.clear();
     ShuffleServerMetrics.register();
     barrier.reset();
     CountDownLatch latch = new CountDownLatch(n);
+    ShuffleTaskInfo taskInfo = new ShuffleTaskInfo("hugePartitionConcurrentTest_appId");
     IntStream.range(0, n).forEach(i -> executorService.submit(() -> {
       try {
         barrier.await();

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
@@ -17,15 +17,45 @@
 
 package org.apache.uniffle.server;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleTaskInfoTest {
 
+  @BeforeAll
+  public static void setup() {
+    ShuffleServerMetrics.register();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    ShuffleServerMetrics.clear();
+  }
+
+  @Test
+  public void hugePartitionTest() {
+    ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo("hugePartition_appId");
+
+    // case1
+    assertFalse(shuffleTaskInfo.hasHugePartition());
+    assertEquals(0, shuffleTaskInfo.getHugePartitionSize());
+
+    // case2
+    shuffleTaskInfo.markHugePartition(1, 1);
+    shuffleTaskInfo.markHugePartition(1, 2);
+    shuffleTaskInfo.markHugePartition(2, 2);
+    assertTrue(shuffleTaskInfo.hasHugePartition());
+    assertEquals(3, shuffleTaskInfo.getHugePartitionSize());
+  }
+
   @Test
   public void partitionSizeSummaryTest() {
-    ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo();
+    ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo("partitionSizeSummaryTest_appId");
     // case1
     long size = shuffleTaskInfo.getPartitionDataSize(0, 0);
     assertEquals(0, size);

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -119,6 +119,18 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
     shuffleTaskManager.updateCachedBlockIds(appId, shuffleId, 1, partitionedData0.getBlockList());
     requiredId = shuffleTaskManager.requireBuffer(appId, 1, Arrays.asList(1), 500);
     assertEquals(-1, requiredId);
+    // metrics test
+    assertEquals(1, ShuffleServerMetrics.counterTotalRequireBufferFailedForHugePartition.get());
+    assertEquals(0, ShuffleServerMetrics.counterTotalRequireBufferFailedForRegularPartition.get());
+    assertEquals(1, ShuffleServerMetrics.counterTotalAppWithHugePartitionNum.get());
+    assertEquals(1, ShuffleServerMetrics.counterTotalHugePartitionNum.get());
+    assertEquals(1, ShuffleServerMetrics.gaugeHugePartitionNum.get());
+    assertEquals(1, ShuffleServerMetrics.gaugeAppWithHugePartitionNum.get());
+
+    // case4
+    shuffleTaskManager.removeResources(appId);
+    assertEquals(0, ShuffleServerMetrics.gaugeHugePartitionNum.get());
+    assertEquals(0, ShuffleServerMetrics.gaugeAppWithHugePartitionNum.get());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce more metrics about huge partition  
__counter__  
1. total_require_buffer_failed_for_huge_partition
2. total_require_buffer_failed_for_regular_partition
3. total_app_num
4. total_app_with_huge_partition_num
5. total_partition_num
6. total_huge_partition_num

__Gauge__  
1. huge_partition_num 
2. app_with_huge_partition_num

### Why are the changes needed?
Having these metrics, we should observe the concrete influence from huge partition for regular partition and huge partition number in one shuffle-server

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. UTs