### PR TITLE
[#678] improvement: Write hdfs files asynchronously when `detectStorage`

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -56,7 +56,7 @@ public class HadoopSecurityContext implements SecurityContext {
 
     if (StringUtils.isNotEmpty(krb5ConfPath)) {
       System.setProperty(KRB5_CONF_KEY, krb5ConfPath);
-//      sun.security.krb5.Config.refresh();
+      sun.security.krb5.Config.refresh();
     }
 
     Configuration conf = new Configuration(false);

--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -56,7 +56,7 @@ public class HadoopSecurityContext implements SecurityContext {
 
     if (StringUtils.isNotEmpty(krb5ConfPath)) {
       System.setProperty(KRB5_CONF_KEY, krb5ConfPath);
-      sun.security.krb5.Config.refresh();
+//      sun.security.krb5.Config.refresh();
     }
 
     Configuration conf = new Configuration(false);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategy.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategy.java
@@ -78,7 +78,6 @@ public class AppBalanceSelectStorageStrategy extends AbstractSelectStorageStrate
     }
     uris = Lists.newCopyOnWriteArrayList(remoteStoragePathRankValue.entrySet()).stream()
         .filter(Objects::nonNull).collect(Collectors.toList());
-    LOG.error("SSSSSS:uris is {}, path is {}, rankValue is {}", uris, path, rankValue);
   }
 
   @Override

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategy.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/AppBalanceSelectStorageStrategy.java
@@ -90,7 +90,8 @@ public class AppBalanceSelectStorageStrategy extends AbstractSelectStorageStrate
             RankValue rankValue = remoteStoragePathRankValue.get(uri.getKey());
             rankValue.setHealthy(new AtomicBoolean(true));
             Path remotePath = new Path(uri.getKey());
-            String rssTest = uri.getKey() + "/rssTest-" + getCoordinatorId();
+            String rssTest = uri.getKey() + "/rssTest-" + getCoordinatorId()
+                + Thread.currentThread().getName();;
             Path testPath = new Path(rssTest);
             try {
               FileSystem fs = HadoopFilesystemProvider.getFilesystem(remotePath, hdfsConf);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/LowestIOSampleCostSelectStorageStrategy.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/strategy/storage/LowestIOSampleCostSelectStorageStrategy.java
@@ -103,7 +103,8 @@ public class LowestIOSampleCostSelectStorageStrategy extends AbstractSelectStora
         Thread detectThread = new Thread(() -> {
           if (uri.getKey().startsWith(ApplicationManager.getPathSchema().get(0))) {
             Path remotePath = new Path(uri.getKey());
-            String rssTest = uri.getKey() + "/rssTest-" + getCoordinatorId();
+            String rssTest = uri.getKey() + "/rssTest-" + getCoordinatorId()
+                + Thread.currentThread().getName();
             Path testPath = new Path(rssTest);
             RankValue rankValue = remoteStoragePathRankValue.get(uri.getKey());
             rankValue.setHealthy(new AtomicBoolean(true));


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Write files to hdfs asynchronously and reduce the time of detectStorage

### Why are the changes needed?
Fix: #678 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Origin uts.
