### PR TITLE
[MINOR] refactor: simplify ShuffleWriteClientImpl#genServerToBlocks()

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -233,6 +233,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
 
     List<ShuffleServerInfo> selected = servers.limit(replicaNum).collect(Collectors.toList());
+    if (excludeServers != null) {
+      excludeServers.addAll(selected);
+    }
     for (ShuffleServerInfo ssi : selected) {
       serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList())
           .add(sbi.getBlockId());
@@ -240,9 +243,6 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           .computeIfAbsent(sbi.getShuffleId(), id -> Maps.newHashMap())
           .computeIfAbsent(sbi.getPartitionId(), id -> Lists.newArrayList())
           .add(sbi);
-    }
-    if (excludeServers != null) {
-      excludeServers.addAll(selected);
     }
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -231,16 +231,18 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       servers = servers.filter(x -> !excludeServers.contains(x));
     }
 
-    servers.limit(replicaNum)
-        .peek(excludeServers != null ? excludeServers::add : ssi -> {})
-        .forEach(ssi -> {
-          serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList())
-              .add(sbi.getBlockId());
-          serverToBlocks.computeIfAbsent(ssi, id -> Maps.newHashMap())
-              .computeIfAbsent(sbi.getShuffleId(), id -> Maps.newHashMap())
-              .computeIfAbsent(sbi.getPartitionId(), id -> Lists.newArrayList())
-              .add(sbi);
-        });
+    Stream<ShuffleServerInfo> selected = servers.limit(replicaNum);
+    if (excludeServers != null) {
+      selected = selected.peek(excludeServers::add);
+    }
+    selected.forEach(ssi -> {
+      serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList())
+          .add(sbi.getBlockId());
+      serverToBlocks.computeIfAbsent(ssi, id -> Maps.newHashMap())
+          .computeIfAbsent(sbi.getShuffleId(), id -> Maps.newHashMap())
+          .computeIfAbsent(sbi.getPartitionId(), id -> Lists.newArrayList())
+          .add(sbi);
+    });
   }
 
   /**

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -227,16 +227,6 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       servers = serverList.stream();
     }
 
-    genServerToBlocks4(sbi, servers, replicaNum, excludeServers, serverToBlocks, serverToBlockIds);
-  }
-
-  void genServerToBlocks4(
-      ShuffleBlockInfo sbi,
-      Stream<ShuffleServerInfo> servers,
-      int replicaNum,
-      List<ShuffleServerInfo> excludeServers,
-      Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
-      Map<ShuffleServerInfo, List<Long>> serverToBlockIds) {
     int partitionId = sbi.getPartitionId();
     int shuffleId = sbi.getShuffleId();
     servers.filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -248,11 +248,21 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       List<ShuffleServerInfo> excludeServers,
       Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
       Map<ShuffleServerInfo, List<Long>> serverToBlockIds) {
+    Stream<ShuffleServerInfo> servers2 = servers
+        .filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)
+        .limit(replicaNum);
+    return genServerToBlocks4(sbi, servers2, excludeServers, serverToBlocks, serverToBlockIds);
+  }
+
+  int genServerToBlocks4(
+      ShuffleBlockInfo sbi,
+      Stream<ShuffleServerInfo> servers,
+      List<ShuffleServerInfo> excludeServers,
+      Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
+      Map<ShuffleServerInfo, List<Long>> serverToBlockIds) {
     int partitionId = sbi.getPartitionId();
     int shuffleId = sbi.getShuffleId();
     return (int) servers
-        .filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)
-        .limit(replicaNum)
         .peek(excludeServers != null ? excludeServers::add : x -> {})
         .peek(ssi -> serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList()).add(sbi.getBlockId()))
         .peek(ssi -> serverToBlocks.computeIfAbsent(ssi, id -> Maps.newHashMap())

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -219,12 +219,16 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
     Stream<ShuffleServerInfo> servers = serverList.stream()
         .filter(replica > 1 ? x -> !defectiveServers.contains(x) : x -> true);
-    int assignedNum = genServerToBlocks3(sbi, servers, replicaNum,
-        excludeServers, serverToBlocks, serverToBlockIds);
+    Stream<ShuffleServerInfo> servers2 = servers
+        .filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)
+        .limit(replicaNum);
+    int assignedNum = genServerToBlocks4(sbi, servers2, excludeServers, serverToBlocks, serverToBlockIds);
 
     if (assignedNum < replicaNum) {
-      genServerToBlocks3(sbi, serverList.stream(), replicaNum - assignedNum,
-          excludeServers, serverToBlocks, serverToBlockIds);
+      Stream<ShuffleServerInfo> servers3 = serverList.stream()
+          .filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)
+          .limit(replicaNum - assignedNum);
+      genServerToBlocks4(sbi, servers3, excludeServers, serverToBlocks, serverToBlockIds);
     }
   }
 
@@ -238,20 +242,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     if (replicaNum <= 0) {
       return;
     }
-    genServerToBlocks3(sbi, serverList.stream(), replicaNum, excludeServers, serverToBlocks, serverToBlockIds);
-  }
-
-  int genServerToBlocks3(
-      ShuffleBlockInfo sbi,
-      Stream<ShuffleServerInfo> servers,
-      int replicaNum,
-      List<ShuffleServerInfo> excludeServers,
-      Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
-      Map<ShuffleServerInfo, List<Long>> serverToBlockIds) {
-    Stream<ShuffleServerInfo> servers2 = servers
+    Stream<ShuffleServerInfo> servers = serverList.stream()
         .filter(excludeServers != null ? x -> !excludeServers.contains(x) : x -> true)
         .limit(replicaNum);
-    return genServerToBlocks4(sbi, servers2, excludeServers, serverToBlocks, serverToBlockIds);
+    genServerToBlocks4(sbi, servers, excludeServers, serverToBlocks, serverToBlockIds);
   }
 
   int genServerToBlocks4(

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -222,7 +222,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
 
     Stream<ShuffleServerInfo> servers;
-    if (replica > 1 && excludeDefectiveServers) {
+    if (excludeDefectiveServers && CollectionUtils.isNotEmpty(defectiveServers)) {
       servers = Stream.concat(serverList.stream().filter(x -> !defectiveServers.contains(x)),
           serverList.stream().filter(defectiveServers::contains));
     } else {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -227,24 +227,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       if (CollectionUtils.isNotEmpty(excludeServers) && excludeServers.contains(ssi)) {
         continue;
       }
-      if (!serverToBlockIds.containsKey(ssi)) {
-        serverToBlockIds.put(ssi, Lists.newArrayList());
-      }
-      serverToBlockIds.get(ssi).add(sbi.getBlockId());
+      serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList())
+          .add(sbi.getBlockId());
 
-      if (!serverToBlocks.containsKey(ssi)) {
-        serverToBlocks.put(ssi, Maps.newHashMap());
-      }
-      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks = serverToBlocks.get(ssi);
-      if (!shuffleIdToBlocks.containsKey(shuffleId)) {
-        shuffleIdToBlocks.put(shuffleId, Maps.newHashMap());
-      }
+      serverToBlocks.computeIfAbsent(ssi, id -> Maps.newHashMap())
+          .computeIfAbsent(shuffleId, id -> Maps.newHashMap())
+          .computeIfAbsent(partitionId, id -> Lists.newArrayList())
+          .add(sbi);
 
-      Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = shuffleIdToBlocks.get(shuffleId);
-      if (!partitionToBlocks.containsKey(partitionId)) {
-        partitionToBlocks.put(partitionId, Lists.newArrayList());
-      }
-      partitionToBlocks.get(partitionId).add(sbi);
       if (excludeServers != null) {
         excludeServers.add(ssi);
       }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -220,8 +220,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     if (replicaNum <= 0) {
       return;
     }
-    Stream<ShuffleServerInfo> servers;
 
+    final Stream<ShuffleServerInfo> servers;
     if (replica > 1 && excludeDefectiveServers) {
       servers = Stream.concat(serverList.stream().filter(x -> !defectiveServers.contains(x)),
           serverList.stream().filter(defectiveServers::contains));
@@ -229,15 +229,13 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       servers = serverList.stream();
     }
 
-    int partitionId = sbi.getPartitionId();
-    int shuffleId = sbi.getShuffleId();
-    servers.filter(x -> !excludeServers.contains(x))
-        .limit(replicaNum)
+    servers.filter(x -> !excludeServers.contains(x)).limit(replicaNum)
         .peek(excludeServers::add)
-        .peek(ssi -> serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList()).add(sbi.getBlockId()))
+        .peek(ssi -> serverToBlockIds.computeIfAbsent(ssi, id -> Lists.newArrayList())
+            .add(sbi.getBlockId()))
         .forEach(ssi -> serverToBlocks.computeIfAbsent(ssi, id -> Maps.newHashMap())
-            .computeIfAbsent(shuffleId, id -> Maps.newHashMap())
-            .computeIfAbsent(partitionId, id -> Lists.newArrayList())
+            .computeIfAbsent(sbi.getShuffleId(), id -> Maps.newHashMap())
+            .computeIfAbsent(sbi.getPartitionId(), id -> Lists.newArrayList())
             .add(sbi));
   }
 

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -136,12 +136,12 @@ public class ShuffleWriteClientImplTest {
         new RssSendShuffleDataResponse(StatusCode.SUCCESS));
     List<ShuffleServerInfo> excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
     assertEquals(2, excludeServers.size());
     assertEquals(ssi2, excludeServers.get(0));
     assertEquals(ssi3, excludeServers.get(1));
-    spyClient.genServerToBlocks2(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        1, excludeServers, Maps.newHashMap(), Maps.newHashMap());
+    spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
+        1, excludeServers, Maps.newHashMap(), Maps.newHashMap(), false);
     assertEquals(3, excludeServers.size());
     assertEquals(ssi1, excludeServers.get(2));
     result = spyClient.sendShuffleData(appId, shuffleBlockInfoList, () -> false);
@@ -162,12 +162,12 @@ public class ShuffleWriteClientImplTest {
     assertEquals(ssi2, spyClient.getDefectiveServers().toArray()[0]);
     excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
     assertEquals(2, excludeServers.size());
     assertEquals(ssi1, excludeServers.get(0));
     assertEquals(ssi3, excludeServers.get(1));
-    spyClient.genServerToBlocks2(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        1, excludeServers, Maps.newHashMap(), Maps.newHashMap());
+    spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
+        1, excludeServers, Maps.newHashMap(), Maps.newHashMap(), false);
     assertEquals(3, excludeServers.size());
     assertEquals(ssi2, excludeServers.get(2));
 
@@ -176,7 +176,7 @@ public class ShuffleWriteClientImplTest {
     assertEquals(2, spyClient.getDefectiveServers().size());
     excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
     assertEquals(2, excludeServers.size());
     assertEquals(ssi3, excludeServers.get(0));
     assertEquals(ssi1, excludeServers.get(1));

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -136,12 +136,12 @@ public class ShuffleWriteClientImplTest {
         new RssSendShuffleDataResponse(StatusCode.SUCCESS));
     List<ShuffleServerInfo> excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
     assertEquals(2, excludeServers.size());
     assertEquals(ssi2, excludeServers.get(0));
     assertEquals(ssi3, excludeServers.get(1));
-    spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        1, excludeServers, Maps.newHashMap(), Maps.newHashMap(), false);
+    spyClient.genServerToBlocks2(shuffleBlockInfoList.get(0), shuffleServerInfoList,
+        1, excludeServers, Maps.newHashMap(), Maps.newHashMap());
     assertEquals(3, excludeServers.size());
     assertEquals(ssi1, excludeServers.get(2));
     result = spyClient.sendShuffleData(appId, shuffleBlockInfoList, () -> false);
@@ -162,12 +162,12 @@ public class ShuffleWriteClientImplTest {
     assertEquals(ssi2, spyClient.getDefectiveServers().toArray()[0]);
     excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
     assertEquals(2, excludeServers.size());
     assertEquals(ssi1, excludeServers.get(0));
     assertEquals(ssi3, excludeServers.get(1));
-    spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        1, excludeServers, Maps.newHashMap(), Maps.newHashMap(), false);
+    spyClient.genServerToBlocks2(shuffleBlockInfoList.get(0), shuffleServerInfoList,
+        1, excludeServers, Maps.newHashMap(), Maps.newHashMap());
     assertEquals(3, excludeServers.size());
     assertEquals(ssi2, excludeServers.get(2));
 
@@ -176,7 +176,7 @@ public class ShuffleWriteClientImplTest {
     assertEquals(2, spyClient.getDefectiveServers().size());
     excludeServers = new ArrayList<>();
     spyClient.genServerToBlocks(shuffleBlockInfoList.get(0), shuffleServerInfoList,
-        2, excludeServers, Maps.newHashMap(), Maps.newHashMap(), true);
+        2, excludeServers, Maps.newHashMap(), Maps.newHashMap());
     assertEquals(2, excludeServers.size());
     assertEquals(ssi3, excludeServers.get(0));
     assertEquals(ssi1, excludeServers.get(1));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify `ShuffleWriteClientImpl#genServerToBlocks()`.

### Why are the changes needed?

Simplify code logic. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by `ShuffleWriteClientImplTest#testSendDataWithDefectiveServers()`.
