### PR TITLE
[#649] test: remove mini-cluster in ClientConfManagerTest

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -74,10 +74,6 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minicluster</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
     </dependency>

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/ClientConfManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/ClientConfManagerTest.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.coordinator;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.Map;
@@ -29,8 +28,6 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,11 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientConfManagerTest {
 
-  @TempDir
-  private final File remotePath = new File("hdfs://rss");
-  private static MiniDFSCluster cluster;
-  private final Configuration hdfsConf = new Configuration();
-
   @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
@@ -62,18 +54,6 @@ public class ClientConfManagerTest {
   @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
-  }
-
-  @AfterAll
-  public static void close() {
-    cluster.close();
-  }
-
-  public void createMiniHdfs(String hdfsPath) throws IOException {
-    hdfsConf.set("fs.defaultFS", remotePath.getAbsolutePath());
-    hdfsConf.set("dfs.nameservices", "rss");
-    hdfsConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath);
-    cluster = (new MiniDFSCluster.Builder(hdfsConf)).build();
   }
 
   @Test
@@ -230,7 +210,6 @@ public class ClientConfManagerTest {
     File cfgFile = Files.createTempFile("dynamicRemoteStorageTest", ".conf").toFile();
     cfgFile.deleteOnExit();
     writeRemoteStorageConf(cfgFile, remotePath1);
-    createMiniHdfs(remotePath.getAbsolutePath());
 
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, updateIntervalSec);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Mini-cluster need take some time to initialize, after the current path detection is triggered manually, we do not need to manually write the file to mini-cluster. So we can remove the dependency of this mini-cluster in Coordinator.

### Why are the changes needed?
Fix: #649

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Before:
```
[INFO] Running org.apache.uniffle.coordinator.ClientConfManagerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.28 s - in org.apache.uniffle.coordinator.ClientConfManagerTest
```

After:
```
[INFO] Running org.apache.uniffle.coordinator.ClientConfManagerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.071 s - in org.apache.uniffle.coordinator.ClientConfManagerTest
```