### PR TITLE
[#635] feat(client): enable LOCAL_ORDER by default for Spark AQE 

### DIFF
--- a/client-spark/spark3/pom.xml
+++ b/client-spark/spark3/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>hadoop-minicluster</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.common.ShuffleDataDistributionType;
+import org.apache.uniffle.common.config.RssClientConf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RssShuffleManagerTest {
+  private static final String SPARK_ADAPTIVE_EXECUTION_ENABLED_KEY = "spark.sql.adaptive.enabled";
+
+  @Test
+  public void testGetDataDistributionType() {
+    // case1
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set(SPARK_ADAPTIVE_EXECUTION_ENABLED_KEY, "true");
+    assertEquals(
+        ShuffleDataDistributionType.LOCAL_ORDER,
+        RssShuffleManager.getDataDistributionType(sparkConf)
+    );
+
+    // case2
+    sparkConf = new SparkConf();
+    sparkConf.set(SPARK_ADAPTIVE_EXECUTION_ENABLED_KEY, "false");
+    assertEquals(
+        RssClientConf.DATA_DISTRIBUTION_TYPE.defaultValue(),
+        RssShuffleManager.getDataDistributionType(sparkConf)
+    );
+
+    // case3
+    sparkConf = new SparkConf();
+    sparkConf.set(SPARK_ADAPTIVE_EXECUTION_ENABLED_KEY, "true");
+    sparkConf.set("spark." + RssClientConf.DATA_DISTRIBUTION_TYPE.key(), ShuffleDataDistributionType.NORMAL.name());
+    assertEquals(
+        ShuffleDataDistributionType.NORMAL,
+        RssShuffleManager.getDataDistributionType(sparkConf)
+    );
+
+    // case4
+    sparkConf = new SparkConf();
+    sparkConf.set(SPARK_ADAPTIVE_EXECUTION_ENABLED_KEY, "true");
+    sparkConf.set(
+        "spark." + RssClientConf.DATA_DISTRIBUTION_TYPE.key(),
+        ShuffleDataDistributionType.LOCAL_ORDER.name()
+    );
+    assertEquals(
+        ShuffleDataDistributionType.LOCAL_ORDER,
+        RssShuffleManager.getDataDistributionType(sparkConf)
+    );
+
+    // case5
+    sparkConf = new SparkConf();
+    boolean aqeEnable = (boolean) sparkConf.get(SQLConf.ADAPTIVE_EXECUTION_ENABLED());
+    if (aqeEnable) {
+      assertEquals(
+          ShuffleDataDistributionType.LOCAL_ORDER,
+          RssShuffleManager.getDataDistributionType(sparkConf)
+      );
+    } else {
+      assertEquals(
+          RssClientConf.DATA_DISTRIBUTION_TYPE.defaultValue(),
+          RssShuffleManager.getDataDistributionType(sparkConf)
+      );
+    }
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -40,7 +40,7 @@ public class RssClientConf {
   public static final ConfigOption<ShuffleDataDistributionType> DATA_DISTRIBUTION_TYPE = ConfigOptions
       .key("rss.client.shuffle.data.distribution.type")
       .enumType(ShuffleDataDistributionType.class)
-      .defaultValue(ShuffleDataDistributionType.LOCAL_ORDER)
+      .defaultValue(ShuffleDataDistributionType.NORMAL)
       .withDescription("The type of partition shuffle data distribution, including normal and local_order. "
           + "The default value is normal. This config is only valid in Spark3.x");
 }

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -40,7 +40,7 @@ public class RssClientConf {
   public static final ConfigOption<ShuffleDataDistributionType> DATA_DISTRIBUTION_TYPE = ConfigOptions
       .key("rss.client.shuffle.data.distribution.type")
       .enumType(ShuffleDataDistributionType.class)
-      .defaultValue(ShuffleDataDistributionType.NORMAL)
+      .defaultValue(ShuffleDataDistributionType.LOCAL_ORDER)
       .withDescription("The type of partition shuffle data distribution, including normal and local_order. "
           + "The default value is normal. This config is only valid in Spark3.x");
 }

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -63,7 +63,7 @@ To improve performance of AQE skew optimization, uniffle introduces the LOCAL_OR
 and Continuous partition assignment mechanism.
 
 1. LOCAL_ORDER shuffle-data distribution mechanism filter the lots of data to reduce network bandwidth and shuffle-server local-disk pressure. 
-   It's enabled by default in Spark3.x
+   It will be enabled by default when AQE is enabled.
 
 2. Continuous partition assignment mechanism assign consecutive partitions to the same ShuffleServer to reduce the frequency of getShuffleResult.
 

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -62,13 +62,8 @@ After apply the patch and rebuild spark, add following configuration in spark co
 To improve performance of AQE skew optimization, uniffle introduces the LOCAL_ORDER shuffle-data distribution mechanism 
 and Continuous partition assignment mechanism.
 
-1. LOCAL_ORDER shuffle-data distribution mechanism filter the lots of data to reduce network bandwidth and shuffle-server local-disk pressure.
-
-    It can be enabled by the following config
-      ```bash
-      # Default value is NORMAL, it will directly append to file when the memory data is flushed to external storage 
-      spark.rss.client.shuffle.data.distribution.type LOCAL_ORDER
-      ```
+1. LOCAL_ORDER shuffle-data distribution mechanism filter the lots of data to reduce network bandwidth and shuffle-server local-disk pressure. 
+   It's enabled by default in Spark3.x
 
 2. Continuous partition assignment mechanism assign consecutive partitions to the same ShuffleServer to reduce the frequency of getShuffleResult.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
enable LOCAL_ORDER by default for Spark AQE 

### Why are the changes needed?
Currently, the local_order data distribution type should be activated explicitly. It's better to enable it when using AQE by default.
Fix: #635

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
1. Existing UTs