### PR TITLE
[ISSUE-512][Operator] Bump golang to 1.17

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -78,10 +78,11 @@ jobs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
-    - name: Set up Go 1.16
+    - name: Set up Go 1.17
+      if: ${{ matrix.profile == "kubernetes" }}
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.17
     - name: Execute maven with -P${{ matrix.profile }}
       if: ${{ !inputs.experimental }}
       run: mvn -B -fae -P${{ matrix.profile }} ${{ inputs.maven-args }} | tee /tmp/maven.log

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -79,7 +79,7 @@ jobs:
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
     - name: Set up Go 1.17
-      if: ${{ matrix.profile == "kubernetes" }}
+      if: ${{ matrix.profile == 'kubernetes' }}
       uses: actions/setup-go@v3
       with:
         go-version: 1.17


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump go version of `deploy/kubernetes/operator` to 1.17.

### Why are the changes needed?

Fix #512.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.
