### PR TITLE
[#580] chore: speed up CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,9 @@ jobs:
       maven-args: package -Dtest=org.apache.uniffle.test.**
       reports-path: "**/target/surefire-reports/*.txt"
 
-  deploy:
-    uses: ./.github/workflows/deploy.yml
+  kubernetes:
+    uses: ./.github/workflows/single.yml
     with:
-      maven-args: package
+      maven-args: package -Pkubernetes -DskipUTs -DskipITs
+      cache-key: package
+      go-version: '1.17'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,13 @@ jobs:
   package:
     uses: ./.github/workflows/parallel.yml
     with:
-      maven-args: package
+      maven-args: package -Dtest=!org.apache.uniffle.test.**
+      reports-path: "**/target/surefire-reports/*.txt"
+
+  integration:
+    uses: ./.github/workflows/parallel.yml
+    with:
+      maven-args: package -Dtest=org.apache.uniffle.test.**
       reports-path: "**/target/surefire-reports/*.txt"
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,14 @@ jobs:
       summary: "grep -r '!?????' --include='rat.txt' | awk '{print $3}'"
 
   spotbugs:
+    needs: [checkstyle, license] # delay execution
     uses: ./.github/workflows/sequential.yml
     with:
       maven-args: test-compile spotbugs:check
       cache-key: spotbugs
   
   java-11:
+    needs: [spotbugs] # delay execution
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
@@ -52,6 +54,7 @@ jobs:
       java-version: '11'
 
   java-17:
+    needs: [spotbugs] # delay execution
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
@@ -72,6 +75,7 @@ jobs:
       reports-path: "**/target/surefire-reports/*.txt"
 
   kubernetes:
+    needs: [checkstyle, license] # delay execution
     uses: ./.github/workflows/single.yml
     with:
       maven-args: package -Pkubernetes -DskipUTs -DskipITs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,10 @@ jobs:
       maven-args: package -Dtest=org.apache.uniffle.test.**
       reports-path: "**/target/surefire-reports/*.txt"
 
-  deploy:
+  kubernetes:
     needs: [checkstyle, license] # delay execution
     uses: ./.github/workflows/single.yml
     with:
       maven-args: package -Pkubernetes -DskipUTs -DskipITs
       cache-key: package
       go-version: '1.17'
-      display-name: kubernetes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,11 @@ jobs:
       maven-args: package -Dtest=org.apache.uniffle.test.**
       reports-path: "**/target/surefire-reports/*.txt"
 
-  kubernetes:
+  deploy:
     needs: [checkstyle, license] # delay execution
     uses: ./.github/workflows/single.yml
     with:
       maven-args: package -Pkubernetes -DskipUTs -DskipITs
       cache-key: package
       go-version: '1.17'
+      display-name: kubernetes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       cache-key: package
       java-version: '17'
 
-  package:
+  unit:
     uses: ./.github/workflows/parallel.yml
     with:
       maven-args: package -Dtest=!org.apache.uniffle.test.**

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -79,7 +79,7 @@ jobs:
           mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
           mvn-${{ inputs.java-version }}-package-
     - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
+      run: mvn -T1C -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -69,13 +69,13 @@ jobs:
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Execute `mvn ${{ inputs.maven-args }} -Pspark3`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+      run: mvn -T1C -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `mvn ${{ inputs.maven-args }} -Pspark2`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+      run: mvn -T1C -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `mvn ${{ inputs.maven-args }} -Pmr`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;
+      run: mvn -T1C -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -48,7 +48,7 @@ on:
         required: false
         type: string
       go-version:
-        default: 'None'
+        default: ''
         required: false
         type: string
       display-name:
@@ -77,7 +77,7 @@ jobs:
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Set up Go ${{ inputs.go-version }}
-      if: ${{ inputs.go-version != 'None' }}
+      if: ${{ inputs.go-version != '' }}
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -51,11 +51,15 @@ on:
         default: 'None'
         required: false
         type: string
+      display-name:
+        default: 'maven'
+        required: false
+        type: string
 
 jobs:
   maven:
     runs-on: ubuntu-20.04
-    name: java ${{ inputs.java-version }} + go ${{ inputs.go-version }}
+    name: ${{ inputs.display-name }}
     steps:
     - name: Checkout project
       uses: actions/checkout@v3

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -51,15 +51,11 @@ on:
         default: ''
         required: false
         type: string
-      display-name:
-        default: 'maven'
-        required: false
-        type: string
 
 jobs:
   maven:
     runs-on: ubuntu-20.04
-    name: ${{ inputs.display-name }}
+    name: java ${{ inputs.java-version }} + go ${{ inputs.go-version }}
     steps:
     - name: Checkout project
       uses: actions/checkout@v3

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         go-version: ${{ inputs.go-version }}
     - name: Execute `mvn ${{ inputs.maven-args }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
+      run: mvn -T1C -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -15,13 +15,17 @@
 # limitations under the License.
 #
 
-name: All Deploy Profiles in Parallel
+name: Single Maven Profile
 
 on:
   workflow_call:
     inputs:
       maven-args:
         required: true
+        type: string
+      cache-key:
+        default: ''
+        required: false
         type: string
       summary:
         default: "grep -e '^\\[ERROR\\]' /tmp/maven.log || true"
@@ -44,19 +48,14 @@ on:
         required: false
         type: string
       go-version:
-        default: '1.17'
+        default: 'None'
         required: false
         type: string
 
 jobs:
-  package:
+  maven:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        profile:
-          - kubernetes
-      fail-fast: false
-    name: ${{ matrix.profile }}
+    name: java ${{ inputs.java-version }} + go ${{ inputs.go-version }}
     steps:
     - name: Checkout project
       uses: actions/checkout@v3
@@ -66,20 +65,20 @@ jobs:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.jdk-distro }}
     - name: Cache local Maven repository
+      if: ${{ inputs.cache-key != '' }}
       uses: actions/cache@v3
       with:
         path: ~/.m2/repository
-        key: mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-${{ hashFiles('**/pom.xml') }}
+        key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
-          mvn-${{ inputs.java-version }}-package-
+          mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
     - name: Set up Go ${{ inputs.go-version }}
-      if: ${{ inputs.go-version != '' }}
+      if: ${{ inputs.go-version != 'None' }}
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
-    - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} -P${{ matrix.profile }} -DskipUTs -DskipITs | tee /tmp/maven.log
+    - name: Execute `mvn ${{ inputs.maven-args }}`
+      run: mvn -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}
@@ -89,7 +88,7 @@ jobs:
       if: ${{ failure() && inputs.reports-path != '' }}
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.reports-name }}-${{ matrix.profile }}
+        name: ${{ inputs.reports-name }}
         path: ${{ inputs.reports-path }}
       continue-on-error: true
     - name: Upload coverage to Codecov


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Split unit test and integration test
2. Enable maven parallel build (`-T1C`)
3. Do not use matrix in deploy/kubernetes workflow
4. Delay some secondary workflows 

### Why are the changes needed?

Resolve #580
Make CI faster.
In case of failure, rerun the failed part only.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/incubator-uniffle/actions/runs/4180474332

<img width="979" alt="image" src="https://user-images.githubusercontent.com/5821159/218936913-30318234-d0c8-48c7-bc9d-beb9f204f3da.png">
