### PR TITLE
[MINOR] improvement: Reduce the size of Spark patch

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -187,7 +187,8 @@ public class RssShuffleManager implements ShuffleManager {
     RssSparkShuffleUtils.validateRssClientConf(sparkConf);
     // External shuffle service is not supported when using remote shuffle service
     sparkConf.set("spark.shuffle.service.enabled", "false");
-    LOG.info("Disable external shuffle service in RssShuffleManager.");
+    sparkConf.set("spark.shuffle.reduceLocality.enabled", "false");
+    LOG.info("Disable external shuffle service and shuffle data locality in RssShuffleManager.");
     if (!sparkConf.getBoolean(RssSparkConfig.RSS_TEST_FLAG.key(), false)) {
       // for non-driver executor, start a thread for sending shuffle data to shuffle server
       LOG.info("RSS data send thread is starting");

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -202,7 +202,8 @@ public class RssShuffleManager implements ShuffleManager {
     RssSparkShuffleUtils.validateRssClientConf(sparkConf);
     // External shuffle service is not supported when using remote shuffle service
     sparkConf.set("spark.shuffle.service.enabled", "false");
-    LOG.info("Disable external shuffle service in RssShuffleManager.");
+    sparkConf.set("spark.shuffle.reduceLocality.enabled", "false");
+    LOG.info("Disable external shuffle service and shuffle data locality in RssShuffleManager.");
     sparkConf.set("spark.sql.adaptive.localShuffleReader.enabled", "false");
     LOG.info("Disable local shuffle reader in RssShuffleManager.");
     taskToSuccessBlockIds = Maps.newConcurrentMap();

--- a/spark-patches/spark-2.4.6_dynamic_allocation_support.patch
+++ b/spark-patches/spark-2.4.6_dynamic_allocation_support.patch
@@ -69,24 +69,3 @@ index 459f575ba7..f563368fa5 100644
        for ((tid, info) <- taskInfos if info.executorId == execId) {
          val index = taskInfos(tid).index
          // We may have a running task whose partition has been marked as successful,
-diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-index 021ce2eac0..50c52b0091 100644
---- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-@@ -149,9 +149,13 @@ class ShuffledRowRDD(
-   }
- 
-   override def getPreferredLocations(partition: Partition): Seq[String] = {
--    val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
--    val dep = dependencies.head.asInstanceOf[ShuffleDependency[_, _, _]]
--    tracker.getPreferredLocationsForShuffle(dep, partition.index)
-+    if (!conf.isRssEnable()) {
-+      val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
-+      val dep = dependencies.head.asInstanceOf[ShuffleDependency[_, _, _]]
-+      tracker.getPreferredLocationsForShuffle(dep, partition.index)
-+    } else {
-+      Nil
-+    }
-   }
- 
-   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {

--- a/spark-patches/spark-3.1.2_dynamic_allocation_support.patch
+++ b/spark-patches/spark-3.1.2_dynamic_allocation_support.patch
@@ -72,44 +72,4 @@ index ad0791fa42..2d2ad52c71 100644
        for ((tid, info) <- taskInfos if info.executorId == execId) {
          val index = taskInfos(tid).index
          // We may have a running task whose partition has been marked as successful,
-diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-index ef84cd27a3..0b1ab0d50b 100644
---- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-@@ -159,19 +159,23 @@ class ShuffledRowRDD(
-   }
- 
-   override def getPreferredLocations(partition: Partition): Seq[String] = {
--    val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
--    partition.asInstanceOf[ShuffledRowRDDPartition].spec match {
--      case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
--        // TODO order by partition size.
--        startReducerIndex.until(endReducerIndex).flatMap { reducerIndex =>
--          tracker.getPreferredLocationsForShuffle(dependency, reducerIndex)
--        }
--
--      case PartialReducerPartitionSpec(_, startMapIndex, endMapIndex, _) =>
--        tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
--
--      case PartialMapperPartitionSpec(mapIndex, _, _) =>
--        tracker.getMapLocation(dependency, mapIndex, mapIndex + 1)
-+    if (!conf.isRssEnable()) {
-+      val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
-+      partition.asInstanceOf[ShuffledRowRDDPartition].spec match {
-+        case CoalescedPartitionSpec(startReducerIndex, endReducerIndex) =>
-+          // TODO order by partition size.
-+          startReducerIndex.until(endReducerIndex).flatMap { reducerIndex =>
-+            tracker.getPreferredLocationsForShuffle(dependency, reducerIndex)
-+          }
-+
-+        case PartialReducerPartitionSpec(_, startMapIndex, endMapIndex, _) =>
-+          tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
-+
-+        case PartialMapperPartitionSpec(mapIndex, _, _) =>
-+          tracker.getMapLocation(dependency, mapIndex, mapIndex + 1)
-+      }
-+    } else {
-+      Nil
-     }
-   }
- 
+

--- a/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
+++ b/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
@@ -59,4 +59,18 @@ index a82d261d545..72e54940ca2 100644
      removeExecutorAndUnregisterOutputs(
        execId = execId,
        fileLost = fileLost,
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+index 3b72103f993..8e03754941e 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+@@ -1015,7 +1015,8 @@ private[spark] class TaskSetManager(
+     // and we are not using an external shuffle server which could serve the shuffle outputs.
+     // The reason is the next stage wouldn't be able to fetch the data from this dead executor
+     // so we would need to rerun these tasks on other executors.
+-    if (isShuffleMapTasks && !env.blockManager.externalShuffleServiceEnabled && !isZombie) {
++    if (isShuffleMapTasks && !env.blockManager.externalShuffleServiceEnabled &&
++        !isZombie && !conf.isRssEnable()) {
+       for ((tid, info) <- taskInfos if info.executorId == execId) {
+         val index = taskInfos(tid).index
+         // We may have a running task whose partition has been marked as successful,
 

--- a/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
+++ b/spark-patches/spark-3.2.1_dynamic_allocation_support.patch
@@ -59,34 +59,4 @@ index a82d261d545..72e54940ca2 100644
      removeExecutorAndUnregisterOutputs(
        execId = execId,
        fileLost = fileLost,
-diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
-index 3b72103f993..8e03754941e 100644
---- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
-+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
-@@ -1015,7 +1015,8 @@ private[spark] class TaskSetManager(
-     // and we are not using an external shuffle server which could serve the shuffle outputs.
-     // The reason is the next stage wouldn't be able to fetch the data from this dead executor
-     // so we would need to rerun these tasks on other executors.
--    if (isShuffleMapTasks && !env.blockManager.externalShuffleServiceEnabled && !isZombie) {
-+    if (isShuffleMapTasks && !env.blockManager.externalShuffleServiceEnabled &&
-+        !isZombie && !conf.isRssEnable()) {
-       for ((tid, info) <- taskInfos if info.executorId == execId) {
-         val index = taskInfos(tid).index
-         // We may have a running task whose partition has been marked as successful,
-diff --git a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-index 47d61196fe8..98a5381bef4 100644
---- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
-@@ -174,6 +174,9 @@ class ShuffledRowRDD(
-   }
- 
-   override def getPreferredLocations(partition: Partition): Seq[String] = {
-+    if (conf.isRssEnable()) {
-+      return Nil
-+    }
-     val tracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
-     partition.asInstanceOf[ShuffledRowRDDPartition].spec match {
-       case CoalescedPartitionSpec(startReducerIndex, endReducerIndex, _) =>
--- 
-2.32.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
As https://github.com/apache/spark/pull/40307#issuecomment-1457619866, we could use `spark.shuffle.reduceLocality.enabled` to reduce the modification of the Apache Spark.

### Why are the changes needed?

Reduce the spark patch size

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
No need
