### PR TITLE
[ISSUE-522] [operator] pass RSS_IP to coordinator container env

### DIFF
--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
@@ -287,6 +287,24 @@ func generateMainContainerENV(rss *unifflev1alpha1.RemoteShuffleService) []corev
 			Name:  controllerconstants.ServiceNameEnv,
 			Value: controllerconstants.CoordinatorServiceName,
 		},
+		{
+			Name: controllerconstants.NodeNameEnv,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: controllerconstants.RssIPEnv,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.podIP",
+				},
+			},
+		},
 	}
 	for _, e := range rss.Spec.Coordinator.Env {
 		if !defaultENVs.Has(e.Name) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`NODE_NAME` and `RSS_IP` env variables are set in coordinator's container.

### Why are the changes needed?
In a complex K8S env, there might be multiple interfaces/ips in the container env. Uniffle cannot detect which
ip should be used automatically. It's better to specify the correct container ip here. 
Also we are passing RSS_IP to shuffle server, coordinator and shuffle server should align this behavior.

This PR fixes #522 

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Manually verify