### PR TITLE
[#585] feat(netty): Add MaxDirectMemorySize option for shuffle Server

### DIFF
--- a/bin/rss-env.sh
+++ b/bin/rss-env.sh
@@ -31,3 +31,4 @@ XMX_SIZE="80g" # Shuffle Server JVM XMX size
 # RSS_PID_DIR, Where the pid file is stored (Default: ${RSS_HOME})
 # RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
 # RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
+# MAX_DIRECT_MEMORY_SIZE Shuffle Server JVM off heap memory size (Default: 0)

--- a/bin/rss-env.sh
+++ b/bin/rss-env.sh
@@ -31,4 +31,4 @@ XMX_SIZE="80g" # Shuffle Server JVM XMX size
 # RSS_PID_DIR, Where the pid file is stored (Default: ${RSS_HOME})
 # RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
 # RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
-# MAX_DIRECT_MEMORY_SIZE Shuffle Server JVM off heap memory size (Default: 0)
+# MAX_DIRECT_MEMORY_SIZE Shuffle Server JVM off heap memory size (Default: not set)

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -66,9 +66,9 @@ JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 
 echo "class path is $CLASSPATH"
 
-MAX_DIRECT_MEMORY_OPTS = ""
+MAX_DIRECT_MEMORY_OPTS=""
 if [ -n "$MAX_DIRECT_MEMORY_SIZE" ]; then
-  MAX_DIRECT_MEMORY_OPTS = "-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY_SIZE"
+  MAX_DIRECT_MEMORY_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY_SIZE"
 fi
 
 JVM_ARGS=" -server \

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -66,9 +66,15 @@ JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 
 echo "class path is $CLASSPATH"
 
+MAX_DIRECT_MEMORY_OPTS = ""
+if [ -n "$MAX_DIRECT_MEMORY_SIZE" ]; then
+  MAX_DIRECT_MEMORY_OPTS = "-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY_SIZE"
+fi
+
 JVM_ARGS=" -server \
           -Xmx${XMX_SIZE} \
           -Xms${XMX_SIZE} \
+          ${MAX_DIRECT_MEMORY_OPTS} \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add MaxDirectMemorySize option for shuffle Server. It will be convenient for Netty.

### Why are the changes needed?

Fix: #585 

### Does this PR introduce _any_ user-facing change?
Yes. I will add the entire document of rss-env.sh in the future.

### How was this patch tested?
Manual test
