### PR TITLE
[#647][FOLLOWUP] set coordinator id before ApplicationMaster

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -149,6 +149,7 @@ public class CoordinatorServer extends ReconfigurableBase {
     jettyServer = new JettyServer(coordinatorConf);
     // register metrics first to avoid NPE problem when add dynamic metrics
     registerMetrics();
+    coordinatorConf.setString(CoordinatorUtils.COORDINATOR_ID, id);
     this.applicationManager = new ApplicationManager(coordinatorConf);
 
     SecurityConfig securityConfig = null;
@@ -162,7 +163,6 @@ public class CoordinatorServer extends ReconfigurableBase {
     }
     SecurityContextFactory.get().init(securityConfig);
 
-    coordinatorConf.setString(CoordinatorUtils.COORDINATOR_ID, id);
 
     // load default hadoop configuration
     Configuration hadoopConf = new Configuration();


### PR DESCRIPTION
### What changes were proposed in this pull request?
set coordinator id before ApplicationMaster construction, otherwise uuid is used for ` AbstractSelectStorageStrategy`

### Why are the changes needed?
Follow up of #647

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually verified
