### PR TITLE
[#580] chore: move deploy/kubernetes to a standalone workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,3 +64,9 @@ jobs:
     with:
       maven-args: package
       reports-path: "**/target/surefire-reports/*.txt"
+
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      maven-args: package
+      maven-options: -DskipUTs -DskipITs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,4 +69,3 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       maven-args: package
-      maven-options: -DskipUTs -DskipITs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,13 +15,17 @@
 # limitations under the License.
 #
 
-name: All Profiles in Parallel
+name: All Deploy Profiles in Parallel
 
 on:
   workflow_call:
     inputs:
       maven-args:
         required: true
+        type: string
+      maven-options:
+        default: ''
+        required: false
         type: string
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
@@ -43,26 +47,21 @@ on:
         default: 'temurin'
         required: false
         type: string
+      go-version:
+        default: '1.17'
+        required: false
+        type: string
 
 jobs:
-  maven:
+  package:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         profile:
-          - spark2
-          - spark2.3
-          - spark3.0
-          - spark3
-          - spark3.2
-          - spark3.2.0
-          - spark3.3
-          - mr
+          - kubernetes
       fail-fast: false
-    name: -P${{ matrix.profile }}
+    name: ${{ matrix.profile }}
     steps:
-    - name: Set /etc/hosts mapping
-      run: sudo hostname "action-host" | sudo echo "127.0.0.1 action-host" | sudo tee -a /etc/hosts
     - name: Checkout project
       uses: actions/checkout@v3
     - name: Set up JDK ${{ inputs.java-version }}
@@ -78,8 +77,13 @@ jobs:
         restore-keys: |
           mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
           mvn-${{ inputs.java-version }}-package-
+    - name: Set up Go ${{ inputs.go-version }}
+      if: ${{ inputs.go-version != '' }}
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ inputs.go-version }}
     - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
+      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} ${{ inputs.maven-options }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,6 @@ on:
       maven-args:
         required: true
         type: string
-      maven-options:
-        default: ''
-        required: false
-        type: string
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
         required: false
@@ -83,7 +79,7 @@ jobs:
       with:
         go-version: ${{ inputs.go-version }}
     - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} ${{ inputs.maven-options }} | tee /tmp/maven.log
+      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} -DskipUTs -DskipITs | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/deploy/kubernetes/pom.xml
+++ b/deploy/kubernetes/pom.xml
@@ -53,6 +53,7 @@
             </goals>
             <configuration>
               <executable>${basedir}/test-operator.sh</executable>
+              <skip>${skipTests}</skip>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,8 @@
     <snappy-java.version>1.1.8.4</snappy-java.version>
     <test.redirectToFile>true</test.redirectToFile>
     <trimStackTrace>false</trimStackTrace>
+    <skipUTs>${skipTests}</skipUTs>
+    <skipITs>${skipTests}</skipITs>
   </properties>
 
   <repositories>
@@ -749,6 +751,7 @@
             <argLine>${argLine} -ea -Xmx3g</argLine>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <skipTests>${skipUTs}</skipTests>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Move `kubernetes` profile from `parallel.yml` to a standalone workflow.
2. Speed up `kubernetes` workflow by skipping java tests.

### Why are the changes needed?

Sub-task of #580

1. Cleanup regular CI `parallel.yml`.
2. Speed up `kubernetes` CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.