### PR TITLE
[ISSUE-496][operator] infer resource request/limit from spec for init container

### DIFF
--- a/deploy/kubernetes/operator/go.mod
+++ b/deploy/kubernetes/operator/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	k8s.io/api v0.22.2
@@ -46,6 +47,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/deploy/kubernetes/operator/pkg/controller/util/util.go
+++ b/deploy/kubernetes/operator/pkg/controller/util/util.go
@@ -175,6 +175,7 @@ func GenerateInitContainers(rssPodSpec *v1alpha1.RSSPodSpec) []corev1.Container 
 				Privileged: pointer.Bool(true),
 			},
 			VolumeMounts: GenerateHostPathVolumeMounts(rssPodSpec.HostPathMounts),
+			Resources:    rssPodSpec.Resources,
 		})
 		if len(rssPodSpec.LogHostPath) > 0 {
 			initContainers = append(initContainers, corev1.Container{
@@ -193,6 +194,7 @@ func GenerateInitContainers(rssPodSpec *v1alpha1.RSSPodSpec) []corev1.Container 
 				VolumeMounts: []corev1.VolumeMount{
 					*generateLogVolumeMount(rssPodSpec),
 				},
+				Resources: rssPodSpec.Resources,
 			})
 		}
 	}


### PR DESCRIPTION
### What changes were proposed in this pull request?
passing RSS resource spec to init-container's

### Why are the changes needed?
This pr fixes #496. 
Without this pr, RSS operator cannot work correctly with resource quota enabled namespace

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
added UT
