### PR TITLE
[#551] docs: update templates for flaky test and pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test-report.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test-report.yml
@@ -16,7 +16,7 @@
 #
 
 name: Uniffle Flaky Test Report
-title: "Flaky Test: "
+title: "[Flaky Test] "
 description: Describe the flaky test you encountered with Apache Uniffle
 labels: ["kind:bug,kind:test,priority:major"]
 body:
@@ -66,7 +66,7 @@ body:
   - type: textarea
     attributes:
       label: Parent issue
-      value: "#1733"
+      value: ""
     validations:
       required: false
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,34 +1,39 @@
 <!--
-Thanks for sending a pull request! Here are some tips for you:
-  1. If this is your first time, please read our contributor guidelines:
+  1. PR title format: "[#ISSUE] type(scope): summary"
+     Examples:
+       - "[#123] feat(operator): support xxx"
+       - "[#233] fix: check null before access result in xxx"
+       - "[MINOR] refactor: fix typo in variable name"
+       - "[MINOR] docs: fix typo in README"
+       - "[#255] test: fix flaky test NameOfTheTest"
+     Reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
+  2. Contributor guideline:
      https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
-  2. Please write your PR title to summarize what this PR proposes.
-     The preferred format is: "[#issue] type(scope): summary"
-     If there is no need to link to a issue: "[MINOR] type(scope): summary"
-     For reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
   3. If the PR is unfinished, please mark this PR as draft.
 -->
 
 ### What changes were proposed in this pull request?
 
-Please outline the changes and how this PR fixes the issue.
+(Please outline the changes and how this PR fixes the issue.)
 
 ### Why are the changes needed?
 
-Please clarify why the changes are needed. For instance,
+(Please clarify why the changes are needed. For instance,
   1. If you propose a new API, clarify the use case for a new API.
-  2. If you fix a bug, describe the bug.
+  2. If you fix a bug, describe the bug.)
 
 Fix: #
 
 ### Does this PR introduce _any_ user-facing change?
 
-Please list the user-facing changes introduced by your change, including
-  1. change in user-facing APIs
-  2. addition or removal of property keys
+(Please list the user-facing changes introduced by your change, including
+  1. Change in user-facing APIs.
+  2. Addition or removal of property keys.)
+
+No.
 
 ### How was this patch tested?
 
-Please test your changes before submit a PR, and provide instructions:
+(Please test your changes before submit a PR, and provide instructions:
   1. If you add a feature or fix a bug, add a test to cover your changes. 
-  2. If you fixed a flaky test, repeat it for many times in CI or IDE.
+  2. If you fixed a flaky test, repeat it for many times to prove it works.)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -36,4 +36,4 @@ No.
 
 (Please test your changes before submit a PR, and provide instructions:
   1. If you add a feature or fix a bug, add a test to cover your changes. 
-  2. If you fixed a flaky test, repeat it for many times to prove it works.)
+  2. If you fix a flaky test, repeat it for many times to prove it works.)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,44 +1,34 @@
 <!--
-Thanks for sending a pull request!  Here are some tips for you:
-  1. If this is your first time, please read our contributor guidelines: https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
-  2. Ensure you have added or run the appropriate tests for your PR
-  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
-  4. Be sure to keep the PR description updated to reflect all changes.
-  5. Please write your PR title to summarize what this PR proposes.
-  6. If possible, provide a concise example to reproduce the issue for a faster review.
+Thanks for sending a pull request! Here are some tips for you:
+  1. If this is your first time, please read our contributor guidelines:
+     https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
+  2. Please write your PR title to summarize what this PR proposes.
+     The preferred format is: "[#issue] type(scope): summary"
+     If there is no need to link to a issue: "[MINOR] type(scope): summary"
+     For reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
+  3. If the PR is unfinished, please mark this PR as draft.
 -->
 
 ### What changes were proposed in this pull request?
-<!--
-Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
-If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
-  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
-  2. If you fix some SQL features, you can provide some references of other DBMSes.
-  3. If there is design documentation, please add the link.
-  4. If there is a discussion in the mailing list, please add the link.
--->
 
