### PR TITLE
[#674] feat(docker): use JDK11 as the default java version in Dockerfile

### DIFF
--- a/deploy/kubernetes/docker/base/centos/Dockerfile
+++ b/deploy/kubernetes/docker/base/centos/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # this docker file serves the rss server base image for CentOS/RedHat distributions
-ARG BASE_IMAGE=eclipse-temurin:8-jdk-centos7
+ARG BASE_IMAGE=eclipse-temurin:11-jdk-centos7
 FROM ${BASE_IMAGE}
 
 RUN yum install lzo zlib zlib-devel lzop lsof netcat dnsutils less procps iputils-ping -y && \

--- a/deploy/kubernetes/docker/base/debian/Dockerfile
+++ b/deploy/kubernetes/docker/base/debian/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # this docker file serves the rss server base image for Debian/Ubuntu releated distributions
-ARG BASE_IMAGE=eclipse-temurin:8-jdk
+ARG BASE_IMAGE=eclipse-temurin:11-jdk
 FROM ${BASE_IMAGE}
 
 RUN apt-get update && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use JDK11 as the default java version in Dockerfile when deploying shuffle servers on K8s.

### Why are the changes needed?

As the GC problems mentioned in #674, I upgraded the JVM version from JDK8 to JDK11 for shuffle server. And after benchmark, I found the effect of the upgrade is remarkable. And it also works well with Hadoop3.1.1

Based on above practice, it's better to use JDK11 as the default java version to improve stability

### Does this PR introduce _any_ user-facing change?

Yes

### How was this patch tested?

Have tested in production env.