### PR TITLE
[#576] test: increase timeout and remove initialization time in storage strategy tests

### DIFF
--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategyTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategyTest.java
@@ -125,7 +125,7 @@ public class AppBalanceSelectStorageStrategyTest {
   }
 
   @Test
-  @Timeout(20)
+  @Timeout(30)
   public void storageCounterMulThreadTest() throws Exception {
     String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2
         + Constants.COMMA_SPLIT_CHAR + remotePath3;
@@ -133,8 +133,6 @@ public class AppBalanceSelectStorageStrategyTest {
     applicationManager.getSelectStorageStrategy().detectStorage();
     CountDownLatch cdl = new CountDownLatch(3);
     String testApp1 = "application_testAppId";
-    // init detectStorageScheduler
-    Thread.sleep(2000);
     Thread pickThread1 = new Thread(() -> {
       for (int i = 0; i < 1000; i++) {
         String appId = testApp1 + i;

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/LowestIOSampleCostSelectStorageStrategyTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/strategy/storage/LowestIOSampleCostSelectStorageStrategyTest.java
@@ -142,7 +142,7 @@ public class LowestIOSampleCostSelectStorageStrategyTest {
   }
 
   @Test
-  @Timeout(20)
+  @Timeout(30)
   public void selectStorageMulThreadTest() throws Exception {
     String remoteStoragePath = remoteStorage1 + Constants.COMMA_SPLIT_CHAR + remoteStorage2
         + Constants.COMMA_SPLIT_CHAR + remoteStorage3;
@@ -150,8 +150,6 @@ public class LowestIOSampleCostSelectStorageStrategyTest {
     applicationManager.getSelectStorageStrategy().detectStorage();
     CountDownLatch cdl = new CountDownLatch(3);
     String testApp1 = "application_testAppId";
-    // init detectStorageScheduler
-    Thread.sleep(2000);
     Thread pickThread1 = new Thread(() -> {
       for (int i = 0; i < 1000; i++) {
         String appId = testApp1 + i;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
1、Increase the method execution timeout
2、Don't need to sleep for 2s to initialize, because we have manually closed the `detectStorageScheduler`


### Why are the changes needed?

Fix: #576

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Fix uts.

