### PR TITLE
[#571][FOLLOWUP] fix: optimize base dir init process

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -19,10 +19,8 @@ package org.apache.uniffle.storage.common;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
@@ -78,14 +76,10 @@ public class LocalStorage extends AbstractStorage {
 
     File baseFolder = new File(basePath);
     try {
-      if (isEmptyAndWritableDir(baseFolder)) {
-        LOG.warn("Base directory is already an empty dir, skip init");
-      } else {
-        FileUtils.deleteDirectory(baseFolder);
-        if (!baseFolder.mkdirs()) {
-          throw new IOException("Failed to create base folder: " + basePath);
-        }
-      }
+      // similar to mkdir -p, ensure the base folder is a dir
+      FileUtils.forceMkdir(baseFolder);
+      // clean the directory if it's data left from previous ran.
+      FileUtils.cleanDirectory(baseFolder);
       FileStore store = Files.getFileStore(baseFolder.toPath());
       this.mountPoint =  store.name();
     } catch (IOException ioe) {
@@ -103,15 +97,6 @@ public class LocalStorage extends AbstractStorage {
             + " is smaller than configuration");
       }
     }
-  }
-
-  private boolean isEmptyAndWritableDir(File baseDir) throws IOException {
-    if (baseDir.isDirectory() && baseDir.canWrite()) {
-      try (DirectoryStream<Path> stream = Files.newDirectoryStream(baseDir.toPath())) {
-        return !stream.iterator().hasNext();
-      }
-    }
-    return false;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
optimize the base dir init logic, it now skips recreate base dir if it's already an dir

### Why are the changes needed?
handles some corner cases such as the base dir is an mount point root path.

### Does this PR introduce _any_ user-facing change?
rss shuffle server can use mounted path as base dir directly.

### How was this patch tested?
Existing UTs.