### PR TITLE
[Deps] Switch to slf4j-reload4j

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -114,6 +114,10 @@
       <artifactId>snappy-java</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
 
     <dependency>
@@ -154,8 +154,9 @@
     <dependencies>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-reload4j</artifactId>
         <version>${slf4j.version}</version>
+        <scope>runtime</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Replace `slf4j-log4j12` with `slf4j-reload4j`.
2. Change dependency scope to `runtime`. 

### Why are the changes needed?

Eliminate this warning from maven:

```
[WARNING] While downloading org.slf4j:slf4j-log4j12:1.7.36
  This artifact has been relocated to org.slf4j:slf4j-reload4j:1.7.36.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.