### PR TITLE
[#632]fix: respect volumes in rss spec

### DIFF
--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
@@ -184,21 +184,21 @@ func GenerateDeploy(rss *unifflev1alpha1.RemoteShuffleService, index int) *appsv
 				Key:    "node-role.kubernetes.io/master",
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: controllerconstants.ConfigurationVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: rss.Spec.ConfigMapName,
-						},
-						DefaultMode: pointer.Int32(0777),
-					},
-				},
-			},
-		},
+		Volumes:      rss.Spec.Coordinator.Volumes,
 		NodeSelector: rss.Spec.Coordinator.NodeSelector,
 	}
+	configurationVolume := corev1.Volume{
+		Name: controllerconstants.ConfigurationVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: rss.Spec.ConfigMapName,
+				},
+				DefaultMode: pointer.Int32(0777),
+			},
+		},
+	}
+	podSpec.Volumes = append(podSpec.Volumes, configurationVolume)
 	if podSpec.HostNetwork {
 		podSpec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}

--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
@@ -68,6 +68,19 @@ var (
 			Value: "127.0.0.1",
 		},
 	}
+	testVolumeName = "test-volume"
+	testVolumes    = []corev1.Volume{
+		{
+			Name: testVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "test-config",
+					},
+				},
+			},
+		},
+	}
 )
 
 func buildRssWithLabels() *uniffleapi.RemoteShuffleService {
@@ -85,6 +98,12 @@ func buildRssWithRuntimeClassName() *uniffleapi.RemoteShuffleService {
 func buildRssWithCustomENVs() *uniffleapi.RemoteShuffleService {
 	rss := utils.BuildRSSWithDefaultValue()
 	rss.Spec.Coordinator.Env = testENVs
+	return rss
+}
+
+func withCustomVolumes(volumes []corev1.Volume) *uniffleapi.RemoteShuffleService {
+	rss := utils.BuildRSSWithDefaultValue()
+	rss.Spec.Coordinator.Volumes = volumes
 	return rss
 }
 
@@ -306,6 +325,18 @@ func TestGenerateDeploy(t *testing.T) {
 						string(actualPortsBody), string(expectPortsBody))
 				}
 				return
+			},
+		},
+		{
+			name: "set custom volumes",
+			rss:  withCustomVolumes(testVolumes),
+			IsValidDeploy: func(deploy *appsv1.Deployment, rss *uniffleapi.RemoteShuffleService) (bool, error) {
+				for _, volume := range deploy.Spec.Template.Spec.Volumes {
+					if volume.Name == testVolumeName {
+						return true, nil
+					}
+				}
+				return false, fmt.Errorf("generated deploy should include volume: %s", testVolumeName)
 			},
 		},
 	} {

--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
@@ -333,7 +333,13 @@ func TestGenerateDeploy(t *testing.T) {
 			IsValidDeploy: func(deploy *appsv1.Deployment, rss *uniffleapi.RemoteShuffleService) (bool, error) {
 				for _, volume := range deploy.Spec.Template.Spec.Volumes {
 					if volume.Name == testVolumeName {
-						return true, nil
+						expectedVolume := testVolumes[0]
+						equal := reflect.DeepEqual(expectedVolume, volume)
+						if equal {
+							return true, nil
+						}
+						volumeJSON, _ := json.Marshal(expectedVolume)
+						return false, fmt.Errorf("generated deploy doesn't contain expected volumn: %s", volumeJSON)
 					}
 				}
 				return false, fmt.Errorf("generated deploy should include volume: %s", testVolumeName)

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
@@ -91,21 +91,21 @@ func GenerateSts(rss *unifflev1alpha1.RemoteShuffleService) *appsv1.StatefulSet 
 				Key:    "node-role.kubernetes.io/master",
 			},
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: controllerconstants.ConfigurationVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: rss.Spec.ConfigMapName,
-						},
-						DefaultMode: pointer.Int32(0777),
-					},
-				},
-			},
-		},
+		Volumes:      rss.Spec.ShuffleServer.Volumes,
 		NodeSelector: rss.Spec.ShuffleServer.NodeSelector,
 	}
+	configurationVolume := corev1.Volume{
+		Name: controllerconstants.ConfigurationVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: rss.Spec.ConfigMapName,
+				},
+				DefaultMode: pointer.Int32(0777),
+			},
+		},
+	}
+	podSpec.Volumes = append(podSpec.Volumes, configurationVolume)
 	if podSpec.HostNetwork {
 		podSpec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
@@ -68,6 +68,19 @@ var (
 			Value: "1G",
 		},
 	}
+	testVolumeName = "test-volume"
+	testVolumes    = []corev1.Volume{
+		{
+			Name: testVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "test-config",
+					},
+				},
+			},
+		},
+	}
 )
 
 func buildRssWithLabels() *uniffleapi.RemoteShuffleService {
@@ -90,6 +103,12 @@ func buildRssWithRuntimeClassName() *uniffleapi.RemoteShuffleService {
 func buildRssWithCustomENVs() *uniffleapi.RemoteShuffleService {
 	rss := utils.BuildRSSWithDefaultValue()
 	rss.Spec.ShuffleServer.Env = testENVs
+	return rss
+}
+
+func withCustomVolumes(volumes []corev1.Volume) *uniffleapi.RemoteShuffleService {
+	rss := utils.BuildRSSWithDefaultValue()
+	rss.Spec.ShuffleServer.Volumes = volumes
 	return rss
 }
 
@@ -313,6 +332,18 @@ func TestGenerateSts(t *testing.T) {
 						string(actualPortsBody), string(expectPortsBody))
 				}
 				return
+			},
+		},
+		{
+			name: "test custom volumes",
+			rss:  withCustomVolumes(testVolumes),
+			IsValidSts: func(sts *appsv1.StatefulSet, rss *uniffleapi.RemoteShuffleService) (valid bool, err error) {
+				for _, volume := range sts.Spec.Template.Spec.Volumes {
+					if volume.Name == testVolumeName {
+						return true, nil
+					}
+				}
+				return false, fmt.Errorf("generated sts should include volume: %s", testVolumeName)
 			},
 		},
 	} {

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
@@ -340,7 +340,13 @@ func TestGenerateSts(t *testing.T) {
 			IsValidSts: func(sts *appsv1.StatefulSet, rss *uniffleapi.RemoteShuffleService) (valid bool, err error) {
 				for _, volume := range sts.Spec.Template.Spec.Volumes {
 					if volume.Name == testVolumeName {
-						return true, nil
+						expectedVolume := testVolumes[0]
+						equal := reflect.DeepEqual(expectedVolume, volume)
+						if equal {
+							return true, nil
+						}
+						volumeJSON, _ := json.Marshal(expectedVolume)
+						return false, fmt.Errorf("generated sts doesn't contain expected volumn: %s", volumeJSON)
 					}
 				}
 				return false, fmt.Errorf("generated sts should include volume: %s", testVolumeName)


### PR DESCRIPTION
### What changes were proposed in this pull request?
respect volumes for rss coordinator and shuffle server

### Why are the changes needed?
This is a bug fix
Fix: #632

### Does this PR introduce _any_ user-facing change?
Admin of rss cluster could specify the volumes which could be used to configure 
hadoop conf for example
### How was this patch tested?
Added UTs.