### PR TITLE
[MINOR] chore: remove duplicated dependency in rss-client-mr

### DIFF
--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -34,6 +34,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
@@ -61,10 +65,6 @@
             <version>${hadoop.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.uniffle</groupId>
-            <artifactId>rss-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -90,10 +90,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.uniffle</groupId>
-            <artifactId>rss-client</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove duplicated dependency in `rss-client-mr`.

### Why are the changes needed?

Dependency `rss-client` is duplicated.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
