### PR TITLE
[#525][FOLLOWUP] fix: add omitempty tag

### DIFF
--- a/deploy/kubernetes/operator/api/uniffle/v1alpha1/remoteshuffleservice_types.go
+++ b/deploy/kubernetes/operator/api/uniffle/v1alpha1/remoteshuffleservice_types.go
@@ -97,11 +97,11 @@ type CoordinatorConfig struct {
 
 	// RPCNodePort defines rpc port of node port service used for coordinators' external access.
 	// +optional
-	RPCNodePort []int32 `json:"rpcNodePort"`
+	RPCNodePort []int32 `json:"rpcNodePort,omitempty"`
 
 	// HTTPNodePort defines http port of node port service used for coordinators' external access.
 	// +optional
-	HTTPNodePort []int32 `json:"httpNodePort"`
+	HTTPNodePort []int32 `json:"httpNodePort,omitempty"`
 }
 
 // ShuffleServerConfig records configuration used to generate workload of shuffle servers.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add omitempty for `RPCNodePort` and `HTTPNodePort`

### Why are the changes needed?
This is a bug fixes. Otherwise, rss spec cannot omit `rpcNodePort` and `httpNodePort`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need
