### PR TITLE
[#291][part-0] feat(client): support async read 

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
@@ -65,7 +65,7 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
                 .getWarmStorageManager();
     for (Storage storage : warmStorageManager.getStorages()) {
       LocalStorage localStorage = (LocalStorage) storage;
-      localStorage.markSpaceFull();
+      localStorage.setWatermarkLimitTriggered(true);
     }
   }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -52,8 +52,8 @@ public class LocalStorage extends AbstractStorage {
   private final double lowWaterMarkOfWrite;
   private final LocalStorageMeta metaData = new LocalStorageMeta();
   private final StorageMedia media;
-  private boolean isSpaceEnough = true;
   private volatile boolean isCorrupted = false;
+  private volatile boolean isWatermarkLimitTriggered = false;
 
   private LocalStorage(Builder builder) {
     this.basePath = builder.basePath;
@@ -144,12 +144,7 @@ public class LocalStorage extends AbstractStorage {
 
   @Override
   public boolean canWrite() {
-    if (isSpaceEnough) {
-      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < highWaterMarkOfWrite;
-    } else {
-      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < lowWaterMarkOfWrite;
-    }
-    return isSpaceEnough && !isCorrupted;
+    return !isWatermarkLimitTriggered && !isCorrupted;
   }
 
   public String getBasePath() {
@@ -237,10 +232,12 @@ public class LocalStorage extends AbstractStorage {
     return appIds;
   }
 
-  // Only for test
-  @VisibleForTesting
-  public void markSpaceFull() {
-    isSpaceEnough = false;
+  public void setWatermarkLimitTriggered(boolean watermarkLimitTriggered) {
+    isWatermarkLimitTriggered = watermarkLimitTriggered;
+  }
+
+  public boolean isWatermarkLimitTriggered() {
+    return isWatermarkLimitTriggered;
   }
 
   public static class Builder {

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -75,17 +75,14 @@ public class LocalStorageTest {
   @Test
   public void canWriteTest() {
     LocalStorage item = createTestStorage(testBaseDir);
+    assertTrue(item.canWrite());
 
-    item.getMetaData().updateDiskSize(20);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(65);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(10);
+    item.setWatermarkLimitTriggered(true);
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
+
+    item.setWatermarkLimitTriggered(false);
+    item.markCorrupted();
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
-    assertTrue(item.canWrite());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. support async read in client side.

#### Limitation:
1. In current implementation, limited by the no-thread-safe client read handler, the thread number of async fetching is restricted to 1. The thread safe read handler could be supported in another PR.

### Why are the changes needed?
In current codebase, the sequence of reading is fetching and then handling. If we could read and fetch data async, the performance will be improved.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
1. Existing UTs
3. New UTs
