### PR TITLE
[Deps] Bump protobuf to 3.19.6 to address vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <prometheus.simpleclient.version>0.9.0</prometheus.simpleclient.version>
-    <protobuf.version>3.19.2</protobuf.version>
+    <protobuf.version>3.19.6</protobuf.version>
     <roaring.bitmap.version>0.9.15</roaring.bitmap.version>
     <rss.shade.packageName>org.apache.uniffle</rss.shade.packageName>
     <skipDeploy>false</skipDeploy>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump com.google.protobuf:protoc to 3.19.6

### Why are the changes needed?

* CVE-2022-3171 7.5 Uncontrolled Resource Consumption vulnerability with medium severity found
* CVE-2022-3509 7.5 Uncontrolled Resource Consumption vulnerability with medium severity found
* CVE-2022-3510 7.5 Uncontrolled Resource Consumption vulnerability with medium severity found

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CI.