### PR TITLE
[#80][Part-2] feat: Add RPC logic and heartbeat logic for decommisson

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
+++ b/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
@@ -42,11 +42,13 @@ public enum ServerStatus {
   }
 
   public static ServerStatus fromCode(Integer code) {
-    return VALUE_MAP.get(code);
+    ServerStatus serverStatus = VALUE_MAP.get(code);
+    return serverStatus == null ? UNKNOWN : serverStatus;
   }
 
   public RssProtos.ServerStatus toProto() {
-    return RssProtos.ServerStatus.forNumber(this.code());
+    RssProtos.ServerStatus serverStatus = RssProtos.ServerStatus.forNumber(this.code());
+    return serverStatus == null ? RssProtos.ServerStatus.UNRECOGNIZED : serverStatus;
   }
 
   public static ServerStatus fromProto(RssProtos.ServerStatus status) {

--- a/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
+++ b/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
@@ -17,12 +17,20 @@
 
 package org.apache.uniffle.common;
 
+import org.apache.uniffle.proto.RssProtos;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public enum ServerStatus {
   UNKNOWN(-1),
   ACTIVE(0),
   DECOMMISSIONING(1),
   DECOMMISSIONED(2);
 
+  static final Map<Integer, ServerStatus> VALUE_MAP =
+      Arrays.stream(ServerStatus.values()).collect(Collectors.toMap(ServerStatus::code, s -> s));
   private final int code;
 
   ServerStatus(int code) {
@@ -31,5 +39,17 @@ public enum ServerStatus {
 
   public int code() {
     return code;
+  }
+
+  public static ServerStatus fromCode(Integer code) {
+    return VALUE_MAP.get(code);
+  }
+
+  public RssProtos.ServerStatus toProto() {
+    return RssProtos.ServerStatus.forNumber(this.code());
+  }
+
+  public static ServerStatus fromProto(RssProtos.ServerStatus status) {
+    return fromCode(status.getNumber());
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
+++ b/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
@@ -27,7 +27,7 @@ public enum ServerStatus {
   ACTIVE(0),
   DECOMMISSIONING(1),
   DECOMMISSIONED(2),
-  UNKNOWN(-1); // UNKNOWN should be the last element of this enum, or unit test will fail.
+  UNKNOWN(-1);
 
   static final Map<Integer, ServerStatus> VALUE_MAP =
       Arrays.stream(ServerStatus.values()).collect(Collectors.toMap(ServerStatus::code, s -> s));

--- a/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
+++ b/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
@@ -17,17 +17,17 @@
 
 package org.apache.uniffle.common;
 
-import org.apache.uniffle.proto.RssProtos;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.uniffle.proto.RssProtos;
+
 public enum ServerStatus {
-  UNKNOWN(-1),
   ACTIVE(0),
   DECOMMISSIONING(1),
-  DECOMMISSIONED(2);
+  DECOMMISSIONED(2),
+  UNKNOWN(-1); // UNKNOWN should be the last element of this enum, or unit test will fail.
 
   static final Map<Integer, ServerStatus> VALUE_MAP =
       Arrays.stream(ServerStatus.values()).collect(Collectors.toMap(ServerStatus::code, s -> s));

--- a/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
@@ -28,7 +28,8 @@ public enum StatusCode {
   NO_PARTITION(5),
   INTERNAL_ERROR(6),
   TIMEOUT(7),
-  ACCESS_DENIED(8);
+  ACCESS_DENIED(8),
+  INVALID_REQUEST(9);
 
   private final int statusCode;
 

--- a/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
@@ -34,7 +34,7 @@ public enum StatusCode {
   TIMEOUT(7),
   ACCESS_DENIED(8),
   INVALID_REQUEST(9),
-  UNKNOWN(-1); // UNKNOWN should be the last element of this enum, or unit test will fail.
+  UNKNOWN(-1);
 
   static final Map<Integer, StatusCode> VALUE_MAP =
       Arrays.stream(StatusCode.values()).collect(Collectors.toMap(StatusCode::statusCode, s -> s));

--- a/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
@@ -17,6 +17,10 @@
 
 package org.apache.uniffle.common.rpc;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.uniffle.proto.RssProtos;
 
 public enum StatusCode {
@@ -31,6 +35,8 @@ public enum StatusCode {
   ACCESS_DENIED(8),
   INVALID_REQUEST(9);
 
+  static final Map<Integer, StatusCode> VALUE_MAP =
+      Arrays.stream(StatusCode.values()).collect(Collectors.toMap(StatusCode::statusCode, s -> s));
   private final int statusCode;
 
   StatusCode(int code) {
@@ -41,8 +47,16 @@ public enum StatusCode {
     return statusCode;
   }
 
+  public static StatusCode fromCode(Integer code) {
+    return VALUE_MAP.get(code);
+  }
+
   public RssProtos.StatusCode toProto() {
     RssProtos.StatusCode code = RssProtos.StatusCode.forNumber(this.statusCode());
     return code == null ? RssProtos.StatusCode.INTERNAL_ERROR : code;
+  }
+
+  public static StatusCode fromProto(RssProtos.StatusCode status) {
+    return fromCode(status.getNumber());
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
@@ -33,7 +33,8 @@ public enum StatusCode {
   INTERNAL_ERROR(6),
   TIMEOUT(7),
   ACCESS_DENIED(8),
-  INVALID_REQUEST(9);
+  INVALID_REQUEST(9),
+  UNKNOWN(-1); // UNKNOWN should be the last element of this enum, or unit test will fail.
 
   static final Map<Integer, StatusCode> VALUE_MAP =
       Arrays.stream(StatusCode.values()).collect(Collectors.toMap(StatusCode::statusCode, s -> s));
@@ -48,12 +49,13 @@ public enum StatusCode {
   }
 
   public static StatusCode fromCode(Integer code) {
-    return VALUE_MAP.get(code);
+    StatusCode statusCode = VALUE_MAP.get(code);
+    return statusCode == null ? UNKNOWN : statusCode;
   }
 
   public RssProtos.StatusCode toProto() {
     RssProtos.StatusCode code = RssProtos.StatusCode.forNumber(this.statusCode());
-    return code == null ? RssProtos.StatusCode.INTERNAL_ERROR : code;
+    return code == null ? RssProtos.StatusCode.UNRECOGNIZED : code;
   }
 
   public static StatusCode fromProto(RssProtos.StatusCode status) {

--- a/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
@@ -29,6 +29,8 @@ public class ServerStatusTest {
   @Test
   public void test() throws Exception {
     assertEquals(-1, ServerStatus.UNKNOWN.code());
+    assertEquals(ServerStatus.fromCode(-2), ServerStatus.UNKNOWN);
+    assertEquals(ServerStatus.fromCode(Integer.MAX_VALUE), ServerStatus.UNKNOWN);
     RssProtos.ServerStatus[] protoStatusCode = RssProtos.ServerStatus.values();
     for (RssProtos.ServerStatus statusCode : protoStatusCode) {
       try {

--- a/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.proto.RssProtos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ServerStatusTest {
+
+  @Test
+  public void test() throws Exception {
+    assertEquals(-1, ServerStatus.UNKNOWN.code());
+    RssProtos.ServerStatus[] protoStatusCode = RssProtos.ServerStatus.values();
+    for (RssProtos.ServerStatus statusCode : protoStatusCode) {
+      try {
+        if (RssProtos.ServerStatus.UNRECOGNIZED.equals(statusCode)) {
+          continue;
+        }
+        ServerStatus.valueOf(statusCode.name());
+      } catch (Exception e) {
+        fail(e.getMessage());
+      }
+    }
+    ServerStatus[] statusCodes = ServerStatus.values();
+    for (ServerStatus statusCode : statusCodes) {
+      if (ServerStatus.UNKNOWN.equals(statusCode)) {
+        continue;
+      }
+      try {
+        RssProtos.ServerStatus.valueOf(statusCode.name());
+      } catch (Exception e) {
+        fail(e.getMessage());
+      }
+    }
+    for (int i = 1; i < statusCodes.length; i++) {
+      assertEquals(protoStatusCode[i - 1], statusCodes[i].toProto());
+      assertEquals(ServerStatus.fromProto(protoStatusCode[i - 1]), statusCodes[i]);
+    }
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
@@ -51,9 +51,9 @@ public class ServerStatusTest {
         fail(e.getMessage());
       }
     }
-    for (int i = 1; i < statusCodes.length; i++) {
-      assertEquals(protoStatusCode[i - 1], statusCodes[i].toProto());
-      assertEquals(ServerStatus.fromProto(protoStatusCode[i - 1]), statusCodes[i]);
+    for (int i = 0; i < statusCodes.length - 1; i++) {
+      assertEquals(protoStatusCode[i], statusCodes[i].toProto());
+      assertEquals(ServerStatus.fromProto(protoStatusCode[i]), statusCodes[i]);
     }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ServerStatusTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.uniffle.common;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.proto.RssProtos;
@@ -31,31 +35,29 @@ public class ServerStatusTest {
     assertEquals(-1, ServerStatus.UNKNOWN.code());
     assertEquals(ServerStatus.fromCode(-2), ServerStatus.UNKNOWN);
     assertEquals(ServerStatus.fromCode(Integer.MAX_VALUE), ServerStatus.UNKNOWN);
-    RssProtos.ServerStatus[] protoStatusCode = RssProtos.ServerStatus.values();
-    for (RssProtos.ServerStatus statusCode : protoStatusCode) {
+    List<RssProtos.ServerStatus> protoServerStatuses = Arrays.stream(RssProtos.ServerStatus.values())
+        .filter(s -> !RssProtos.ServerStatus.UNRECOGNIZED.equals(s)).collect(Collectors.toList());
+
+    for (RssProtos.ServerStatus statusCode : protoServerStatuses) {
+
       try {
-        if (RssProtos.ServerStatus.UNRECOGNIZED.equals(statusCode)) {
-          continue;
-        }
         ServerStatus.valueOf(statusCode.name());
       } catch (Exception e) {
         fail(e.getMessage());
       }
     }
-    ServerStatus[] statusCodes = ServerStatus.values();
-    for (ServerStatus statusCode : statusCodes) {
-      if (ServerStatus.UNKNOWN.equals(statusCode)) {
-        continue;
-      }
+    List<ServerStatus> serverStatuses = Arrays.stream(ServerStatus.values())
+        .filter(s -> !ServerStatus.UNKNOWN.equals(s)).collect(Collectors.toList());
+    for (ServerStatus serverStatus : serverStatuses) {
       try {
-        RssProtos.ServerStatus.valueOf(statusCode.name());
+        RssProtos.ServerStatus.valueOf(serverStatus.name());
       } catch (Exception e) {
         fail(e.getMessage());
       }
     }
-    for (int i = 0; i < statusCodes.length - 1; i++) {
-      assertEquals(protoStatusCode[i], statusCodes[i].toProto());
-      assertEquals(ServerStatus.fromProto(protoStatusCode[i]), statusCodes[i]);
+    for (int i = 0; i < serverStatuses.size() - 1; i++) {
+      assertEquals(protoServerStatuses.get(i), serverStatuses.get(i).toProto());
+      assertEquals(ServerStatus.fromProto(protoServerStatuses.get(i)), serverStatuses.get(i));
     }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
@@ -49,6 +49,7 @@ public class StatusCodeTest {
     }
     for (int i = 0; i < statusCodes.length; i++) {
       assertEquals(protoStatusCode[i], statusCodes[i].toProto());
+      assertEquals(StatusCode.fromProto(protoStatusCode[i]), statusCodes[i]);
     }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.uniffle.common.rpc;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.proto.RssProtos;
@@ -28,31 +32,32 @@ public class StatusCodeTest {
 
   @Test
   public void test() throws Exception {
-    RssProtos.StatusCode[] protoStatusCode = RssProtos.StatusCode.values();
+    assertEquals(-1, StatusCode.UNKNOWN.statusCode());
+    assertEquals(StatusCode.fromCode(-2), StatusCode.UNKNOWN);
+    assertEquals(StatusCode.fromCode(Integer.MAX_VALUE), StatusCode.UNKNOWN);
+    List<RssProtos.StatusCode> protoStatusCode = Arrays.stream(RssProtos.StatusCode.values())
+        .filter(s -> !RssProtos.StatusCode.UNRECOGNIZED.equals(s)).collect(Collectors.toList());
+
     for (RssProtos.StatusCode statusCode : protoStatusCode) {
       try {
-        if (RssProtos.StatusCode.UNRECOGNIZED.equals(statusCode)) {
-          continue;
-        }
         StatusCode.valueOf(statusCode.name());
       } catch (Exception e) {
         fail(e.getMessage());
       }
     }
-    StatusCode[] statusCodes = StatusCode.values();
+    List<StatusCode> statusCodes = Arrays.stream(StatusCode.values())
+        .filter(s -> !StatusCode.UNKNOWN.equals(s)).collect(Collectors.toList());
+
     for (StatusCode statusCode : statusCodes) {
-      if (StatusCode.UNKNOWN.equals(statusCode)) {
-        continue;
-      }
       try {
         RssProtos.StatusCode.valueOf(statusCode.name());
       } catch (Exception e) {
         fail(e.getMessage());
       }
     }
-    for (int i = 0; i < statusCodes.length - 1; i++) {
-      assertEquals(protoStatusCode[i], statusCodes[i].toProto());
-      assertEquals(StatusCode.fromProto(protoStatusCode[i]), statusCodes[i]);
+    for (int i = 0; i < statusCodes.size() - 1; i++) {
+      assertEquals(protoStatusCode.get(i), statusCodes.get(i).toProto());
+      assertEquals(StatusCode.fromProto(protoStatusCode.get(i)), statusCodes.get(i));
     }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/StatusCodeTest.java
@@ -41,13 +41,16 @@ public class StatusCodeTest {
     }
     StatusCode[] statusCodes = StatusCode.values();
     for (StatusCode statusCode : statusCodes) {
+      if (StatusCode.UNKNOWN.equals(statusCode)) {
+        continue;
+      }
       try {
         RssProtos.StatusCode.valueOf(statusCode.name());
       } catch (Exception e) {
         fail(e.getMessage());
       }
     }
-    for (int i = 0; i < statusCodes.length; i++) {
+    for (int i = 0; i < statusCodes.length - 1; i++) {
       assertEquals(protoStatusCode[i], statusCodes[i].toProto());
       assertEquals(StatusCode.fromProto(protoStatusCode[i]), statusCodes[i]);
     }

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -36,7 +36,10 @@
       <groupId>org.apache.uniffle</groupId>
       <artifactId>rss-common</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.uniffle</groupId>
+      <artifactId>rss-internal-client</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -56,4 +56,10 @@ public interface ClusterManager extends Closeable, Reconfigurable {
    * @return whether to be ready for serving
    */
   boolean isReadyForServe();
+
+  ServerNode getServerNodeById(String serverId);
+
+  void decommission(String serverId);
+
+  void cancelDecommission(String serverId);
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -197,6 +197,12 @@ public class CoordinatorConf extends RssBaseConf {
       .defaultValue(60 * 1000L)
       .withDescription("Update interval for the default number of submitted apps per user");
 
+  public static final ConfigOption<Long> COORDINATOR_NODES_CLIENT_CACHE_EXPIRED = ConfigOptions
+          .key("rss.coordinator.nodes.client.cache.expired")
+          .longType()
+          .defaultValue(120 * 1000L)
+          .withDescription("Expired time (ms) for the clients communicating with nodes.");
+
   public CoordinatorConf() {
   }
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -203,6 +203,12 @@ public class CoordinatorConf extends RssBaseConf {
           .defaultValue(120 * 1000L)
           .withDescription("Expired time (ms) for the clients communicating with nodes.");
 
+  public static final ConfigOption<Integer> COORDINATOR_NODES_CLIENT_CACHE_MAX = ConfigOptions
+      .key("rss.coordinator.nodes.client.cache.max")
+      .intType()
+      .defaultValue(1000)
+      .withDescription("The max number of clients that communicating with nodes and storing in the cache.");
+
   public CoordinatorConf() {
   }
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorFactory.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorFactory.java
@@ -33,8 +33,10 @@ public class CoordinatorFactory {
   public ServerInterface getServer() {
     String type = conf.getString(CoordinatorConf.RPC_SERVER_TYPE);
     if (type.equals(ServerType.GRPC.name())) {
-      return new GrpcServer(conf, new CoordinatorGrpcService(coordinatorServer),
-          coordinatorServer.getGrpcMetrics());
+      return GrpcServer.Builder.newBuilder()
+          .conf(conf)
+          .grpcMetrics(coordinatorServer.getGrpcMetrics())
+          .addService(new CoordinatorGrpcService(coordinatorServer)).build();
     } else {
       throw new UnsupportedOperationException("Unsupported server type " + type);
     }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.storage.StorageInfoUtils;
 import org.apache.uniffle.coordinator.access.AccessCheckResult;
 import org.apache.uniffle.coordinator.access.AccessInfo;
@@ -376,6 +377,7 @@ public class CoordinatorGrpcService extends CoordinatorServerGrpc.CoordinatorSer
         request.getEventNumInFlush(),
         Sets.newHashSet(request.getTagsList()),
         isHealthy,
+        ServerStatus.fromProto(request.getStatus()),
         StorageInfoUtils.fromProto(request.getStorageInfoMap()));
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
@@ -368,6 +368,7 @@ public class CoordinatorGrpcService extends CoordinatorServerGrpc.CoordinatorSer
     if (request.hasIsHealthy()) {
       isHealthy = request.getIsHealthy().getValue();
     }
+    ServerStatus serverStatus = request.hasStatus() ? ServerStatus.fromProto(request.getStatus()) : ServerStatus.ACTIVE;
     return new ServerNode(request.getServerId().getId(),
         request.getServerId().getIp(),
         request.getServerId().getPort(),
@@ -377,7 +378,7 @@ public class CoordinatorGrpcService extends CoordinatorServerGrpc.CoordinatorSer
         request.getEventNumInFlush(),
         Sets.newHashSet(request.getTagsList()),
         isHealthy,
-        ServerStatus.fromProto(request.getStatus()),
+        serverStatus,
         StorageInfoUtils.fromProto(request.getStorageInfoMap()));
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -41,6 +41,8 @@ import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.apache.uniffle.coordinator.strategy.assignment.AssignmentStrategy;
 import org.apache.uniffle.coordinator.strategy.assignment.AssignmentStrategyFactory;
 import org.apache.uniffle.coordinator.util.CoordinatorUtils;
+import org.apache.uniffle.coordinator.web.servlet.DecommissionServlet;
+import org.apache.uniffle.coordinator.web.servlet.NodesServlet;
 
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_ENABLE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_KEYTAB_FILE;
@@ -147,6 +149,7 @@ public class CoordinatorServer extends ReconfigurableBase {
     id = ip + "-" + port;
     LOG.info("Start to initialize coordinator {}", id);
     jettyServer = new JettyServer(coordinatorConf);
+    registerRESTAPI();
     // register metrics first to avoid NPE problem when add dynamic metrics
     registerMetrics();
     coordinatorConf.setString(CoordinatorUtils.COORDINATOR_ID, id);
@@ -177,6 +180,16 @@ public class CoordinatorServer extends ReconfigurableBase {
         applicationManager.getQuotaManager(), hadoopConf);
     CoordinatorFactory coordinatorFactory = new CoordinatorFactory(this);
     server = coordinatorFactory.getServer();
+  }
+
+  private void registerRESTAPI() throws Exception {
+    LOG.info("Register REST API");
+    jettyServer.addServlet(
+        new NodesServlet(this),
+        "/api/server/nodes");
+    jettyServer.addServlet(
+        new DecommissionServlet(this),
+        "/api/server/decommission");
   }
 
   private void registerMetrics() throws Exception {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -41,8 +41,6 @@ import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.apache.uniffle.coordinator.strategy.assignment.AssignmentStrategy;
 import org.apache.uniffle.coordinator.strategy.assignment.AssignmentStrategyFactory;
 import org.apache.uniffle.coordinator.util.CoordinatorUtils;
-import org.apache.uniffle.coordinator.web.servlet.DecommissionServlet;
-import org.apache.uniffle.coordinator.web.servlet.NodesServlet;
 
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_ENABLE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_KEYTAB_FILE;
@@ -149,7 +147,6 @@ public class CoordinatorServer extends ReconfigurableBase {
     id = ip + "-" + port;
     LOG.info("Start to initialize coordinator {}", id);
     jettyServer = new JettyServer(coordinatorConf);
-    registerRESTAPI();
     // register metrics first to avoid NPE problem when add dynamic metrics
     registerMetrics();
     coordinatorConf.setString(CoordinatorUtils.COORDINATOR_ID, id);
@@ -180,16 +177,6 @@ public class CoordinatorServer extends ReconfigurableBase {
         applicationManager.getQuotaManager(), hadoopConf);
     CoordinatorFactory coordinatorFactory = new CoordinatorFactory(this);
     server = coordinatorFactory.getServer();
-  }
-
-  private void registerRESTAPI() throws Exception {
-    LOG.info("Register REST API");
-    jettyServer.addServlet(
-        new NodesServlet(this),
-        "/api/server/nodes");
-    jettyServer.addServlet(
-        new DecommissionServlet(this),
-        "/api/server/decommission");
   }
 
   private void registerMetrics() throws Exception {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.google.common.collect.Maps;
 
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.storage.StorageInfo;
 import org.apache.uniffle.proto.RssProtos.ShuffleServerId;
 
@@ -37,8 +38,10 @@ public class ServerNode implements Comparable<ServerNode> {
   private long timestamp;
   private Set<String> tags;
   private boolean isHealthy;
+  private final ServerStatus status;
   private Map<String, StorageInfo> storageInfo;
 
+  // Only for test
   public ServerNode(
       String id,
       String ip,
@@ -50,7 +53,7 @@ public class ServerNode implements Comparable<ServerNode> {
       Set<String> tags,
       boolean isHealthy) {
     this(id, ip, port, usedMemory, preAllocatedMemory, availableMemory, eventNumInFlush, tags, isHealthy,
-        Maps.newHashMap());
+        ServerStatus.ACTIVE, Maps.newHashMap());
   }
 
   public ServerNode(
@@ -63,6 +66,22 @@ public class ServerNode implements Comparable<ServerNode> {
       int eventNumInFlush,
       Set<String> tags,
       boolean isHealthy,
+      ServerStatus status) {
+    this(id, ip, port, usedMemory, preAllocatedMemory, availableMemory, eventNumInFlush, tags, isHealthy,
+        status, Maps.newHashMap());
+  }
+
+  public ServerNode(
+      String id,
+      String ip,
+      int port,
+      long usedMemory,
+      long preAllocatedMemory,
+      long availableMemory,
+      int eventNumInFlush,
+      Set<String> tags,
+      boolean isHealthy,
+      ServerStatus status,
       Map<String, StorageInfo> storageInfoMap) {
     this.id = id;
     this.ip = ip;
@@ -74,6 +93,7 @@ public class ServerNode implements Comparable<ServerNode> {
     this.timestamp = System.currentTimeMillis();
     this.tags = tags;
     this.isHealthy = isHealthy;
+    this.status = status;
     this.storageInfo = storageInfoMap;
   }
 
@@ -121,6 +141,10 @@ public class ServerNode implements Comparable<ServerNode> {
     return isHealthy;
   }
 
+  public ServerStatus getStatus() {
+    return status;
+  }
+
   public Map<String, StorageInfo> getStorageInfo() {
     return storageInfo;
   }
@@ -137,6 +161,7 @@ public class ServerNode implements Comparable<ServerNode> {
         + "], timestamp[" + timestamp
         + "], tags" + tags.toString() + ""
         + ", healthy[" + isHealthy
+        + ", status[" + status
         + "], storages[num=" + storageInfo.size() + "]";
 
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -107,11 +107,13 @@ public class SimpleClusterManager implements ClusterManager {
           () -> updateExcludeNodes(excludeNodesPath), updateNodesInterval, updateNodesInterval, TimeUnit.MILLISECONDS);
     }
 
-    Long clientExpiredTime = conf.get(CoordinatorConf.COORDINATOR_NODES_CLIENT_CACHE_EXPIRED);
+    long clientExpiredTime = conf.get(CoordinatorConf.COORDINATOR_NODES_CLIENT_CACHE_EXPIRED);
+    int maxClient = conf.get(CoordinatorConf.COORDINATOR_NODES_CLIENT_CACHE_MAX);
     clientCache = CacheBuilder.newBuilder()
-            .expireAfterAccess(clientExpiredTime, TimeUnit.MILLISECONDS)
-            .removalListener(notify -> ((ShuffleServerInternalGrpcClient) notify.getValue()).close())
-            .build();
+        .expireAfterAccess(clientExpiredTime, TimeUnit.MILLISECONDS)
+        .maximumSize(maxClient)
+        .removalListener(notify -> ((ShuffleServerInternalGrpcClient) notify.getValue()).close())
+        .build();
     this.startTime = System.currentTimeMillis();
 
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -265,13 +265,13 @@ public class SimpleClusterManager implements ClusterManager {
   @Override
   public void decommission(String serverId) {
     ServerNode serverNode = getServerNodeById(serverId);
-    getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(true));
+    getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(false));
   }
 
   @Override
   public void cancelDecommission(String serverId) {
     ServerNode serverNode = getServerNodeById(serverId);
-    getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(false));
+    getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(true));
   }
 
   private ShuffleServerInternalGrpcClient getShuffleServerClient(ServerNode serverNode) {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -265,21 +265,12 @@ public class SimpleClusterManager implements ClusterManager {
   @Override
   public void decommission(String serverId) {
     ServerNode serverNode = getServerNodeById(serverId);
-    if (!ServerStatus.ACTIVE.equals(serverNode.getStatus())) {
-      throw new InvalidRequestException("Server [" + serverId
-          + "] is processing other procedures, current status:" + serverNode.getStatus());
-    }
     getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(true));
-
   }
 
   @Override
   public void cancelDecommission(String serverId) {
     ServerNode serverNode = getServerNodeById(serverId);
-    if (!ServerStatus.DECOMMISSIONING.equals(serverNode.getStatus())) {
-      LOG.info("Shuffle server is not decommissioning. Nothing needs to be done.");
-      return;
-    }
     getShuffleServerClient(serverNode).decommission(new RssDecommissionRequest(false));
   }
 

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/ServerNodeTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/ServerNodeTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.storage.StorageInfo;
 import org.apache.uniffle.common.storage.StorageMedia;
 import org.apache.uniffle.common.storage.StorageStatus;
@@ -65,7 +66,8 @@ public class ServerNodeTest {
         60L,
         StorageStatus.NORMAL);
     localStorageInfo.put("/mnt", info);
-    ServerNode sn2 = new ServerNode("sn2", "ip", 0, 100L, 50L, 20, 10, tags, true, localStorageInfo);
+    ServerNode sn2 = new ServerNode("sn2", "ip", 0, 100L, 50L, 20, 10, tags,
+        true, ServerStatus.ACTIVE, localStorageInfo);
     assertEquals(1, sn2.getStorageInfo().size());
   }
 }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcServerTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcServerTest.java
@@ -61,7 +61,11 @@ public class CoordinatorGrpcServerTest {
 
     GRPCMetrics grpcMetrics = new CoordinatorGrpcMetrics();
     grpcMetrics.register(new CollectorRegistry(true));
-    GrpcServer grpcServer = new GrpcServer(baseConf, new MockedCoordinatorGrpcService(), grpcMetrics);
+    GrpcServer grpcServer = GrpcServer.Builder.newBuilder()
+        .conf(baseConf)
+        .grpcMetrics(grpcMetrics)
+        .addService(new MockedCoordinatorGrpcService())
+        .build();
     grpcServer.start();
 
     // case1: test the single one connection metric

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -40,6 +40,7 @@ import org.apache.uniffle.storage.util.StorageType;
 
 public abstract class IntegrationTestBase extends HdfsTestBase {
 
+  protected static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
   protected static final int SHUFFLE_SERVER_PORT = 20001;
   protected static final String LOCALHOST;
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -40,7 +40,6 @@ import org.apache.uniffle.storage.util.StorageType;
 
 public abstract class IntegrationTestBase extends HdfsTestBase {
 
-  protected static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
   protected static final int SHUFFLE_SERVER_PORT = 20001;
   protected static final String LOCALHOST;
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Lists;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerInternalGrpcClient;
+import org.apache.uniffle.client.request.RssDecommissionRequest;
+import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
+import org.apache.uniffle.client.request.RssUnregisterShuffleRequest;
+import org.apache.uniffle.client.response.RssDecommissionResponse;
+import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.ServerStatus;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServer;
+import org.apache.uniffle.server.ShuffleServerConf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ShuffleServerInternalGrpcTest extends IntegrationTestBase {
+
+  private ShuffleServerGrpcClient shuffleServerClient;
+  private ShuffleServerInternalGrpcClient shuffleServerInternalClient;
+
+  @BeforeAll
+  public static void setupServers(@TempDir File tmpDir) throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    File dataDir1 = new File(tmpDir, "data1");
+    String basePath = dataDir1.getAbsolutePath();
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_CHECK_INTERVAL, 500L);
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
+  @BeforeEach
+  public void createClient() {
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    shuffleServerInternalClient = new ShuffleServerInternalGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  }
+
+  @Test
+  public void decommissionTest() {
+    String appId = "decommissionTest";
+    int shuffleId = 0;
+    shuffleServerClient.registerShuffle(new RssRegisterShuffleRequest(appId, shuffleId,
+        Lists.newArrayList(new PartitionRange(0, 1)), ""));
+    RssDecommissionResponse response = shuffleServerInternalClient.decommission(new RssDecommissionRequest(true));
+    assertTrue(response.isOn());
+    response = shuffleServerInternalClient.decommission(new RssDecommissionRequest(false));
+    assertTrue(!response.isOn());
+    ShuffleServer shuffleServer = shuffleServers.get(0);
+    assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
+
+    // Clean all apps, shuffle server will be shutdown right now.
+    shuffleServerClient.unregisterShuffle(new RssUnregisterShuffleRequest(appId, shuffleId));
+    response = shuffleServerInternalClient.decommission(new RssDecommissionRequest(true));
+    assertTrue(response.isOn());
+    assertEquals(ServerStatus.DECOMMISSIONING, shuffleServer.getServerStatus());
+    try {
+      Awaitility.await().timeout(10, TimeUnit.SECONDS).until(() ->
+          !shuffleServer.isRunning());
+      // Server is already shutdown, so io exception should be thrown here.
+      shuffleServerInternalClient.decommission(new RssDecommissionRequest(false));
+      fail(EXPECTED_EXCEPTION_MESSAGE);
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("UNAVAILABLE: io exception"));
+    }
+  }
+
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerInternalClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerInternalClient.java
@@ -17,12 +17,16 @@
 
 package org.apache.uniffle.client.api;
 
+import org.apache.uniffle.client.request.RssCancelDecommissionRequest;
 import org.apache.uniffle.client.request.RssDecommissionRequest;
+import org.apache.uniffle.client.response.RssCancelDecommissionResponse;
 import org.apache.uniffle.client.response.RssDecommissionResponse;
 
 public interface ShuffleServerInternalClient {
 
   RssDecommissionResponse decommission(RssDecommissionRequest request);
+
+  RssCancelDecommissionResponse cancelDecommission(RssCancelDecommissionRequest rssCancelDecommissionRequest);
 
   void close();
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerInternalClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerInternalClient.java
@@ -15,25 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.server;
+package org.apache.uniffle.client.api;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.uniffle.client.request.RssDecommissionRequest;
+import org.apache.uniffle.client.response.RssDecommissionResponse;
 
-import org.apache.uniffle.common.config.RssBaseConf;
-import org.apache.uniffle.common.metrics.GRPCMetrics;
-import org.apache.uniffle.common.rpc.GrpcServer;
+public interface ShuffleServerInternalClient {
 
-public class MockedGrpcServer extends GrpcServer {
-  MockedShuffleServerGrpcService service;
+  RssDecommissionResponse decommission(RssDecommissionRequest request);
 
-  public MockedGrpcServer(RssBaseConf conf, MockedShuffleServerGrpcService service,
-                          GRPCMetrics grpcMetrics) {
-    super(conf, Lists.newArrayList(Pair.of(service, Lists.newArrayList())), grpcMetrics);
-    this.service = service;
-  }
+  void close();
 
-  public MockedShuffleServerGrpcService getService() {
-    return service;
-  }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
@@ -50,6 +50,7 @@ import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
 import org.apache.uniffle.client.response.RssSendHeartBeatResponse;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.rpc.StatusCode;
@@ -117,6 +118,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
       long timeout,
       Set<String> tags,
       boolean isHealthy,
+      ServerStatus serverStatus,
       Map<String, StorageInfo> storageInfo) {
     ShuffleServerId serverId =
         ShuffleServerId.newBuilder().setId(id).setIp(ip).setPort(port).build();
@@ -129,6 +131,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
             .setEventNumInFlush(eventNumInFlush)
             .addAllTags(tags)
             .setIsHealthy(BoolValue.newBuilder().setValue(isHealthy).build())
+            .setStatusValue(serverStatus.ordinal())
             .putAllStorageInfo(StorageInfoUtils.toProto(storageInfo))
             .build();
 
@@ -194,6 +197,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
         request.getTimeout(),
         request.getTags(),
         request.isHealthy(),
+        request.getServerStatus(),
         request.getStorageInfo());
 
     RssSendHeartBeatResponse response;

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
@@ -19,12 +19,13 @@ package org.apache.uniffle.client.impl.grpc;
 
 import java.util.concurrent.TimeUnit;
 
-import com.google.protobuf.BoolValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleServerInternalClient;
+import org.apache.uniffle.client.request.RssCancelDecommissionRequest;
 import org.apache.uniffle.client.request.RssDecommissionRequest;
+import org.apache.uniffle.client.response.RssCancelDecommissionResponse;
 import org.apache.uniffle.client.response.RssDecommissionResponse;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.proto.RssProtos;
@@ -58,11 +59,18 @@ public class ShuffleServerInternalGrpcClient extends GrpcClient implements Shuff
   @Override
   public RssDecommissionResponse decommission(RssDecommissionRequest request) {
     RssProtos.DecommissionRequest protoRequest =
-        RssProtos.DecommissionRequest.newBuilder()
-            .setCancel(BoolValue.newBuilder().setValue(request.isCancel()).build())
-            .build();
+        RssProtos.DecommissionRequest.newBuilder().build();
     RssProtos.DecommissionResponse rpcResponse = getBlockingStub().decommission(protoRequest);
     return new RssDecommissionResponse(
         StatusCode.fromProto(rpcResponse.getStatus()), rpcResponse.getRetMsg());
+  }
+
+  @Override
+  public RssCancelDecommissionResponse cancelDecommission(RssCancelDecommissionRequest rssCancelDecommissionRequest) {
+    RssProtos.CancelDecommissionRequest protoRequest =
+            RssProtos.CancelDecommissionRequest.newBuilder().build();
+    RssProtos.CancelDecommissionResponse rpcResponse = getBlockingStub().cancelDecommission(protoRequest);
+    return new RssCancelDecommissionResponse(
+            StatusCode.fromProto(rpcResponse.getStatus()), rpcResponse.getRetMsg());
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl.grpc;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.protobuf.BoolValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.client.api.ShuffleServerInternalClient;
+import org.apache.uniffle.client.request.RssDecommissionRequest;
+import org.apache.uniffle.client.response.RssDecommissionResponse;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
+import org.apache.uniffle.proto.ShuffleServerInternalGrpc;
+
+public class ShuffleServerInternalGrpcClient extends GrpcClient implements ShuffleServerInternalClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ShuffleServerGrpcClient.class);
+  private static final long FAILED_REQUIRE_ID = -1;
+  private static final long RPC_TIMEOUT_DEFAULT_MS = 60000;
+  private long rpcTimeout = RPC_TIMEOUT_DEFAULT_MS;
+  private ShuffleServerInternalGrpc.ShuffleServerInternalBlockingStub blockingStub;
+
+  public ShuffleServerInternalGrpcClient(String host, int port) {
+    this(host, port, 3);
+  }
+
+  public ShuffleServerInternalGrpcClient(String host, int port, int maxRetryAttempts) {
+    this(host, port, maxRetryAttempts, true);
+  }
+
+  public ShuffleServerInternalGrpcClient(String host, int port, int maxRetryAttempts, boolean usePlaintext) {
+    super(host, port, maxRetryAttempts, usePlaintext);
+    // todo Add ClientInterceptor for authentication
+    blockingStub = ShuffleServerInternalGrpc.newBlockingStub(channel);
+  }
+
+  public ShuffleServerInternalGrpc.ShuffleServerInternalBlockingStub getBlockingStub() {
+    return blockingStub.withDeadlineAfter(rpcTimeout, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public RssDecommissionResponse decommission(RssDecommissionRequest request) {
+    RssProtos.DecommissionRequest protoRequest =
+        RssProtos.DecommissionRequest.newBuilder().setOn(BoolValue.newBuilder().setValue(request.isOn()).build())
+            .build();
+    RssProtos.DecommissionResponse rpcResponse =
+        blockingStub.withDeadlineAfter(RPC_TIMEOUT_DEFAULT_MS, TimeUnit.MILLISECONDS).decommission(protoRequest);
+    RssProtos.StatusCode statusCode = rpcResponse.getStatus();
+
+    RssDecommissionResponse response;
+    switch (statusCode) {
+      case SUCCESS:
+        response = new RssDecommissionResponse(
+            StatusCode.SUCCESS, rpcResponse.getOn().getValue());
+        break;
+      default:
+        String msg = String.format("Send %s command to %s:%s failed, errorMsg:%s",
+            request.isOn() ? "decommission" : "cancel decommission", host, port, rpcResponse.getRetMsg());
+        LOG.error(msg);
+        throw new RuntimeException(msg);
+    }
+    return response;
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerInternalGrpcClient.java
@@ -58,11 +58,11 @@ public class ShuffleServerInternalGrpcClient extends GrpcClient implements Shuff
   @Override
   public RssDecommissionResponse decommission(RssDecommissionRequest request) {
     RssProtos.DecommissionRequest protoRequest =
-        RssProtos.DecommissionRequest.newBuilder().setOn(BoolValue.newBuilder().setValue(request.isOn()).build())
+        RssProtos.DecommissionRequest.newBuilder()
+            .setCancel(BoolValue.newBuilder().setValue(request.isCancel()).build())
             .build();
     RssProtos.DecommissionResponse rpcResponse = getBlockingStub().decommission(protoRequest);
     return new RssDecommissionResponse(
-        StatusCode.fromProto(rpcResponse.getStatus()),
-        rpcResponse.getOn().getValue(), rpcResponse.getRetMsg());
+        StatusCode.fromProto(rpcResponse.getStatus()), rpcResponse.getRetMsg());
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssCancelDecommissionRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssCancelDecommissionRequest.java
@@ -17,5 +17,5 @@
 
 package org.apache.uniffle.client.request;
 
-public class RssDecommissionRequest {
+public class RssCancelDecommissionRequest {
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssDecommissionRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssDecommissionRequest.java
@@ -18,13 +18,13 @@
 package org.apache.uniffle.client.request;
 
 public class RssDecommissionRequest {
-  private boolean on;
+  private boolean cancel;
 
-  public boolean isOn() {
-    return on;
+  public boolean isCancel() {
+    return cancel;
   }
 
-  public RssDecommissionRequest(boolean on) {
-    this.on = on;
+  public RssDecommissionRequest(boolean cancel) {
+    this.cancel = cancel;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssDecommissionRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssDecommissionRequest.java
@@ -15,25 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.server;
+package org.apache.uniffle.client.request;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Pair;
+public class RssDecommissionRequest {
+  private boolean on;
 
-import org.apache.uniffle.common.config.RssBaseConf;
-import org.apache.uniffle.common.metrics.GRPCMetrics;
-import org.apache.uniffle.common.rpc.GrpcServer;
-
-public class MockedGrpcServer extends GrpcServer {
-  MockedShuffleServerGrpcService service;
-
-  public MockedGrpcServer(RssBaseConf conf, MockedShuffleServerGrpcService service,
-                          GRPCMetrics grpcMetrics) {
-    super(conf, Lists.newArrayList(Pair.of(service, Lists.newArrayList())), grpcMetrics);
-    this.service = service;
+  public boolean isOn() {
+    return on;
   }
 
-  public MockedShuffleServerGrpcService getService() {
-    return service;
+  public RssDecommissionRequest(boolean on) {
+    this.on = on;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendHeartBeatRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendHeartBeatRequest.java
@@ -21,6 +21,7 @@ package org.apache.uniffle.client.request;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.storage.StorageInfo;
 
 public class RssSendHeartBeatRequest {
@@ -35,6 +36,7 @@ public class RssSendHeartBeatRequest {
   private final Set<String> tags;
   private final long timeout;
   private final boolean isHealthy;
+  private final ServerStatus serverStatus;
   private final Map<String, StorageInfo> storageInfo;
 
   public RssSendHeartBeatRequest(
@@ -48,6 +50,7 @@ public class RssSendHeartBeatRequest {
       long timeout,
       Set<String> tags,
       boolean isHealthy,
+      ServerStatus serverStatus,
       Map<String, StorageInfo> storageInfo) {
     this.shuffleServerId = shuffleServerId;
     this.shuffleServerIp = shuffleServerIp;
@@ -59,6 +62,7 @@ public class RssSendHeartBeatRequest {
     this.tags = tags;
     this.timeout = timeout;
     this.isHealthy = isHealthy;
+    this.serverStatus = serverStatus;
     this.storageInfo = storageInfo;
   }
 
@@ -100,6 +104,10 @@ public class RssSendHeartBeatRequest {
 
   public boolean isHealthy() {
     return isHealthy;
+  }
+
+  public ServerStatus getServerStatus() {
+    return serverStatus;
   }
 
   public Map<String, StorageInfo> getStorageInfo() {

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssCancelDecommissionResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssCancelDecommissionResponse.java
@@ -15,7 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.client.request;
+package org.apache.uniffle.client.response;
 
-public class RssDecommissionRequest {
+import org.apache.uniffle.common.rpc.StatusCode;
+
+public class RssCancelDecommissionResponse extends ClientResponse {
+  private String retMsg;
+
+  public RssCancelDecommissionResponse(StatusCode statusCode, String retMsg) {
+    super(statusCode);
+    this.retMsg = retMsg;
+  }
+
+  public String getRetMsg() {
+    return retMsg;
+  }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
@@ -21,13 +21,19 @@ import org.apache.uniffle.common.rpc.StatusCode;
 
 public class RssDecommissionResponse extends ClientResponse {
   private boolean on;
+  private String retMsg;
 
-  public RssDecommissionResponse(StatusCode statusCode, boolean on) {
+  public RssDecommissionResponse(StatusCode statusCode, boolean on, String retMsg) {
     super(statusCode);
     this.on = on;
+    this.retMsg = retMsg;
   }
 
   public boolean isOn() {
     return on;
+  }
+
+  public String getRetMsg() {
+    return retMsg;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.server;
+package org.apache.uniffle.client.response;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.uniffle.common.rpc.StatusCode;
 
-import org.apache.uniffle.common.config.RssBaseConf;
-import org.apache.uniffle.common.metrics.GRPCMetrics;
-import org.apache.uniffle.common.rpc.GrpcServer;
+public class RssDecommissionResponse extends ClientResponse {
+  private boolean on;
 
-public class MockedGrpcServer extends GrpcServer {
-  MockedShuffleServerGrpcService service;
-
-  public MockedGrpcServer(RssBaseConf conf, MockedShuffleServerGrpcService service,
-                          GRPCMetrics grpcMetrics) {
-    super(conf, Lists.newArrayList(Pair.of(service, Lists.newArrayList())), grpcMetrics);
-    this.service = service;
+  public RssDecommissionResponse(StatusCode statusCode, boolean on) {
+    super(statusCode);
+    this.on = on;
   }
 
-  public MockedShuffleServerGrpcService getService() {
-    return service;
+  public boolean isOn() {
+    return on;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssDecommissionResponse.java
@@ -20,17 +20,11 @@ package org.apache.uniffle.client.response;
 import org.apache.uniffle.common.rpc.StatusCode;
 
 public class RssDecommissionResponse extends ClientResponse {
-  private boolean on;
   private String retMsg;
 
-  public RssDecommissionResponse(StatusCode statusCode, boolean on, String retMsg) {
+  public RssDecommissionResponse(StatusCode statusCode, String retMsg) {
     super(statusCode);
-    this.on = on;
     this.retMsg = retMsg;
-  }
-
-  public boolean isOn() {
-    return on;
   }
 
   public String getRetMsg() {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -234,6 +234,13 @@ message ShuffleCommitResponse {
   string retMsg = 3;
 }
 
+enum ServerStatus {
+  ACTIVE = 0;
+  DECOMMISSIONING = 1;
+  DECOMMISSIONED = 2;
+  // todo: more status, such as UPGRADING
+}
+
 message ShuffleServerHeartBeatRequest {
   ShuffleServerId serverId = 1;
   int64 usedMemory = 2;
@@ -242,6 +249,7 @@ message ShuffleServerHeartBeatRequest {
   int32 eventNumInFlush = 5;
   repeated string tags = 6;
   google.protobuf.BoolValue isHealthy = 7;
+  ServerStatus status = 8;
   map<string, StorageInfo> storageInfo = 21; // mount point to storage info mapping.
 }
 
@@ -272,6 +280,7 @@ enum StatusCode {
   INTERNAL_ERROR = 6;
   TIMEOUT = 7;
   ACCESS_DENIED = 8;
+  INVALID_REQUEST = 9;
   // add more status
 }
 
@@ -457,4 +466,18 @@ message RemoteStorage {
 message FetchRemoteStorageResponse {
   StatusCode status = 1;
   RemoteStorage remoteStorage = 2;
+}
+
+service ShuffleServerInternal {
+  rpc decommission(DecommissionRequest) returns (DecommissionResponse);
+}
+
+message DecommissionRequest {
+  google.protobuf.BoolValue on = 1;
+}
+
+message DecommissionResponse {
+  StatusCode status = 1;
+  google.protobuf.BoolValue on = 2;
+  string retMsg = 3;
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -249,7 +249,7 @@ message ShuffleServerHeartBeatRequest {
   int32 eventNumInFlush = 5;
   repeated string tags = 6;
   google.protobuf.BoolValue isHealthy = 7;
-  ServerStatus status = 8;
+  optional ServerStatus status = 8;
   map<string, StorageInfo> storageInfo = 21; // mount point to storage info mapping.
 }
 

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -470,13 +470,21 @@ message FetchRemoteStorageResponse {
 
 service ShuffleServerInternal {
   rpc decommission(DecommissionRequest) returns (DecommissionResponse);
+  rpc cancelDecommission(CancelDecommissionRequest) returns (CancelDecommissionResponse);
 }
 
 message DecommissionRequest {
-  google.protobuf.BoolValue cancel = 1;
 }
 
 message DecommissionResponse {
+  StatusCode status = 1;
+  string retMsg = 2;
+}
+
+message CancelDecommissionRequest {
+}
+
+message CancelDecommissionResponse {
   StatusCode status = 1;
   string retMsg = 2;
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -473,11 +473,10 @@ service ShuffleServerInternal {
 }
 
 message DecommissionRequest {
-  google.protobuf.BoolValue on = 1;
+  google.protobuf.BoolValue cancel = 1;
 }
 
 message DecommissionResponse {
   StatusCode status = 1;
-  google.protobuf.BoolValue on = 2;
-  string retMsg = 3;
+  string retMsg = 2;
 }

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -35,6 +35,7 @@ import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.factory.CoordinatorClientFactory;
 import org.apache.uniffle.client.request.RssSendHeartBeatRequest;
 import org.apache.uniffle.client.response.RssSendHeartBeatResponse;
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.storage.StorageInfo;
 import org.apache.uniffle.common.util.ThreadUtils;
@@ -83,6 +84,7 @@ public class RegisterHeartBeat {
             shuffleServer.getEventNumInFlush(),
             shuffleServer.getTags(),
             shuffleServer.isHealthy(),
+            shuffleServer.getServerStatus(),
             shuffleServer.getStorageManager().getStorageInfo());
       } catch (Exception e) {
         LOG.warn("Error happened when send heart beat to coordinator");
@@ -102,6 +104,7 @@ public class RegisterHeartBeat {
       int eventNumInFlush,
       Set<String> tags,
       boolean isHealthy,
+      ServerStatus serverStatus,
       Map<String, StorageInfo> localStorageInfo) {
     boolean sendSuccessfully = false;
     RssSendHeartBeatRequest request = new RssSendHeartBeatRequest(
@@ -115,6 +118,7 @@ public class RegisterHeartBeat {
         heartBeatTimeout,
         tags,
         isHealthy,
+        serverStatus,
         localStorageInfo);
     List<Future<RssSendHeartBeatResponse>> respFutures = coordinatorClients
         .stream()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerFactory.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerFactory.java
@@ -33,8 +33,13 @@ public class ShuffleServerFactory {
   public ServerInterface getServer() {
     String type = conf.getString(ShuffleServerConf.RPC_SERVER_TYPE);
     if (type.equals(ServerType.GRPC.name())) {
-      return new GrpcServer(conf, new ShuffleServerGrpcService(shuffleServer),
-          shuffleServer.getGrpcMetrics());
+      return GrpcServer.Builder.newBuilder()
+          .conf(conf)
+          .grpcMetrics(shuffleServer.getGrpcMetrics())
+          .addService(new ShuffleServerGrpcService(shuffleServer))
+          // todo: Add ServerInterceptor for authentication
+          .addService(new ShuffleServerInternalGrpcService(shuffleServer))
+          .build();
     } else {
       throw new UnsupportedOperationException("Unsupported server type " + type);
     }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
@@ -35,14 +35,9 @@ public class ShuffleServerInternalGrpcService extends ShuffleServerInternalImplB
   public void decommission(
       RssProtos.DecommissionRequest request,
       StreamObserver<RssProtos.DecommissionResponse> responseObserver) {
-    boolean isCancel = request.getCancel().getValue();
     RssProtos.DecommissionResponse response;
     try {
-      if (isCancel) {
-        shuffleServer.cancelDecommission();
-      } else {
-        shuffleServer.decommission();
-      }
+      shuffleServer.decommission();
       response = RssProtos.DecommissionResponse
           .newBuilder()
           .setStatus(StatusCode.SUCCESS.toProto())
@@ -57,6 +52,32 @@ public class ShuffleServerInternalGrpcService extends ShuffleServerInternalImplB
           .setStatus(statusCode.toProto())
           .setRetMsg(e.getMessage())
           .build();
+    }
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void cancelDecommission(
+          RssProtos.CancelDecommissionRequest request,
+          StreamObserver<RssProtos.CancelDecommissionResponse> responseObserver) {
+    RssProtos.CancelDecommissionResponse response;
+    try {
+      shuffleServer.cancelDecommission();
+      response = RssProtos.CancelDecommissionResponse
+              .newBuilder()
+              .setStatus(StatusCode.SUCCESS.toProto())
+              .build();
+    } catch (Exception e) {
+      StatusCode statusCode = StatusCode.INTERNAL_ERROR;
+      if (e instanceof InvalidRequestException) {
+        statusCode = StatusCode.INVALID_REQUEST;
+      }
+      response = RssProtos.CancelDecommissionResponse
+              .newBuilder()
+              .setStatus(statusCode.toProto())
+              .setRetMsg(e.getMessage())
+              .build();
     }
     responseObserver.onNext(response);
     responseObserver.onCompleted();

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server;
+
+import com.google.protobuf.BoolValue;
+import io.grpc.stub.StreamObserver;
+
+import org.apache.uniffle.common.exception.InvalidRequestException;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
+import org.apache.uniffle.proto.ShuffleServerInternalGrpc.ShuffleServerInternalImplBase;
+
+public class ShuffleServerInternalGrpcService extends ShuffleServerInternalImplBase {
+  private final ShuffleServer shuffleServer;
+
+  public ShuffleServerInternalGrpcService(ShuffleServer shuffleServer) {
+    this.shuffleServer = shuffleServer;
+  }
+
+  @Override
+  public void decommission(
+      RssProtos.DecommissionRequest request,
+      StreamObserver<RssProtos.DecommissionResponse> responseObserver) {
+    boolean decommission = request.getOn().getValue();
+    RssProtos.DecommissionResponse response;
+    try {
+      if (decommission) {
+        shuffleServer.decommission();
+      } else {
+        shuffleServer.cancelDecommission();
+      }
+      response = RssProtos.DecommissionResponse
+          .newBuilder()
+          .setStatus(StatusCode.SUCCESS.toProto())
+          .setOn(BoolValue.newBuilder().setValue(shuffleServer.isDecommissioning()).build())
+          .build();
+    } catch (Exception e) {
+      StatusCode statusCode = StatusCode.INTERNAL_ERROR;
+      if (e instanceof InvalidRequestException) {
+        statusCode = StatusCode.INVALID_REQUEST;
+      }
+      response = RssProtos.DecommissionResponse
+          .newBuilder()
+          .setStatus(statusCode.toProto())
+          .setOn(BoolValue.newBuilder().setValue(shuffleServer.isDecommissioning()).build())
+          .setRetMsg(e.getMessage())
+          .build();
+    }
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerInternalGrpcService.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.server;
 
-import com.google.protobuf.BoolValue;
 import io.grpc.stub.StreamObserver;
 
 import org.apache.uniffle.common.exception.InvalidRequestException;
@@ -36,18 +35,17 @@ public class ShuffleServerInternalGrpcService extends ShuffleServerInternalImplB
   public void decommission(
       RssProtos.DecommissionRequest request,
       StreamObserver<RssProtos.DecommissionResponse> responseObserver) {
-    boolean decommission = request.getOn().getValue();
+    boolean isCancel = request.getCancel().getValue();
     RssProtos.DecommissionResponse response;
     try {
-      if (decommission) {
-        shuffleServer.decommission();
-      } else {
+      if (isCancel) {
         shuffleServer.cancelDecommission();
+      } else {
+        shuffleServer.decommission();
       }
       response = RssProtos.DecommissionResponse
           .newBuilder()
           .setStatus(StatusCode.SUCCESS.toProto())
-          .setOn(BoolValue.newBuilder().setValue(shuffleServer.isDecommissioning()).build())
           .build();
     } catch (Exception e) {
       StatusCode statusCode = StatusCode.INTERNAL_ERROR;
@@ -57,7 +55,6 @@ public class ShuffleServerInternalGrpcService extends ShuffleServerInternalImplB
       response = RssProtos.DecommissionResponse
           .newBuilder()
           .setStatus(statusCode.toProto())
-          .setOn(BoolValue.newBuilder().setValue(shuffleServer.isDecommissioning()).build())
           .setRetMsg(e.getMessage())
           .build();
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add RPC logic and heartbeat logic for decommisson

### Why are the changes needed?

Support shuffle server decommission. It is a part of #80

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

UT
