### PR TITLE
[#655]feat(coordinator): heap size configurable and add gc log

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -54,12 +54,19 @@ JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 echo "class path is $CLASSPATH"
 
 JVM_ARGS=" -server \
-          -Xmx8g \
+          -Xmx${XMX_SIZE:-8g} \
+          -Xms${XMX_SIZE:-8g} \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
           -XX:ConcGCThreads=5 \
-          -XX:InitiatingHeapOccupancyPercent=45 "
+          -XX:InitiatingHeapOccupancyPercent=45 \
+          -XX:+PrintGC \
+          -XX:+PrintAdaptiveSizePolicy \
+          -XX:+PrintGCDateStamps \
+          -XX:+PrintGCTimeStamps \
+          -XX:+PrintGCDetails \
+          -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 ARGS=""
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. make heap size of coordinator configurable
2. add gc log for coordinator

### Why are the changes needed?
1. heap size configurable otherwise, there's no point to set it in the rss spec
2. gc log: for better logging
3. Fix: #655

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need.