### PR TITLE
[#580] chore: improve CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-  
 
 jobs:
   checkstyle:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
   license:
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: org.apache.rat:apache-rat-plugin:check
+      maven-args: apache-rat:check
       summary: "grep -r '!?????' --include='rat.txt' | awk '{print $3}'"
 
   spotbugs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
-      cache-key: compile
+      cache-key: package
       java-version: '11'
 
   java-17:
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
-      cache-key: compile
+      cache-key: package
       java-version: '17'
 
   package:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,14 +46,14 @@ jobs:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -Djava.version=11 -DskipTests
+      maven-args: package -DskipTests
       java-version: '11'
 
   java-17:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -Djava.version=17 -DskipTests
+      maven-args: package -DskipTests
       java-version: '17'
 
   package:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,14 +46,14 @@ jobs:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -DskipTests
+      maven-args: package -Djava.version=11 -DskipTests
       java-version: '11'
 
   java-17:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -DskipTests
+      maven-args: package -Djava.version=17 -DskipTests
       java-version: '17'
 
   package:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,23 +28,27 @@ jobs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: checkstyle:check
+      cache-key: checkstyle
 
   license:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: apache-rat:check
+      cache-key: license
       summary: "grep -r '!?????' --include='rat.txt' | awk '{print $3}'"
 
   spotbugs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: test-compile spotbugs:check
+      cache-key: spotbugs
   
   java-11:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
+      cache-key: compile
       java-version: '11'
 
   java-17:
@@ -52,6 +56,7 @@ jobs:
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: package -DskipTests
+      cache-key: compile
       java-version: '17'
 
   package:

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -88,6 +88,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
+        cache: true
     - name: Execute \`mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}\`
       run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -75,7 +75,14 @@ jobs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
-        cache: maven
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
+          mvn-${{ inputs.java-version }}-package-
     - name: Set up Go ${{ inputs.go-version }}
       if: ${{ matrix.profile == 'kubernetes' }}
       uses: actions/setup-go@v3

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         go-version: ${{ inputs.go-version }}
         cache: true
-    - name: Execute \`mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}\`
+    - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
       run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -45,6 +45,10 @@ on:
         default: 'temurin'
         required: false
         type: string
+      go-version:
+        default: '1.17'
+        required: false
+        type: string
 
 jobs:
   maven:
@@ -74,11 +78,11 @@ jobs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
-    - name: Set up Go 1.17
+    - name: Set up Go ${{ inputs.go-version }}
       if: ${{ matrix.profile == 'kubernetes' }}
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ inputs.go-version }}
     - name: Execute \`mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}\`
       run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -89,6 +89,7 @@ jobs:
       with:
         go-version: ${{ inputs.go-version }}
         cache: true
+        cache-dependency-path: deploy/kubernetes/operator/go.sum
     - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
       run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: All Profiles in Parallel
 

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.17
-    - name: Execute mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}
+    - name: Execute \`mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}\`
       run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -25,10 +25,6 @@ on:
       maven-args:
         required: true
         type: string
-      experimental:
-        default: false
-        required: false
-        type: boolean
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
         required: false
@@ -83,17 +79,11 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.17
-    - name: Execute maven with -P${{ matrix.profile }}
-      if: ${{ !inputs.experimental }}
-      run: mvn -B -fae -P${{ matrix.profile }} ${{ inputs.maven-args }} | tee /tmp/maven.log
+    - name: Execute mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}
+      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash
-    - name: Execute maven with -P${{ matrix.profile }} (experimental)
-      if: ${{ inputs.experimental }}
-      run: mvn -B -fae -P${{ matrix.profile }} ${{ inputs.maven-args }} | tee /tmp/maven.log
-      shell: bash
-      continue-on-error: true
     - name: Summary of failures
-      if: ${{ (failure() || inputs.experimental) && inputs.summary != '' }}
+      if: ${{ failure() && inputs.summary != '' }}
       run: ${{ inputs.summary }}
       continue-on-error: true
     - name: Upload test reports

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -68,13 +68,13 @@ jobs:
         key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
-    - name: Execute \`mvn ${{ inputs.maven-args }} -Pspark3\`
+    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark3`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute \`mvn ${{ inputs.maven-args }} -Pspark2\`
+    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark2`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute \`mvn ${{ inputs.maven-args }} -Pmr\`
+    - name: Execute `mvn ${{ inputs.maven-args }} -Pmr`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -25,10 +25,6 @@ on:
       maven-args:
         required: true
         type: string
-      experimental:
-        default: false
-        required: false
-        type: boolean
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
         required: false
@@ -53,9 +49,6 @@ on:
 jobs:
   maven:
     runs-on: ubuntu-20.04
-    env:
-      # check main profiles only, just enough to cover all modules.
-      PROFILE: 'spark2 spark3 mr'
     name: java ${{ inputs.java-version }}
     steps:
     - name: Checkout project
@@ -66,23 +59,17 @@ jobs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
-    - name: Execute maven with ${{ env.PROFILE }}
-      if: ${{ !inputs.experimental }}
-      run: |
-        for profile in ${PROFILE}; do
-          mvn -B -fae -P${profile} ${{ inputs.maven-args }} | tee -a /tmp/maven.log;
-        done
+    - name: Execute mvn ${{ inputs.maven-args }} -Pspark3
+      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute maven with ${{ env.PROFILE }} (experimental)
-      if: ${{ inputs.experimental }}
-      run: |
-        for profile in ${PROFILE}; do
-          mvn -B -fae -P${profile} ${{ inputs.maven-args }} | tee -a /tmp/maven.log;
-        done
+    - name: Execute mvn ${{ inputs.maven-args }} -Pspark2
+      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
-      continue-on-error: true
+    - name: Execute mvn ${{ inputs.maven-args }} -Pmr
+      run: mvn -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;
+      shell: bash
     - name: Summary of failures
-      if: ${{ (failure() || inputs.experimental) && inputs.summary != '' }}
+      if: ${{ failure() && inputs.summary != '' }}
       run: ${{ inputs.summary }}
       continue-on-error: true
     - name: Upload test reports

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -59,13 +59,13 @@ jobs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
         cache: maven
-    - name: Execute mvn ${{ inputs.maven-args }} -Pspark3
+    - name: Execute \`mvn ${{ inputs.maven-args }} -Pspark3\`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute mvn ${{ inputs.maven-args }} -Pspark2
+    - name: Execute \`mvn ${{ inputs.maven-args }} -Pspark2\`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute mvn ${{ inputs.maven-args }} -Pmr
+    - name: Execute \`mvn ${{ inputs.maven-args }} -Pmr\`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Main Profiles in Sequential
 

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -23,6 +23,10 @@ on:
       maven-args:
         required: true
         type: string
+      cache-key:
+        default: ''
+        required: false
+        type: string
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
         required: false
@@ -56,7 +60,14 @@ jobs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
-        cache: maven
+    - name: Cache local Maven repository
+      if: ${{ inputs.cache-key != '' }}
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Execute \`mvn ${{ inputs.maven-args }} -Pspark3\`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Cache maven dependencies with explicit `cache-key`.
2. Cache go dependencies based on `go.sum`.
3. Expand the sequential reusable workflow.
4. Remove `experimental` option, as it's no longer needed.
5. General cleanup.

### Why are the changes needed?

Improve CI workflows. #580

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/actions/runs/4140385049