### PR TITLE
Result of mkdirs() is ignored in LocalFileWriteHandler#createBasePath()

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -20,7 +20,6 @@ package org.apache.uniffle.storage.handler.impl;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,11 +53,12 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
   }
 
   private void createBasePath() {
-    if (new File(basePath).isDirectory()) {
+    File baseFolder = new File(basePath);
+    if (baseFolder.isDirectory()) {
       return;
     }
     try {
-      Files.createDirectories(Paths.get(basePath));
+      Files.createDirectories(baseFolder.toPath());
     } catch (IOException e) {
       throw new RssException("Failed to create shuffle folder: " + basePath, e);
     }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -27,8 +27,8 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -54,6 +54,9 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
   }
 
   private void createBasePath() {
+    if (new File(basePath).isDirectory()) {
+      return;
+    }
     try {
       Files.createDirectories(Paths.get(basePath));
     } catch (IOException e) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
@@ -56,7 +57,7 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
     try {
       Files.createDirectories(Paths.get(basePath));
     } catch (IOException e) {
-      throw new RuntimeException("Failed to create shuffle folder: " + basePath, e);
+      throw new RssException("Failed to create shuffle folder: " + basePath, e);
     }
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -19,6 +19,8 @@ package org.apache.uniffle.storage.handler.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -51,19 +53,10 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
   }
 
   private void createBasePath() {
-    File baseFolder = new File(basePath);
-    // check if shuffle folder exist
-    if (!baseFolder.exists()) {
-      try {
-        // try to create folder, it may be created by other Shuffle Server
-        baseFolder.mkdirs();
-      } catch (SecurityException e) {
-        // if folder exist, ignore the exception
-        if (!baseFolder.exists()) {
-          LOG.error("Can't create shuffle folder:" + basePath, e);
-          throw e;
-        }
-      }
+    try {
+      Files.createDirectories(Paths.get(basePath));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create shuffle folder: " + basePath, e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix error handling in `LocalFileWriteHandler#createBasePath()`.
Throw a `RssException` in case of failure.

### Why are the changes needed?

The return value of `baseFolder.mkdirs()` was ignored.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.