### PR TITLE
[#708] test: do not assume hostname of hdfs mini-cluster

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
@@ -259,7 +259,7 @@ public class KerberizedHdfs implements Serializable {
   }
 
   public String getSchemeAndAuthorityPrefix() {
-    return "hdfs://" + kerberizedDfsCluster.getNameNode().getNameNodeAddressHostPortString() + "/";
+    return kerberizedDfsCluster.getURI().toString();
   }
 
   public Configuration getConf() throws IOException {

--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
@@ -259,7 +259,7 @@ public class KerberizedHdfs implements Serializable {
   }
 
   public String getSchemeAndAuthorityPrefix() {
-    return kerberizedDfsCluster.getURI().toString();
+    return kerberizedDfsCluster.getURI().toString() + "/";
   }
 
   public Configuration getConf() throws IOException {

--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
@@ -259,7 +259,7 @@ public class KerberizedHdfs implements Serializable {
   }
 
   public String getSchemeAndAuthorityPrefix() {
-    return String.format("hdfs://localhost:%s/", kerberizedDfsCluster.getNameNodePort());
+    return "hdfs://" + kerberizedDfsCluster.getNameNode().getNameNodeAddressHostPortString() + "/";
   }
 
   public Configuration getConf() throws IOException {

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -153,7 +153,7 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     storageManager.registerRemoteStorage(appId, remoteStorage);
-    String storageHost = "localhost";
+    String storageHost = cluster.getURI().getHost();
     assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.get(storageHost).get(), 0.5);
     assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageRetryWrite.get(storageHost).get(), 0.5);
     assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageFailedWrite.get(storageHost).get(), 0.5);

--- a/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
@@ -47,7 +47,7 @@ public class HdfsTestBase implements Serializable {
     conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
         baseDir.getAbsolutePath());
     cluster = (new MiniDFSCluster.Builder(conf)).build();
-    HDFS_URI = "hdfs://localhost:" + cluster.getNameNodePort() + "/";
+    HDFS_URI = "hdfs://" + cluster.getNameNode().getNameNodeAddressHostPortString() + "/";
     fs = (new Path(HDFS_URI)).getFileSystem(conf);
   }
 

--- a/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
@@ -47,7 +47,7 @@ public class HdfsTestBase implements Serializable {
     conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
         baseDir.getAbsolutePath());
     cluster = (new MiniDFSCluster.Builder(conf)).build();
-    HDFS_URI = cluster.getURI().toString();
+    HDFS_URI = cluster.getURI().toString() + "/";
     fs = (new Path(HDFS_URI)).getFileSystem(conf);
   }
 

--- a/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HdfsTestBase.java
@@ -47,7 +47,7 @@ public class HdfsTestBase implements Serializable {
     conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
         baseDir.getAbsolutePath());
     cluster = (new MiniDFSCluster.Builder(conf)).build();
-    HDFS_URI = "hdfs://" + cluster.getNameNode().getNameNodeAddressHostPortString() + "/";
+    HDFS_URI = cluster.getURI().toString();
     fs = (new Path(HDFS_URI)).getFileSystem(conf);
   }
 

--- a/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
@@ -53,7 +53,7 @@ public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
     dataOut.write(buf);
     dataOut.close();
     fileOut.close();
-    String path = clusterPathPrefix + "/test";
+    String path = clusterPathPrefix + "test";
     HdfsFileWriter writer = new HdfsFileWriter(fileSystem, new Path(path), hadoopConf);
     long size = ShuffleStorageUtils.uploadFile(file, writer, 1024);
     assertEquals(2096, size);

--- a/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
@@ -32,7 +32,6 @@ import org.apache.uniffle.storage.HdfsTestBase;
 import org.apache.uniffle.storage.handler.impl.HdfsFileWriter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
 
@@ -46,27 +45,20 @@ public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
       FileSystem fileSystem,
       String clusterPathPrefix,
       Configuration hadoopConf) throws Exception {
-    FileOutputStream fileOut = null;
-    DataOutputStream dataOut = null;
-    try {
-      File file = new File(tempDir, "test");
-      fileOut = new FileOutputStream(file);
-      dataOut = new DataOutputStream(fileOut);
-      byte[] buf = new byte[2096];
-      new Random().nextBytes(buf);
-      dataOut.write(buf);
-      dataOut.close();
-      fileOut.close();
-      String path = clusterPathPrefix + "test";
-      HdfsFileWriter writer = new HdfsFileWriter(fileSystem, new Path(path), hadoopConf);
-      long size = ShuffleStorageUtils.uploadFile(file, writer, 1024);
-      assertEquals(2096, size);
-      size = ShuffleStorageUtils.uploadFile(file, writer, 100);
-      assertEquals(2096, size);
-      writer.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail();
-    }
+    File file = new File(tempDir, "test");
+    FileOutputStream fileOut = new FileOutputStream(file);
+    DataOutputStream dataOut = new DataOutputStream(fileOut);
+    byte[] buf = new byte[2096];
+    new Random().nextBytes(buf);
+    dataOut.write(buf);
+    dataOut.close();
+    fileOut.close();
+    String path = clusterPathPrefix + "test";
+    HdfsFileWriter writer = new HdfsFileWriter(fileSystem, new Path(path), hadoopConf);
+    long size = ShuffleStorageUtils.uploadFile(file, writer, 1024);
+    assertEquals(2096, size);
+    size = ShuffleStorageUtils.uploadFile(file, writer, 100);
+    assertEquals(2096, size);
+    writer.close();
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleHdfsStorageUtilsTest.java
@@ -53,7 +53,7 @@ public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
     dataOut.write(buf);
     dataOut.close();
     fileOut.close();
-    String path = clusterPathPrefix + "test";
+    String path = clusterPathPrefix + "/test";
     HdfsFileWriter writer = new HdfsFileWriter(fileSystem, new Path(path), hadoopConf);
     long size = ShuffleStorageUtils.uploadFile(file, writer, 1024);
     assertEquals(2096, size);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Do not assume hostname in hdfs URL.
Also, let exception be thrown in `ShuffleHdfsStorageUtilsTest` to print verbose message.

### Why are the changes needed?

Fix #708 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested manually