### PR TITLE
[#554] feat: infer rss base storage conf from env

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssConf.java
@@ -640,4 +640,9 @@ public class RssConf implements Cloneable {
   public String toString() {
     return this.settings.toString();
   }
+
+  public String getEnv(String key) {
+    return System.getenv(key);
+  }
+
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -31,6 +31,7 @@ import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -48,11 +49,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 
 public class RssUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RssUtils.class);
+  public static final String RSS_LOCAL_DIR_KEY = "RSS_LOCAL_DIRS";
 
   private RssUtils() {
   }
@@ -290,5 +294,13 @@ public class RssUtils {
       taskIdBitmap.addLong(idHelper.getTaskAttemptId(iterator.next()));
     }
     return taskIdBitmap;
+  }
+
+  public static List<String> getConfiguredLocalDirs(RssConf conf) {
+    if (conf.getEnv(RSS_LOCAL_DIR_KEY) != null) {
+      return Arrays.asList(conf.getEnv(RSS_LOCAL_DIR_KEY).split(","));
+    } else {
+      return conf.get(RssBaseConf.RSS_STORAGE_BASE_PATH);
+    }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.common.util;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,11 +35,14 @@ import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.config.RssConf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
@@ -175,6 +179,24 @@ public class RssUtilsTest {
     assertEquals(serverToPartitions.get(server2), Sets.newHashSet(1, 3));
     assertEquals(serverToPartitions.get(server3), Sets.newHashSet(2, 4));
     assertEquals(serverToPartitions.get(server4), Sets.newHashSet(2, 4));
+  }
+
+  @Test
+  public void testGetConfiguredLocalDirs() throws Exception {
+    RssConf conf = new RssConf();
+    withEnvironmentVariable(RssUtils.RSS_LOCAL_DIR_KEY, "/path/a").execute(() -> {
+      assertEquals(Collections.singletonList("/path/a"), RssUtils.getConfiguredLocalDirs(conf));
+    });
+
+    withEnvironmentVariable(RssUtils.RSS_LOCAL_DIR_KEY, "/path/a,/path/b").execute(() -> {
+      assertEquals(Arrays.asList("/path/a", "/path/b"), RssUtils.getConfiguredLocalDirs(conf));
+    });
+
+    withEnvironmentVariable(RssUtils.RSS_LOCAL_DIR_KEY, null).execute(() -> {
+      assertNull(RssUtils.getConfiguredLocalDirs(conf));
+      conf.set(RssBaseConf.RSS_STORAGE_BASE_PATH, Arrays.asList("/path/a", "/path/b"));
+      assertEquals(Arrays.asList("/path/a", "/path/b"), RssUtils.getConfiguredLocalDirs(conf));
+    });
   }
 
   // Copy from ClientUtils

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.storage.common.LocalStorage;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;
 
@@ -47,7 +48,7 @@ public class LocalStorageChecker extends Checker {
 
   public LocalStorageChecker(ShuffleServerConf conf, List<LocalStorage> storages) {
     super(conf);
-    List<String> basePaths = conf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH);
+    List<String> basePaths = RssUtils.getConfiguredLocalDirs(conf);
     if (CollectionUtils.isEmpty(basePaths)) {
       throw new IllegalArgumentException("The base path cannot be empty");
     }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
 import org.apache.uniffle.server.storage.MultiStorageManager;
 import org.apache.uniffle.server.storage.StorageManager;
@@ -82,7 +83,7 @@ public class ShuffleFlushManager {
     this.maxConcurrencyOfSingleOnePartition =
         shuffleServerConf.get(ShuffleServerConf.SERVER_MAX_CONCURRENCY_OF_ONE_PARTITION);
 
-    storageBasePaths = shuffleServerConf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH);
+    storageBasePaths = RssUtils.getConfiguredLocalDirs(shuffleServerConf);
     pendingEventTimeoutSec = shuffleServerConf.getLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC);
     threadPoolExecutor = createFlushEventExecutor();
     startEventProcessor();

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -85,7 +85,7 @@ public class LocalStorageManager extends SingleStorageManager {
   @VisibleForTesting
   LocalStorageManager(ShuffleServerConf conf) {
     super(conf);
-    storageBasePaths = conf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH);
+    storageBasePaths = RssUtils.getConfiguredLocalDirs(conf);
     if (CollectionUtils.isEmpty(storageBasePaths)) {
       throw new IllegalArgumentException("Base path dirs must not be empty");
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
new method `getConfiguredLocalDirs` is added to retrieve rss base storage path from env first



### Why are the changes needed?
Fixes #554 


### Does this PR introduce _any_ user-facing change?
RSS admin may specify rss base path for shuffle server when deploying

### How was this patch tested?
Added UT.