### PR TITLE
[#575] refactor: replace switch-case with EnumMap in ComposedClientReadHandler

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -211,7 +211,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     assertNull(sdr);
 
     if (checkSkippedMetrics) {
-      String readBlokNumInfo = composedClientReadHandler.getReadBlokNumInfo();
+      String readBlokNumInfo = composedClientReadHandler.getReadBlockNumInfo();
       assert (readBlokNumInfo.contains("Client read 0 blocks from [" + ssi + "]")
           && readBlokNumInfo.contains("Skipped[ hot:3 warm:3 cold:2 frozen:0 ]")
           && readBlokNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
@@ -224,7 +224,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
           && readUncompressLengthInfo.contains("Skipped[ hot:75 warm:150 cold:400 frozen:0 ]")
           && readBlokNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
     } else {
-      String readBlokNumInfo = composedClientReadHandler.getReadBlokNumInfo();
+      String readBlokNumInfo = composedClientReadHandler.getReadBlockNumInfo();
       assert (readBlokNumInfo.contains("Client read 8 blocks from [" + ssi + "]")
           && readBlokNumInfo.contains("Consumed[ hot:3 warm:3 cold:2 frozen:0 ]")
           && readBlokNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -52,6 +52,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
@@ -211,31 +212,31 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     assertNull(sdr);
 
     if (checkSkippedMetrics) {
-      String readBlokNumInfo = composedClientReadHandler.getReadBlockNumInfo();
-      assert (readBlokNumInfo.contains("Client read 0 blocks from [" + ssi + "]")
-          && readBlokNumInfo.contains("Skipped[ hot:3 warm:3 cold:2 frozen:0 ]")
-          && readBlokNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      String readBlockNumInfo = composedClientReadHandler.getReadBlockNumInfo();
+      assertTrue(readBlockNumInfo.contains("Client read 0 blocks from [" + ssi + "]"));
+      assertTrue(readBlockNumInfo.contains("Skipped[ hot:3 warm:3 cold:2 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
       String readLengthInfo = composedClientReadHandler.getReadLengthInfo();
-      assert (readLengthInfo.contains("Client read 0 bytes from [" + ssi + "]")
-          && readLengthInfo.contains("Skipped[ hot:75 warm:150 cold:400 frozen:0 ]")
-          && readBlokNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      assertTrue(readLengthInfo.contains("Client read 0 bytes from [" + ssi + "]"));
+      assertTrue(readLengthInfo.contains("Skipped[ hot:75 warm:150 cold:400 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
       String readUncompressLengthInfo = composedClientReadHandler.getReadUncompressLengthInfo();
-      assert (readUncompressLengthInfo.contains("Client read 0 uncompressed bytes from [" + ssi + "]")
-          && readUncompressLengthInfo.contains("Skipped[ hot:75 warm:150 cold:400 frozen:0 ]")
-          && readBlokNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      assertTrue(readUncompressLengthInfo.contains("Client read 0 uncompressed bytes from [" + ssi + "]"));
+      assertTrue(readUncompressLengthInfo.contains("Skipped[ hot:75 warm:150 cold:400 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Consumed[ hot:0 warm:0 cold:0 frozen:0 ]"));
     } else {
-      String readBlokNumInfo = composedClientReadHandler.getReadBlockNumInfo();
-      assert (readBlokNumInfo.contains("Client read 8 blocks from [" + ssi + "]")
-          && readBlokNumInfo.contains("Consumed[ hot:3 warm:3 cold:2 frozen:0 ]")
-          && readBlokNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      String readBlockNumInfo = composedClientReadHandler.getReadBlockNumInfo();
+      assertTrue(readBlockNumInfo.contains("Client read 8 blocks from [" + ssi + "]"));
+      assertTrue(readBlockNumInfo.contains("Consumed[ hot:3 warm:3 cold:2 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
       String readLengthInfo = composedClientReadHandler.getReadLengthInfo();
-      assert (readLengthInfo.contains("Client read 625 bytes from [" + ssi + "]")
-          && readLengthInfo.contains("Consumed[ hot:75 warm:150 cold:400 frozen:0 ]")
-          && readBlokNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      assertTrue(readLengthInfo.contains("Client read 625 bytes from [" + ssi + "]"));
+      assertTrue(readLengthInfo.contains("Consumed[ hot:75 warm:150 cold:400 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
       String readUncompressLengthInfo = composedClientReadHandler.getReadUncompressLengthInfo();
-      assert (readUncompressLengthInfo.contains("Client read 625 uncompressed bytes from [" + ssi + "]")
-          && readUncompressLengthInfo.contains("Consumed[ hot:75 warm:150 cold:400 frozen:0 ]")
-          && readBlokNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
+      assertTrue(readUncompressLengthInfo.contains("Client read 625 uncompressed bytes from [" + ssi + "]"));
+      assertTrue(readUncompressLengthInfo.contains("Consumed[ hot:75 warm:150 cold:400 frozen:0 ]"));
+      assertTrue(readBlockNumInfo.contains("Skipped[ hot:0 warm:0 cold:0 frozen:0 ]"));
     }
     
   }

--- a/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/factory/ShuffleHandlerFactory.java
@@ -19,7 +19,7 @@ package org.apache.uniffle.storage.factory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
@@ -93,7 +93,7 @@ public class ShuffleHandlerFactory {
       return getLocalfileClientReaderHandler(request, serverInfo);
     }
 
-    List<Callable<ClientReadHandler>> handlers = new ArrayList<>();
+    List<Supplier<ClientReadHandler>> handlers = new ArrayList<>();
     if (StorageType.withMemory(type)) {
       handlers.add(
           () -> getMemoryClientReadHandler(request, serverInfo)

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.storage.handler.impl;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -131,44 +132,34 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
 
   @VisibleForTesting
   public String getReadBlockNumInfo() {
-    return "Client read " + readHandlerMetric.getReadBlockNum()
-        + " blocks from [" + serverInfo + "], Consumed["
-        + " hot:" + metricsMap.get(Tier.HOT).getReadBlockNum()
-        + " warm:" + metricsMap.get(Tier.WARM).getReadBlockNum()
-        + " cold:" + metricsMap.get(Tier.COLD).getReadBlockNum()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getReadBlockNum()
-        + " ], Skipped[" + " hot:" + metricsMap.get(Tier.HOT).getSkippedReadBlockNum()
-        + " warm:" + metricsMap.get(Tier.WARM).getSkippedReadBlockNum()
-        + " cold:" + metricsMap.get(Tier.COLD).getSkippedReadBlockNum()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getSkippedReadBlockNum() + " ]";
+    return getMetricsInfo("blocks", ClientReadHandlerMetric::getReadBlockNum,
+        ClientReadHandlerMetric::getSkippedReadBlockNum);
   }
 
   @VisibleForTesting
   public String getReadLengthInfo() {
-    return "Client read " + readHandlerMetric.getReadLength()
-        + " bytes from [" + serverInfo + "], Consumed["
-        + " hot:" + metricsMap.get(Tier.HOT).getReadLength()
-        + " warm:" + metricsMap.get(Tier.WARM).getReadLength()
-        + " cold:" + metricsMap.get(Tier.COLD).getReadLength()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getReadLength() + " ], Skipped["
-        + " hot:" + metricsMap.get(Tier.HOT).getSkippedReadLength()
-        + " warm:" + metricsMap.get(Tier.WARM).getSkippedReadLength()
-        + " cold:" + metricsMap.get(Tier.COLD).getSkippedReadLength()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getSkippedReadLength() + " ]";
+    return getMetricsInfo("bytes", ClientReadHandlerMetric::getReadLength,
+        ClientReadHandlerMetric::getSkippedReadLength);
   }
 
   @VisibleForTesting
   public String getReadUncompressLengthInfo() {
-    return "Client read " + readHandlerMetric.getReadUncompressLength()
-        + " uncompressed bytes from [" + serverInfo + "], Consumed["
-        + " hot:" + metricsMap.get(Tier.HOT).getReadUncompressLength()
-        + " warm:" + metricsMap.get(Tier.WARM).getReadUncompressLength()
-        + " cold:" + metricsMap.get(Tier.COLD).getReadUncompressLength()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getReadUncompressLength() + " ], Skipped["
-        + " hot:" + metricsMap.get(Tier.HOT).getSkippedReadUncompressLength()
-        + " warm:" + metricsMap.get(Tier.WARM).getSkippedReadUncompressLength()
-        + " cold:" + metricsMap.get(Tier.COLD).getSkippedReadUncompressLength()
-        + " frozen:" + metricsMap.get(Tier.FROZEN).getSkippedReadUncompressLength() + " ]";
+    return getMetricsInfo("uncompressed bytes", ClientReadHandlerMetric::getReadUncompressLength,
+        ClientReadHandlerMetric::getSkippedReadUncompressLength);
+  }
+
+  private String getMetricsInfo(String name, Function<ClientReadHandlerMetric, Long> consumed,
+      Function<ClientReadHandlerMetric, Long> skipped) {
+    return "Client read " + consumed.apply(readHandlerMetric)
+        + " " + name + " from [" + serverInfo + "], Consumed["
+        + " hot:" + consumed.apply(metricsMap.get(Tier.HOT))
+        + " warm:" + consumed.apply(metricsMap.get(Tier.WARM))
+        + " cold:" + consumed.apply(metricsMap.get(Tier.COLD))
+        + " frozen:" + consumed.apply(metricsMap.get(Tier.FROZEN)) + " ], Skipped["
+        + " hot:" + skipped.apply(metricsMap.get(Tier.HOT))
+        + " warm:" + skipped.apply(metricsMap.get(Tier.WARM))
+        + " cold:" + skipped.apply(metricsMap.get(Tier.COLD))
+        + " frozen:" + skipped.apply(metricsMap.get(Tier.FROZEN)) + " ]";
   }
 
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -41,20 +41,7 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ComposedClientReadHandler.class);
 
   private enum Tier {
-    HOT(1),
-    WARM(2),
-    COLD(3),
-    FROZEN(4);
-
-    private final int value;
-
-    Tier(int value) {
-      this.value = value;
-    }
-
-    public int getValue() {
-      return value;
-    }
+    HOT, WARM, COLD, FROZEN;
 
     public Tier next() {
       return values()[this.ordinal() + 1];
@@ -150,7 +137,7 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
     // when is no data for current handler, and the upmostLevel is not reached,
     // then try next one if there has
     if (shuffleDataResult == null || shuffleDataResult.isEmpty()) {
-      if (currentHandler.getValue() < topLevelOfHandler) {
+      if (currentHandler.ordinal() + 1 < topLevelOfHandler) {
         currentHandler = currentHandler.next();
       } else {
         return null;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -62,6 +62,12 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
   private Tier currentTier = Tier.VALUES[0]; // == Tier.HOT
   private final int numTiers;
 
+  {
+    for (Tier tier : Tier.VALUES) {
+      metricsMap.put(tier, new ClientReadHandlerMetric());
+    }
+  }
+
   public ComposedClientReadHandler(ShuffleServerInfo serverInfo, ClientReadHandler... handlers) {
     Preconditions.checkArgument(handlers.length <= Tier.VALUES.length,
         "Too many handlers, got %d, max %d", handlers.length, Tier.VALUES.length);
@@ -69,9 +75,6 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
     numTiers = handlers.length;
     for (int i = 0; i < numTiers; i++) {
       handlerMap.put(Tier.VALUES[i], handlers[i]);
-    }
-    for (Tier tier : Tier.VALUES) {
-      metricsMap.put(tier, new ClientReadHandlerMetric());
     }
   }
 
@@ -82,9 +85,6 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
     numTiers = suppliers.size();
     for (int i = 0; i < numTiers; i++) {
       supplierMap.put(Tier.VALUES[i], suppliers.get(i));
-    }
-    for (Tier tier : Tier.VALUES) {
-      metricsMap.put(tier, new ClientReadHandlerMetric());
     }
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -58,7 +58,7 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
   private final Map<Tier, Supplier<ClientReadHandler>> supplierMap = new EnumMap<>(Tier.class);
   private final Map<Tier, ClientReadHandler> handlerMap = new EnumMap<>(Tier.class);
   private final Map<Tier, ClientReadHandlerMetric> metricsMap = new EnumMap<>(Tier.class);
-  private Tier currentTier = Tier.VALUES[0];
+  private Tier currentTier = Tier.VALUES[0]; // == Tier.HOT
   private final int numTiers;
 
   public ComposedClientReadHandler(ShuffleServerInfo serverInfo, ClientReadHandler... handlers) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -89,13 +89,13 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
 
   @Override
   public ShuffleDataResult readShuffleData() {
-    ShuffleDataResult shuffleDataResult = null;
+    ClientReadHandler handler = handlerMap.computeIfAbsent(currentTier,
+        key -> supplierMap.getOrDefault(key, () -> null).get());
+    if (handler == null) {
+      throw new RssException("Unexpected null when getting " + currentTier.name() + " handler");
+    }
+    ShuffleDataResult shuffleDataResult;
     try {
-      ClientReadHandler handler = handlerMap.computeIfAbsent(currentTier,
-          key -> supplierMap.getOrDefault(key, () -> null).get());
-      if (handler == null) {
-        return null;
-      }
       shuffleDataResult = handler.readShuffleData();
     } catch (Exception e) {
       throw new RssException("Failed to read shuffle data from " + currentTier.name() + " handler", e);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -46,8 +46,10 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
   private enum Tier {
     HOT, WARM, COLD, FROZEN;
 
-    public Tier next() {
-      return values()[this.ordinal() + 1];
+    static final Tier[] VALUES = Tier.values();
+
+    Tier next() {
+      return VALUES[this.ordinal() + 1];
     }
   }
 
@@ -55,27 +57,27 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
   private final Map<Tier, Supplier<ClientReadHandler>> supplierMap = new EnumMap<>(Tier.class);
   private final Map<Tier, ClientReadHandler> handlerMap = new EnumMap<>(Tier.class);
   private final Map<Tier, ClientReadHandlerMetric> metricsMap = new EnumMap<>(Tier.class);
-  private Tier currentTier = Tier.values()[0];
+  private Tier currentTier = Tier.VALUES[0];
   private final int numTiers;
 
   public ComposedClientReadHandler(ShuffleServerInfo serverInfo, ClientReadHandler... handlers) {
     this.serverInfo = serverInfo;
-    numTiers = Math.min(Tier.values().length, handlers.length);
+    numTiers = Math.min(Tier.VALUES.length, handlers.length);
     for (int i = 0; i < numTiers; i++) {
-      handlerMap.put(Tier.values()[i], handlers[i]);
+      handlerMap.put(Tier.VALUES[i], handlers[i]);
     }
-    for (Tier tier : Tier.values()) {
+    for (Tier tier : Tier.VALUES) {
       metricsMap.put(tier, new ClientReadHandlerMetric());
     }
   }
 
   public ComposedClientReadHandler(ShuffleServerInfo serverInfo, List<Supplier<ClientReadHandler>> callables) {
     this.serverInfo = serverInfo;
-    numTiers = Math.min(Tier.values().length, callables.size());
+    numTiers = Math.min(Tier.VALUES.length, callables.size());
     for (int i = 0; i < numTiers; i++) {
-      supplierMap.put(Tier.values()[i], callables.get(i));
+      supplierMap.put(Tier.VALUES[i], callables.get(i));
     }
-    for (Tier tier : Tier.values()) {
+    for (Tier tier : Tier.VALUES) {
       metricsMap.put(tier, new ClientReadHandlerMetric());
     }
   }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -157,16 +157,19 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
 
   private String getMetricsInfo(String name, Function<ClientReadHandlerMetric, Long> consumed,
       Function<ClientReadHandlerMetric, Long> skipped) {
-    return "Client read " + consumed.apply(readHandlerMetric)
-        + " " + name + " from [" + serverInfo + "], Consumed["
-        + " hot:" + consumed.apply(metricsMap.get(Tier.HOT))
-        + " warm:" + consumed.apply(metricsMap.get(Tier.WARM))
-        + " cold:" + consumed.apply(metricsMap.get(Tier.COLD))
-        + " frozen:" + consumed.apply(metricsMap.get(Tier.FROZEN)) + " ], Skipped["
-        + " hot:" + skipped.apply(metricsMap.get(Tier.HOT))
-        + " warm:" + skipped.apply(metricsMap.get(Tier.WARM))
-        + " cold:" + skipped.apply(metricsMap.get(Tier.COLD))
-        + " frozen:" + skipped.apply(metricsMap.get(Tier.FROZEN)) + " ]";
+    StringBuilder sb = new StringBuilder("Client read ").append(consumed.apply(readHandlerMetric))
+        .append(" ").append(name).append(" from [").append(serverInfo).append("], Consumed[");
+    for (Tier tier : Tier.VALUES) {
+      sb.append(" ").append(tier.name().toLowerCase()).append(":")
+          .append(consumed.apply(metricsMap.get(tier)));
+    }
+    sb.append(" ], Skipped[");
+    for (Tier tier : Tier.VALUES) {
+      sb.append(" ").append(tier.name().toLowerCase()).append(":")
+          .append(skipped.apply(metricsMap.get(tier)));
+    }
+    sb.append(" ]");
+    return sb.toString();
   }
 
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/ComposedClientReadHandler.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.storage.handler.impl;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -116,9 +117,7 @@ public class ComposedClientReadHandler extends AbstractClientReadHandler {
 
   @Override
   public void close() {
-    for (ClientReadHandler handler : handlerMap.values()) {
-      handler.close();
-    }
+    handlerMap.values().stream().filter(Objects::nonNull).forEach(ClientReadHandler::close);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add enum Tier, use EnumMap to replace switch-case in ComposedClientReadHandler.

### Why are the changes needed?

Make the code more concise.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CI.