### PR TITLE
[Improvement] Only report to the shuffle servers that owns the blocks

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -551,7 +551,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
           LOG.info("Report shuffle result to " + ssi + " for appId[" + appId
               + "], shuffleId[" + shuffleId + "] successfully");
-          for (Integer partitionId : entry.getValue()) {
+          for (Integer partitionId : requestBlockIds.keySet()) {
             partitionReportTracker.put(partitionId, partitionReportTracker.get(partitionId) + 1);
           }
         } else {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -527,7 +527,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         }
         groupedPartitions.get(ssi).add(partitionIdx);
       }
-      if (CollectionUtils.isNotEmpty(partitionToBlockIds.getOrDefault(partitionIdx, null))) {
+      if (CollectionUtils.isNotEmpty(partitionToBlockIds.get(partitionIdx))) {
         partitionReportTracker.putIfAbsent(partitionIdx, 0);
       }
     }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -522,7 +522,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     for (Map.Entry<Integer, List<ShuffleServerInfo>> entry : partitionToServers.entrySet()) {
       int partitionIdx = entry.getKey();
       for (ShuffleServerInfo ssi : entry.getValue()) {
-        groupedPartitions.putIfAbsent(ssi, Lists.newArrayList());
+        if (!groupedPartitions.containsKey(ssi)) {
+          groupedPartitions.put(ssi, Lists.newArrayList());
+        }
         groupedPartitions.get(ssi).add(partitionIdx);
       }
       if (CollectionUtils.isNotEmpty(partitionToBlockIds.get(partitionIdx))) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -522,9 +522,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     for (Map.Entry<Integer, List<ShuffleServerInfo>> entry : partitionToServers.entrySet()) {
       int partitionIdx = entry.getKey();
       for (ShuffleServerInfo ssi : entry.getValue()) {
-        if (!groupedPartitions.containsKey(ssi)) {
-          groupedPartitions.put(ssi, Lists.newArrayList());
-        }
+        groupedPartitions.putIfAbsent(ssi, Lists.newArrayList());
         groupedPartitions.get(ssi).add(partitionIdx);
       }
       if (CollectionUtils.isNotEmpty(partitionToBlockIds.get(partitionIdx))) {
@@ -535,9 +533,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     for (Map.Entry<ShuffleServerInfo, List<Integer>> entry : groupedPartitions.entrySet()) {
       Map<Integer, List<Long>> requestBlockIds = Maps.newHashMap();
       for (Integer partitionId : entry.getValue()) {
-        List<Long> partitions = partitionToBlockIds.get(partitionId);
-        if (CollectionUtils.isNotEmpty(partitions)) {
-          requestBlockIds.put(partitionId, partitions);
+        List<Long> blockIds = partitionToBlockIds.get(partitionId);
+        if (CollectionUtils.isNotEmpty(blockIds)) {
+          requestBlockIds.put(partitionId, blockIds);
         }
       }
       if (requestBlockIds.isEmpty()) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -520,18 +520,28 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     Map<ShuffleServerInfo, List<Integer>> groupedPartitions = Maps.newHashMap();
     Map<Integer, Integer> partitionReportTracker = Maps.newHashMap();
     for (Map.Entry<Integer, List<ShuffleServerInfo>> entry : partitionToServers.entrySet()) {
+      int partitionIdx = entry.getKey();
       for (ShuffleServerInfo ssi : entry.getValue()) {
         if (!groupedPartitions.containsKey(ssi)) {
-          groupedPartitions.putIfAbsent(ssi, Lists.newArrayList());
+          groupedPartitions.put(ssi, Lists.newArrayList());
         }
-        groupedPartitions.get(ssi).add(entry.getKey());
+        groupedPartitions.get(ssi).add(partitionIdx);
       }
-      partitionReportTracker.putIfAbsent(entry.getKey(), 0);
+      if (CollectionUtils.isNotEmpty(partitionToBlockIds.getOrDefault(partitionIdx, null))) {
+        partitionReportTracker.putIfAbsent(partitionIdx, 0);
+      }
     }
+
     for (Map.Entry<ShuffleServerInfo, List<Integer>> entry : groupedPartitions.entrySet()) {
       Map<Integer, List<Long>> requestBlockIds = Maps.newHashMap();
       for (Integer partitionId : entry.getValue()) {
-        requestBlockIds.put(partitionId, partitionToBlockIds.get(partitionId));
+        List<Long> partitions = partitionToBlockIds.get(partitionId);
+        if (CollectionUtils.isNotEmpty(partitions)) {
+          requestBlockIds.put(partitionId, partitions);
+        }
+      }
+      if (requestBlockIds.isEmpty()) {
+        continue;
       }
       RssReportShuffleResultRequest request = new RssReportShuffleResultRequest(
           appId, shuffleId, taskAttemptId, requestBlockIds, bitmapNum);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -151,6 +151,57 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   }
 
   @Test
+  public void reportBlocksToShuffleServerIfNecessary() {
+    String testAppId = "reportBlocksToShuffleServerIfNecessary_appId";
+
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo1,
+        testAppId,
+        1,
+        Lists.newArrayList(new PartitionRange(1, 1)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
+
+    shuffleWriteClientImpl.registerShuffle(
+        shuffleServerInfo2,
+        testAppId,
+        1,
+        Lists.newArrayList(new PartitionRange(2, 2)),
+        new RemoteStorageInfo(""),
+        ShuffleDataDistributionType.NORMAL
+    );
+
+    Map<Integer, List<ShuffleServerInfo>> partitionToServers = Maps.newHashMap();
+    partitionToServers.putIfAbsent(1, Lists.newArrayList(shuffleServerInfo1));
+    partitionToServers.putIfAbsent(2, Lists.newArrayList(shuffleServerInfo2));
+    Map<Integer, List<Long>> partitionToBlocks = Maps.newHashMap();
+    List<Long> blockIds = Lists.newArrayList();
+
+    int partitionIdx = 1;
+    for (int i = 0; i < 5; i++) {
+      blockIds.add(ClientUtils.getBlockId(partitionIdx, 0, i));
+    }
+    partitionToBlocks.put(partitionIdx, blockIds);
+
+    // case1
+    shuffleWriteClientImpl
+        .reportShuffleResult(partitionToServers, testAppId, 1, 0, partitionToBlocks, 1);
+    Roaring64NavigableMap bitmap = shuffleWriteClientImpl
+        .getShuffleResult("GRPC", Sets.newHashSet(shuffleServerInfo1), testAppId,
+            1, 0);
+    assertTrue(bitmap.isEmpty());
+
+    bitmap = shuffleWriteClientImpl
+        .getShuffleResult("GRPC", Sets.newHashSet(shuffleServerInfo1), testAppId,
+            1, partitionIdx);
+    assertEquals(5, bitmap.getLongCardinality());
+    for (int i = 0; i < 5; i++) {
+      assertTrue(bitmap.contains(partitionToBlocks.get(1).get(i)));
+    }
+  }
+
+  @Test
   public void reportMultipleServerTest() throws Exception {
     String testAppId = "reportMultipleServerTest";
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -173,8 +173,8 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     );
 
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = Maps.newHashMap();
-    partitionToServers.putIfAbsent(1, Lists.newArrayList(shuffleServerInfo1));
-    partitionToServers.putIfAbsent(2, Lists.newArrayList(shuffleServerInfo2));
+    partitionToServers.put(1, Lists.newArrayList(shuffleServerInfo1));
+    partitionToServers.put(2, Lists.newArrayList(shuffleServerInfo2));
     Map<Integer, List<Long>> partitionToBlocks = Maps.newHashMap();
     List<Long> blockIds = Lists.newArrayList();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Only report to the shuffle servers that owns the blocks

### Why are the changes needed?
I found some unnecessary log is shown in the shuffle server's log, like this 

```
[INFO] 2023-02-02 10:59:04,045 Grpc-881 ShuffleServerGrpcService reportShuffleResult - Report 0 blocks as shuffle result for the task of appId[application_1672821343673_3878453_1675303644304], shuffleId[1619], taskAttemptId[1198007]
```

As shown above, there is no necessary to report 0 blocks to shuffle server for client. Let's remove this logic.

__Improvement__
1.  for shuffle server, it reduces the log size and make its more clear
2. for client, it speeds up the client reporting due to avoiding unnecessary rpc request

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
1. UTs
