### PR TITLE
[#706] Implement spill method to avoid memory deadlock

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -28,10 +28,25 @@ import scala.Tuple2;
 import scala.runtime.AbstractFunction1;
 
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.config.ConfigOption;
+import org.apache.uniffle.common.config.ConfigOptions;
 import org.apache.uniffle.common.config.ConfigUtils;
 import org.apache.uniffle.common.config.RssConf;
 
 public class RssSparkConfig {
+
+  public static final ConfigOption<Long> RSS_CLIENT_SEND_SIZE_LIMITATION = ConfigOptions
+      .key("rss.client.send.size.limit")
+      .longType()
+      .defaultValue(1024 * 1024 * 16L)
+      .withDescription("The max data size sent to shuffle server");
+
+  public static final ConfigOption<Integer> RSS_MEMORY_SPILL_TIMEOUT = ConfigOptions
+      .key("rss.client.memory.spill.timeout.sec")
+      .intType()
+      .defaultValue(1)
+      .withDescription("The timeout of spilling data to remote shuffle server, "
+          + "which will be triggered by Spark TaskMemoryManager. Unit is sec, default value is 1");
 
   public static final String SPARK_RSS_CONFIG_PREFIX = "spark.";
 
@@ -114,11 +129,6 @@ public class RssSparkConfig {
   public static final ConfigEntry<Integer> RSS_CLIENT_HEARTBEAT_THREAD_NUM = createIntegerBuilder(
       new ConfigBuilder("spark.rss.client.heartBeat.threadNum"))
       .createWithDefault(4);
-
-  public static final ConfigEntry<String> RSS_CLIENT_SEND_SIZE_LIMIT = createStringBuilder(
-      new ConfigBuilder("spark.rss.client.send.size.limit")
-          .doc("The max data size sent to shuffle server"))
-      .createWithDefault("16m");
 
   public static final ConfigEntry<Integer> RSS_CLIENT_UNREGISTER_THREAD_POOL_SIZE = createIntegerBuilder(
       new ConfigBuilder("spark.rss.client.unregister.thread.pool.size"))

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
@@ -25,10 +26,26 @@ public class AddBlockEvent {
 
   private String taskId;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
+  private List<Runnable> processedCallbackChain;
 
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
     this.taskId = taskId;
     this.shuffleDataInfoList = shuffleDataInfoList;
+    this.processedCallbackChain = new ArrayList<>();
+  }
+
+  public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleBlockInfoList, Runnable callback) {
+    this.taskId = taskId;
+    this.shuffleDataInfoList = shuffleBlockInfoList;
+    this.processedCallbackChain = new ArrayList<>();
+    addCallback(callback);
+  }
+
+  /**
+   * @param callback, should not throw any exception and execute fast.
+   */
+  public void addCallback(Runnable callback) {
+    processedCallbackChain.add(callback);
   }
 
   public String getTaskId() {
@@ -37,6 +54,10 @@ public class AddBlockEvent {
 
   public List<ShuffleBlockInfo> getShuffleDataInfoList() {
     return shuffleDataInfoList;
+  }
+
+  public List<Runnable> getProcessedCallbackChain() {
+    return processedCallbackChain;
   }
 
   @Override

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.writer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.client.api.ShuffleWriteClient;
+import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.ThreadUtils;
+
+/**
+ * A {@link DataPusher} that is responsible for sending data to remote
+ * shuffle servers asynchronously.
+ */
+public class DataPusher implements Closeable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataPusher.class);
+
+  private final ExecutorService executorService;
+
+  private final ShuffleWriteClient shuffleWriteClient;
+  // Must be thread safe
+  private final Map<String, Set<Long>> taskToSuccessBlockIds;
+  // Must be thread safe
+  private final Map<String, Set<Long>> taskToFailedBlockIds;
+  private String rssAppId;
+  // Must be thread safe
+  private final Set<String> failedTaskIds;
+
+  public DataPusher(ShuffleWriteClient shuffleWriteClient,
+      Map<String, Set<Long>> taskToSuccessBlockIds,
+      Map<String, Set<Long>> taskToFailedBlockIds,
+      Set<String> failedTaskIds,
+      int threadPoolSize,
+      int threadKeepAliveTime) {
+    this.shuffleWriteClient = shuffleWriteClient;
+    this.taskToSuccessBlockIds = taskToSuccessBlockIds;
+    this.taskToFailedBlockIds = taskToFailedBlockIds;
+    this.failedTaskIds = failedTaskIds;
+    this.executorService = new ThreadPoolExecutor(
+        threadPoolSize,
+        threadPoolSize * 2,
+        threadKeepAliveTime,
+        TimeUnit.SECONDS,
+        Queues.newLinkedBlockingQueue(Integer.MAX_VALUE),
+        ThreadUtils.getThreadFactory(this.getClass().getName())
+    );
+  }
+
+  public CompletableFuture<Long> send(AddBlockEvent event) {
+    if (rssAppId == null) {
+      throw new RssException("RssAppId should be set.");
+    }
+    return CompletableFuture.supplyAsync(() -> {
+      String taskId = event.getTaskId();
+      List<ShuffleBlockInfo> shuffleBlockInfoList = event.getShuffleDataInfoList();
+      try {
+        SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(
+            rssAppId,
+            shuffleBlockInfoList,
+            () -> !isValidTask(taskId)
+        );
+        putBlockId(taskToSuccessBlockIds, taskId, result.getSuccessBlockIds());
+        putBlockId(taskToFailedBlockIds, taskId, result.getFailedBlockIds());
+      } finally {
+        List<Runnable> callbackChain = Optional.of(event.getProcessedCallbackChain()).orElse(Collections.EMPTY_LIST);
+        for (Runnable runnable : callbackChain) {
+          runnable.run();
+        }
+      }
+      return shuffleBlockInfoList.stream()
+          .map(x -> x.getFreeMemory())
+          .reduce((a, b) -> a + b)
+          .get();
+    }, executorService);
+  }
+
+  private synchronized void putBlockId(
+      Map<String, Set<Long>> taskToBlockIds,
+      String taskAttemptId,
+      Set<Long> blockIds) {
+    if (blockIds == null || blockIds.isEmpty()) {
+      return;
+    }
+    taskToBlockIds.computeIfAbsent(taskAttemptId, x -> Sets.newConcurrentHashSet()).addAll(blockIds);
+  }
+
+  public boolean isValidTask(String taskId) {
+    return !failedTaskIds.contains(taskId);
+  }
+
+  public void setRssAppId(String rssAppId) {
+    this.rssAppId = rssAppId;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (executorService != null) {
+      try {
+        ThreadUtils.shutdownThreadPool(executorService, 5);
+      } catch (InterruptedException interruptedException) {
+        LOGGER.error("Errors on shutdown thread pool of [{}].", this.getClass().getSimpleName());
+      }
+    }
+  }
+}

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -17,10 +17,16 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.clearspring.analytics.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
@@ -61,6 +67,7 @@ public class WriteBufferManager extends MemoryConsumer {
   private Map<Integer, Integer> partitionToSeqNo = Maps.newHashMap();
   private long askExecutorMemory;
   private int shuffleId;
+  private String taskId;
   private long taskAttemptId;
   private SerializerInstance instance;
   private ShuffleWriteMetrics shuffleWriteMetrics;
@@ -81,6 +88,9 @@ public class WriteBufferManager extends MemoryConsumer {
   private long requireMemoryInterval;
   private int requireMemoryRetryMax;
   private Codec codec;
+  private Function<AddBlockEvent, CompletableFuture<Long>> spillFunc;
+  private long sendSizeLimit;
+  private int memorySpillTimeoutSec;
 
   public WriteBufferManager(
       int shuffleId,
@@ -91,12 +101,38 @@ public class WriteBufferManager extends MemoryConsumer {
       TaskMemoryManager taskMemoryManager,
       ShuffleWriteMetrics shuffleWriteMetrics,
       RssConf rssConf) {
+    this(
+        shuffleId,
+        null,
+        taskAttemptId,
+        bufferManagerOptions,
+        serializer,
+        partitionToServers,
+        taskMemoryManager,
+        shuffleWriteMetrics,
+        rssConf,
+        null
+    );
+  }
+
+  public WriteBufferManager(
+      int shuffleId,
+      String taskId,
+      long taskAttemptId,
+      BufferManagerOptions bufferManagerOptions,
+      Serializer serializer,
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      TaskMemoryManager taskMemoryManager,
+      ShuffleWriteMetrics shuffleWriteMetrics,
+      RssConf rssConf,
+      Function<AddBlockEvent, CompletableFuture<Long>> spillFunc) {
     super(taskMemoryManager, taskMemoryManager.pageSizeBytes(), MemoryMode.ON_HEAP);
     this.bufferSize = bufferManagerOptions.getBufferSize();
     this.spillSize = bufferManagerOptions.getBufferSpillThreshold();
     this.instance = serializer.newInstance();
     this.buffers = Maps.newHashMap();
     this.shuffleId = shuffleId;
+    this.taskId = taskId;
     this.taskAttemptId = taskAttemptId;
     this.partitionToServers = partitionToServers;
     this.shuffleWriteMetrics = shuffleWriteMetrics;
@@ -111,6 +147,9 @@ public class WriteBufferManager extends MemoryConsumer {
             .substring(RssSparkConfig.SPARK_RSS_CONFIG_PREFIX.length()),
         RssSparkConfig.SPARK_SHUFFLE_COMPRESS_DEFAULT);
     this.codec = compress ? Codec.newInstance(rssConf) : null;
+    this.spillFunc = spillFunc;
+    this.sendSizeLimit = rssConf.get(RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMITATION);
+    this.memorySpillTimeoutSec = rssConf.get(RssSparkConfig.RSS_MEMORY_SPILL_TIMEOUT);
   }
 
   public List<ShuffleBlockInfo> addRecord(int partitionId, Object key, Object value) {
@@ -165,7 +204,7 @@ public class WriteBufferManager extends MemoryConsumer {
   }
 
   // transform all [partition, records] to [partition, ShuffleBlockInfo] and clear cache
-  public List<ShuffleBlockInfo> clear() {
+  public synchronized List<ShuffleBlockInfo> clear() {
     List<ShuffleBlockInfo> result = Lists.newArrayList();
     long dataSize = 0;
     long memoryUsed = 0;
@@ -247,10 +286,64 @@ public class WriteBufferManager extends MemoryConsumer {
     }
   }
 
+  public List<AddBlockEvent> buildBlockEvents(List<ShuffleBlockInfo> shuffleBlockInfoList) {
+    long totalSize = 0;
+    long memoryUsed = 0;
+    List<AddBlockEvent> events = new ArrayList<>();
+    List<ShuffleBlockInfo> shuffleBlockInfosPerEvent = Lists.newArrayList();
+    for (ShuffleBlockInfo sbi : shuffleBlockInfoList) {
+      totalSize += sbi.getSize();
+      memoryUsed += sbi.getFreeMemory();
+      shuffleBlockInfosPerEvent.add(sbi);
+      // split shuffle data according to the size
+      if (totalSize > sendSizeLimit) {
+        LOG.info("Build event with " + shuffleBlockInfosPerEvent.size()
+            + " blocks and " + totalSize + " bytes");
+        // Use final temporary variables for closures
+        final long _memoryUsed = memoryUsed;
+        events.add(
+            new AddBlockEvent(taskId, shuffleBlockInfosPerEvent, () -> freeAllocatedMemory(_memoryUsed))
+        );
+        shuffleBlockInfosPerEvent = Lists.newArrayList();
+        totalSize = 0;
+        memoryUsed = 0;
+      }
+    }
+    if (!shuffleBlockInfosPerEvent.isEmpty()) {
+      LOG.info("Build event with " + shuffleBlockInfosPerEvent.size()
+          + " blocks and " + totalSize + " bytes");
+      // Use final temporary variables for closures
+      final long _memoryUsed = memoryUsed;
+      events.add(
+          new AddBlockEvent(taskId, shuffleBlockInfosPerEvent, () -> freeAllocatedMemory(_memoryUsed))
+      );
+    }
+    return events;
+  }
+
   @Override
   public long spill(long size, MemoryConsumer trigger) {
-    // there is no spill for such situation
-    return 0;
+    List<AddBlockEvent> events = buildBlockEvents(clear());
+    List<CompletableFuture<Long>> futures = events.stream().map(x -> spillFunc.apply(x)).collect(Collectors.toList());
+    CompletableFuture<Void> allOfFutures =
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
+    try {
+      allOfFutures.get(memorySpillTimeoutSec, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // A best effort strategy to wait.
+      // If timeout exception occurs, the underlying tasks won't be cancelled.
+    } finally {
+      long releasedSize = futures.stream().filter(x -> x.isDone()).mapToLong(x -> {
+        try {
+          return x.get();
+        } catch (Exception e) {
+          return 0;
+        }
+      }).sum();
+      LOG.info("[taskId: {}] Spill triggered by memory consumer of {}, released memory size: {}",
+          taskId, trigger.getClass().getSimpleName(), releasedSize);
+      return releasedSize;
+    }
   }
 
   @VisibleForTesting
@@ -306,5 +399,21 @@ public class WriteBufferManager extends MemoryConsumer {
         + serializeTime + "], compressTime[" + compressTime + "], estimateTime["
         + estimateTime + "], requireMemoryTime[" + requireMemoryTime
         + "], uncompressedDataLen[" + uncompressedDataLen + "]";
+  }
+
+  @VisibleForTesting
+  public void setTaskId(String taskId) {
+    this.taskId = taskId;
+  }
+
+  @VisibleForTesting
+  public void setSpillFunc(
+      Function<AddBlockEvent, CompletableFuture<Long>> spillFunc) {
+    this.spillFunc = spillFunc;
+  }
+
+  @VisibleForTesting
+  public void setSendSizeLimit(long sendSizeLimit) {
+    this.sendSizeLimit = sendSizeLimit;
   }
 }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.writer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
+import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.common.ShuffleBlockInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataPusherTest {
+
+  static class FakedShuffleWriteClient extends ShuffleWriteClientImpl {
+    private SendShuffleDataResult fakedShuffleDataResult;
+
+    FakedShuffleWriteClient() {
+      this(
+          "GRPC",
+          1,
+          1,
+          10,
+          1,
+          1,
+          1,
+          false,
+          1,
+          1,
+          1,
+          1
+      );
+    }
+
+    private FakedShuffleWriteClient(String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
+        int replica, int replicaWrite, int replicaRead, boolean replicaSkipEnabled, int dataTransferPoolSize,
+        int dataCommitPoolSize, int unregisterThreadPoolSize, int unregisterRequestTimeSec) {
+      super(clientType, retryMax, retryIntervalMax, heartBeatThreadNum, replica, replicaWrite, replicaRead,
+          replicaSkipEnabled, dataTransferPoolSize, dataCommitPoolSize, unregisterThreadPoolSize,
+          unregisterRequestTimeSec);
+    }
+
+    @Override
+    public SendShuffleDataResult sendShuffleData(String appId, List<ShuffleBlockInfo> shuffleBlockInfoList,
+        Supplier<Boolean> needCancelRequest) {
+      return fakedShuffleDataResult;
+    }
+
+    public void setFakedShuffleDataResult(SendShuffleDataResult fakedShuffleDataResult) {
+      this.fakedShuffleDataResult = fakedShuffleDataResult;
+    }
+  }
+
+  @Test
+  public void testSendData() throws ExecutionException, InterruptedException {
+    FakedShuffleWriteClient shuffleWriteClient = new FakedShuffleWriteClient();
+
+    Map<String, Set<Long>> taskToSuccessBlockIds = Maps.newConcurrentMap();
+    Map<String, Set<Long>> taskToFailedBlockIds = Maps.newConcurrentMap();
+    Set<String> failedTaskIds = new HashSet<>();
+
+    DataPusher dataPusher = new DataPusher(
+        shuffleWriteClient,
+        taskToSuccessBlockIds,
+        taskToFailedBlockIds,
+        failedTaskIds,
+        1,
+        2
+    );
+    dataPusher.setRssAppId("testSendData_appId");
+
+    // sync send
+    AddBlockEvent event = new AddBlockEvent("taskId", Arrays.asList(
+        new ShuffleBlockInfo(
+            1, 1, 1, 1, 1, new byte[1], null, 1, 100, 1
+        ))
+    );
+    shuffleWriteClient.setFakedShuffleDataResult(
+        new SendShuffleDataResult(
+            Sets.newHashSet(1L, 2L),
+            Sets.newHashSet(3L, 4L)
+        )
+    );
+    CompletableFuture<Long> future = dataPusher.send(event);
+    long memoryFree = future.get();
+    assertEquals(100, memoryFree);
+    assertTrue(taskToSuccessBlockIds.get("taskId").contains(1L));
+    assertTrue(taskToSuccessBlockIds.get("taskId").contains(2L));
+    assertTrue(taskToFailedBlockIds.get("taskId").contains(3L));
+    assertTrue(taskToFailedBlockIds.get("taskId").contains(4L));
+  }
+}

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -70,6 +70,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.common.util.ThreadUtils;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -70,7 +70,6 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
-import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.common.util.ThreadUtils;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -75,7 +75,6 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final boolean shouldPartition;
   private final long sendCheckTimeout;
   private final long sendCheckInterval;
-  private final long sendSizeLimit;
   private final int bitmapSplitNum;
   private final Map<Integer, Set<Long>> partitionToBlockIds;
   private final ShuffleWriteClient shuffleWriteClient;
@@ -137,8 +136,6 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     this.shouldPartition = partitioner.numPartitions() > 1;
     this.sendCheckTimeout = sparkConf.get(RssSparkConfig.RSS_CLIENT_SEND_CHECK_TIMEOUT_MS);
     this.sendCheckInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS);
-    this.sendSizeLimit = sparkConf.getSizeAsBytes(RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMIT.key(),
-        RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMIT.defaultValue().get());
     this.bitmapSplitNum = sparkConf.get(RssSparkConfig.RSS_CLIENT_BITMAP_SPLIT_NUM);
     this.partitionToBlockIds = Maps.newHashMap();
     this.shuffleWriteClient = shuffleWriteClient;
@@ -231,26 +228,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   }
 
   protected void postBlockEvent(List<ShuffleBlockInfo> shuffleBlockInfoList) {
-    long totalSize = 0;
-    List<ShuffleBlockInfo> shuffleBlockInfosPerEvent = Lists.newArrayList();
-    for (ShuffleBlockInfo sbi : shuffleBlockInfoList) {
-      totalSize += sbi.getSize();
-      shuffleBlockInfosPerEvent.add(sbi);
-      // split shuffle data according to the size
-      if (totalSize > sendSizeLimit) {
-        LOG.debug("Post event to queue with " + shuffleBlockInfosPerEvent.size()
-            + " blocks and " + totalSize + " bytes");
-        shuffleManager.postEvent(
-            new AddBlockEvent(taskId, shuffleBlockInfosPerEvent));
-        shuffleBlockInfosPerEvent = Lists.newArrayList();
-        totalSize = 0;
-      }
-    }
-    if (!shuffleBlockInfosPerEvent.isEmpty()) {
-      LOG.debug("Post event to queue with " + shuffleBlockInfosPerEvent.size()
-          + " blocks and " + totalSize + " bytes");
-      shuffleManager.postEvent(
-          new AddBlockEvent(taskId, shuffleBlockInfosPerEvent));
+    for (AddBlockEvent event : bufferManager.buildBlockEvents(shuffleBlockInfoList)) {
+      shuffleManager.sendData(event);
     }
   }
 

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -22,8 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.SparkConf;
-import org.apache.spark.shuffle.writer.AddBlockEvent;
-import org.apache.spark.util.EventLoop;
+import org.apache.spark.shuffle.writer.DataPusher;
 
 public class TestUtils {
 
@@ -33,10 +32,10 @@ public class TestUtils {
   public static RssShuffleManager createShuffleManager(
       SparkConf conf,
       Boolean isDriver,
-      EventLoop<AddBlockEvent> loop,
+      DataPusher dataPusher,
       Map<String, Set<Long>> successBlockIds,
       Map<String, Set<Long>> failBlockIds) {
-    return new RssShuffleManager(conf, isDriver, loop, successBlockIds, failBlockIds);
+    return new RssShuffleManager(conf, isDriver, dataPusher, successBlockIds, failBlockIds);
   }
 
   public static boolean isMacOnAppleSilicon() {

--- a/common/src/main/java/org/apache/uniffle/common/util/ThreadUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/ThreadUtils.java
@@ -22,15 +22,19 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Provide a general method to create a thread factory to make the code more standardized
- */
 public class ThreadUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThreadUtils.class);
 
+  /**
+   * Provide a general method to create a thread factory to make the code more standardized
+   */
   public static ThreadFactory getThreadFactory(String factoryName) {
     return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(factoryName + "-%d").build();
   }
@@ -73,5 +77,18 @@ public class ThreadUtils {
    */
   public static ExecutorService getDaemonCachedThreadPool(String factoryName) {
     return Executors.newCachedThreadPool(getThreadFactory(factoryName));
+  }
+
+  public static void shutdownThreadPool(ExecutorService threadPool, int waitSec) throws InterruptedException {
+    if (threadPool == null) {
+      return;
+    }
+    threadPool.shutdown();
+    if (!threadPool.awaitTermination(waitSec, TimeUnit.SECONDS)) {
+      threadPool.shutdownNow();
+      if (!threadPool.awaitTermination(waitSec, TimeUnit.SECONDS)) {
+        LOGGER.warn("Thread pool don't stop gracefully.");
+      }
+    }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/util/ThreadUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/ThreadUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ThreadUtilsTest {
+
+  @Test
+  public void shutdownThreadPoolTest() throws InterruptedException {
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    AtomicBoolean finished = new AtomicBoolean(false);
+    executorService.submit(() -> {
+      try {
+        Thread.sleep(100000);
+      } catch (InterruptedException interruptedException) {
+        // ignore
+      } finally {
+        finished.set(true);
+      }
+    });
+    ThreadUtils.shutdownThreadPool(executorService, 1);
+    assertTrue(finished.get());
+    assertTrue(executorService.isShutdown());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.  Introduce the `DataPusher` to replace the `eventLoop`, this could be as general part for spark2 and spark3.
2. Implement the `spill` method in `WriterBufferManager` to avoid memory deadlock.

### Why are the changes needed?
In current codebase, if having several `WriterBufferManagers`, when each other is acquiring memory, the deadlock will happen. To solve this, we should implement spill function to break this deadlock condition.

Fix: #706 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
1. Existing UTs
2. Newly added UTs