### PR TITLE
chore: unify the style of spark profile id

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -50,10 +50,10 @@ jobs:
     strategy:
       matrix:
         profile:
-          - spark2
           - spark2.3
+          - spark2.4
           - spark3.0
-          - spark3
+          - spark3.1
           - spark3.2
           - spark3.2.0
           - spark3.3

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -68,11 +68,11 @@ jobs:
         key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark3`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark3.1`
+      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3.1 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark2`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark2.4`
+      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2.4 | tee -a /tmp/maven.log;
       shell: bash
     - name: Execute `mvn ${{ inputs.maven-args }} -Pmr`
       run: mvn -B -fae ${{ inputs.maven-args }} -Pmr | tee -a /tmp/maven.log;

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ To build it, run:
 
     mvn -DskipTests clean package
 
-Build against profile Spark 2 (2.4.6)
+Build against profile Spark 2.4.x
 
-    mvn -DskipTests clean package -Pspark2
+    mvn -DskipTests clean package -Pspark2.4
 
-Build against profile Spark 3 (3.1.2)
+Build against profile Spark 3.1.x
 
-    mvn -DskipTests clean package -Pspark3
+    mvn -DskipTests clean package -Pspark3.1
 
 Build against Spark 3.2.x, Except 3.2.0
 

--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -42,9 +42,9 @@ function exit_with_usage() {
   exit 1
 }
 
-SPARK2_PROFILE_ID="spark2"
+SPARK2_PROFILE_ID="spark2.4"
 SPARK2_MVN_OPTS=""
-SPARK3_PROFILE_ID="spark3"
+SPARK3_PROFILE_ID="spark3.1"
 SPARK3_MVN_OPTS=""
 while (( "$#" )); do
   case $1 in

--- a/pom.xml
+++ b/pom.xml
@@ -1055,7 +1055,7 @@
     </profile>
 
     <profile>
-      <id>spark2</id>
+      <id>spark2.4</id>
       <properties>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.6</spark.version>
@@ -1171,7 +1171,7 @@
     </profile>
 
     <profile>
-      <id>spark3</id>
+      <id>spark3.1</id>
       <properties>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.2</spark.version>


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Change `spark3` profile to `spark3.1`.
Change `spark2` profile to `spark2.4`.

### Why are the changes needed?

To make profile names more intuitive.

### Does this PR introduce _any_ user-facing change?

`-Pspark3` should be replaced by `-Pspark3.1`.
`-Pspark2` should be replaced by `-Pspark2.4`.

### How was this patch tested?

CI.