+Please outline the changes and how this PR fixes the issue.
 
 ### Why are the changes needed?
-<!--
+
 Please clarify why the changes are needed. For instance,
   1. If you propose a new API, clarify the use case for a new API.
-  2. If you fix a bug, you can clarify why it is a bug.
--->
+  2. If you fix a bug, describe the bug.
 
+Fix: #
 
 ### Does this PR introduce _any_ user-facing change?
-<!--
-Note that it means *any* user-facing change including all aspects such as the documentation fix.
-If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
-If possible, please also clarify if this is a user-facing change compared to the released versions or within the unreleased branches such as master.
-If no, write 'No'.
--->
 
+Please list the user-facing changes introduced by your change, including
+  1. change in user-facing APIs
+  2. addition or removal of property keys
 
 ### How was this patch tested?
-<!--
-If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
-If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
-If tests were not added, please describe why they were not added and/or why it was difficult to add.
--->
+
+Please test your changes before submit a PR, and provide instructions:
+  1. If you add a feature or fix a bug, add a test to cover your changes. 
+  2. If you fixed a flaky test, repeat it for many times in CI or IDE.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,7 +7,7 @@
        - "[MINOR] docs: fix typo in README"
        - "[#255] test: fix flaky test NameOfTheTest"
      Reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
-  2. Contributor guideline:
+  2. Contributor guidelines:
      https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
   3. If the PR is unfinished, please mark this PR as draft.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -34,6 +34,6 @@ No.
 
 ### How was this patch tested?
 
-(Please test your changes before submit a PR, and provide instructions:
+(Please test your changes, and provide instructions on how to test it:
   1. If you add a feature or fix a bug, add a test to cover your changes. 
   2. If you fix a flaky test, repeat it for many times to prove it works.)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 <!--
-1. Title: [#<issue>]<type>(<scope>): <subject>
+1. Title: [#<issue>] <type>(<scope>): <subject>
    Examples:
      - "[#123] feat(operator): support xxx"
      - "[#233] fix: check null before access result in xxx"

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,15 +1,15 @@
 <!--
-  1. PR title format: "[#ISSUE] type(scope): summary"
-     Examples:
-       - "[#123] feat(operator): support xxx"
-       - "[#233] fix: check null before access result in xxx"
-       - "[MINOR] refactor: fix typo in variable name"
-       - "[MINOR] docs: fix typo in README"
-       - "[#255] test: fix flaky test NameOfTheTest"
-     Reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
-  2. Contributor guidelines:
-     https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
-  3. If the PR is unfinished, please mark this PR as draft.
+1. Title: [#<issue>]<type>(<scope>): <subject>
+   Examples:
+     - "[#123] feat(operator): support xxx"
+     - "[#233] fix: check null before access result in xxx"
+     - "[MINOR] refactor: fix typo in variable name"
+     - "[MINOR] docs: fix typo in README"
+     - "[#255] test: fix flaky test NameOfTheTest"
+   Reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
+2. Contributor guidelines:
+   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
+3. If the PR is unfinished, please mark this PR as draft.
 -->
 
 ### What changes were proposed in this pull request?
@@ -22,7 +22,7 @@
   1. If you propose a new API, clarify the use case for a new API.
   2. If you fix a bug, describe the bug.)
 
-Fix: #
+Fix: # (issue)
 
 ### Does this PR introduce _any_ user-facing change?
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,7 +6,7 @@
      - "[MINOR] refactor: fix typo in variable name"
      - "[MINOR] docs: fix typo in README"
      - "[#255] test: fix flaky test NameOfTheTest"
-   Reference: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
+   Reference: https://www.conventionalcommits.org/en/v1.0.0/
 2. Contributor guidelines:
    https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
 3. If the PR is unfinished, please mark this PR as draft.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update flaky test template and pr template.

### Why are the changes needed?

1. Flaky test template
    * Title is not consistent with other templates.
    * Default parent issue is invalid. 
2. PR template
    * Make the instructions shorter to read.
    * Let PR author remove the instructions so they will read (hopefully).
    * Update instructions, and add example for PR title. (Resolves #551)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.