### PR TITLE
[#674] improvement(server): use ByteString#asReadOnlyByteBuffer to reduce the memory allocation

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -36,7 +36,7 @@ public class ShuffleDataResult {
   }
 
   public ShuffleDataResult(byte[] data, List<BufferSegment> bufferSegments) {
-    this(bufferSegments, ByteBuffer.wrap(data));
+    this(bufferSegments, data == null ? null : ByteBuffer.wrap(data));
   }
 
   public ShuffleDataResult(List<BufferSegment> bufferSegments, ByteBuffer data) {

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -17,13 +17,14 @@
 
 package org.apache.uniffle.common;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 
 public class ShuffleDataResult {
 
-  private final byte[] data;
+  private final ByteBuffer bufferData;
   private final List<BufferSegment> bufferSegments;
 
   public ShuffleDataResult() {
@@ -35,12 +36,16 @@ public class ShuffleDataResult {
   }
 
   public ShuffleDataResult(byte[] data, List<BufferSegment> bufferSegments) {
-    this.data = data;
+    this(bufferSegments, ByteBuffer.wrap(data));
+  }
+
+  public ShuffleDataResult(List<BufferSegment> bufferSegments, ByteBuffer data) {
+    this.bufferData = data;
     this.bufferSegments = bufferSegments;
   }
 
   public byte[] getData() {
-    return data;
+    return bufferData.array();
   }
 
   public List<BufferSegment> getBufferSegments() {
@@ -48,7 +53,9 @@ public class ShuffleDataResult {
   }
 
   public boolean isEmpty() {
-    return bufferSegments == null || bufferSegments.isEmpty() || data == null || data.length == 0;
+    return bufferSegments == null
+        || bufferSegments.isEmpty()
+        || bufferData == null
+        || (bufferData.limit() - bufferData.position() <= 0);
   }
-
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
@@ -56,7 +56,7 @@ public class ShufflePartitionedBlock {
       long blockId,
       long taskAttemptId,
       byte[] data) {
-    this(length, uncompressLength, crc, blockId, ByteBuffer.wrap(data), taskAttemptId);
+    this(length, uncompressLength, crc, blockId, data == null ? null : ByteBuffer.wrap(data), taskAttemptId);
   }
 
   // calculate the data size for this block in memory including metadata which are

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageHdfsFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageHdfsFallbackTest.java
@@ -27,8 +27,6 @@ import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class MultiStorageHdfsFallbackTest extends MultiStorageFaultToleranceBase {
 
   @BeforeAll
@@ -51,8 +49,6 @@ public class MultiStorageHdfsFallbackTest extends MultiStorageFaultToleranceBase
 
   @Override
   public void makeChaos() {
-    assertEquals(1, cluster.getDataNodes().size());
-    cluster.stopDataNode(0);
-    assertEquals(0, cluster.getDataNodes().size());
+    cluster.shutdown();
   }
 }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -65,7 +65,7 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
+    shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
     createShuffleServer(shuffleServerConf);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -65,7 +65,7 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
+    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
     createShuffleServer(shuffleServerConf);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -760,8 +760,9 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
           block.getUncompressLength(),
           block.getCrc(),
           block.getBlockId(),
-          block.getTaskAttemptId(),
-          block.getData().toByteArray());
+          block.getData().asReadOnlyByteBuffer(),
+          block.getTaskAttemptId()
+      );
       i++;
     }
     return ret;

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -113,7 +113,9 @@ public class LocalStorageManager extends SingleStorageManager {
       final int idx = i;
       String storagePath = storageBasePaths.get(i);
       executorService.submit(() -> {
+        LOG.info("Start checking {}", storagePath);
         try {
+          LOG.info("Enter this.");
           StorageMedia storageType = getStorageTypeForBasePath(storagePath);
           localStorageArray[idx] = LocalStorage.newBuilder()
               .basePath(storagePath)
@@ -125,10 +127,12 @@ public class LocalStorageManager extends SingleStorageManager {
               .localStorageMedia(storageType)
               .build();
           successCount.incrementAndGet();
+          LOG.info("Initialized path: {}", storagePath);
         } catch (Exception e) {
           LOG.error("LocalStorage init failed!", e);
         } finally {
           countDownLatch.countDown();
+          LOG.info("Finished. {}", storagePath);
         }
       });
     }
@@ -158,13 +162,13 @@ public class LocalStorageManager extends SingleStorageManager {
   }
 
   private StorageMedia getStorageTypeForBasePath(String basePath) {
-    for (StorageMediaProvider provider : this.typeProviders) {
-      StorageMedia result = provider.getStorageMediaFor(basePath);
-      if (result != StorageMedia.UNKNOWN) {
-        return result;
-      }
-    }
-    return StorageMedia.UNKNOWN;
+//    for (StorageMediaProvider provider : this.typeProviders) {
+//      StorageMedia result = provider.getStorageMediaFor(basePath);
+//      if (result != StorageMedia.UNKNOWN) {
+//        return result;
+//      }
+//    }
+    return StorageMedia.SSD;
   }
 
   @Override

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -162,13 +162,13 @@ public class LocalStorageManager extends SingleStorageManager {
   }
 
   private StorageMedia getStorageTypeForBasePath(String basePath) {
-//    for (StorageMediaProvider provider : this.typeProviders) {
-//      StorageMedia result = provider.getStorageMediaFor(basePath);
-//      if (result != StorageMedia.UNKNOWN) {
-//        return result;
-//      }
-//    }
-    return StorageMedia.SSD;
+    for (StorageMediaProvider provider : this.typeProviders) {
+      StorageMedia result = provider.getStorageMediaFor(basePath);
+      if (result != StorageMedia.UNKNOWN) {
+        return result;
+      }
+    }
+    return StorageMedia.UNKNOWN;
   }
 
   @Override

--- a/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
@@ -24,9 +24,7 @@ import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
 public interface FileWriter {
 
-  void writeData(ByteBuffer data) throws Exception;
-
-  void writeData(byte[] data) throws IOException;
+  void writeData(ByteBuffer data) throws IOException;
 
   void writeIndex(FileBasedShuffleSegment segment) throws IOException;
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
@@ -18,10 +18,13 @@
 package org.apache.uniffle.storage.api;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
 public interface FileWriter {
+
+  void writeData(ByteBuffer data) throws Exception;
 
   void writeData(byte[] data) throws IOException;
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleWriteHandler.java
@@ -117,7 +117,7 @@ public class HdfsShuffleWriteHandler implements ShuffleWriteHandler {
           long blockId = block.getBlockId();
           long crc = block.getCrc();
           long startOffset = dataWriter.nextOffset();
-          dataWriter.writeData(block.getData());
+          dataWriter.writeData(block.getBufferData());
 
           FileBasedShuffleSegment segment = new FileBasedShuffleSegment(
               blockId, startOffset, block.getLength(), block.getUncompressLength(), crc, block.getTaskAttemptId());

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -106,7 +106,7 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
         long blockId = block.getBlockId();
         long crc = block.getCrc();
         long startOffset = dataWriter.nextOffset();
-        dataWriter.writeData(block.getData());
+        dataWriter.writeData(block.getBufferData());
 
         FileBasedShuffleSegment segment = new FileBasedShuffleSegment(
             blockId, startOffset, block.getLength(), block.getUncompressLength(), crc, block.getTaskAttemptId());

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
@@ -45,7 +45,7 @@ public class LocalFileWriter implements FileWriter, Closeable {
   }
 
   @Override
-  public void writeData(ByteBuffer data) throws Exception {
+  public void writeData(ByteBuffer data) throws IOException {
     if (data != null && data.limit() - data.position() > 0) {
       int len = data.limit() - data.position();
       fileChannel.write(data);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
@@ -47,7 +47,7 @@ public class LocalFileWriter implements FileWriter, Closeable {
   @Override
   public void writeData(ByteBuffer data) throws Exception {
     if (data != null && data.limit() - data.position() > 0) {
-      int len = data.limit();
+      int len = data.limit() - data.position();
       fileChannel.write(data);
       nextOffset = nextOffset + len;
     }

--- a/storage/src/test/java/org/apache/uniffle/storage/HdfsShuffleHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HdfsShuffleHandlerTestBase.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.storage;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -88,7 +89,7 @@ public class HdfsShuffleHandlerTestBase {
       offset += spb.getLength();
       segments.add(segment);
       if (doWrite) {
-        writer.writeData(spb.getData());
+        writer.writeData(ByteBuffer.wrap(spb.getData()));
       }
     }
     expectedIndexSegments.put(partitionId, segments);
@@ -97,7 +98,7 @@ public class HdfsShuffleHandlerTestBase {
   public static byte[] writeData(HdfsFileWriter writer, int len) throws IOException {
     byte[] data = new byte[len];
     new Random().nextBytes(data);
-    writer.writeData(data);
+    writer.writeData(ByteBuffer.wrap(data));
     return data;
   }
 

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandlerTest.java
@@ -81,8 +81,8 @@ public class HdfsClientReadHandlerTest extends HdfsTestBase {
        */
       String indexFileName = ShuffleStorageUtils.generateIndexFileName("test_0");
       HdfsFileWriter indexWriter = writeHandler.createWriter(indexFileName);
-      indexWriter.writeData(ByteBuffer.allocate(4).putInt(169560).array());
-      indexWriter.writeData(ByteBuffer.allocate(4).putInt(999).array());
+      indexWriter.writeData(ByteBuffer.allocate(4).putInt(169560));
+      indexWriter.writeData(ByteBuffer.allocate(4).putInt(999));
       indexWriter.close();
 
       Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsFileReaderTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsFileReaderTest.java
@@ -67,7 +67,7 @@ public class HdfsFileReaderTest extends HdfsTestBase {
     long crc11 = ChecksumUtils.getCrc32(ByteBuffer.wrap(data, offset, length));
 
     try (HdfsFileWriter writer = new HdfsFileWriter(fs, path, conf)) {
-      writer.writeData(data);
+      writer.writeData(ByteBuffer.wrap(data));
     }
     FileBasedShuffleSegment segment = new FileBasedShuffleSegment(23, offset, length, length, 0xdeadbeef, 1);
     try (HdfsFileReader reader = new HdfsFileReader(path, conf)) {

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsFileWriterTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsFileWriterTest.java
@@ -54,7 +54,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     Path path = new Path(HDFS_URI, "createStreamAppendTest");
     try (HdfsFileWriter writer = new HdfsFileWriter(fs, path, conf)) {
       assertEquals(0, writer.nextOffset());
-      writer.writeData(data);
+      writer.writeData(ByteBuffer.wrap(data));
       assertEquals(32, writer.nextOffset());
     }
 
@@ -92,7 +92,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     try (HdfsFileWriter writer = new HdfsFileWriter(fs, path, conf)) {
       assertEquals(0, writer.nextOffset());
       buf.flip();
-      writer.writeData(buf.array());
+      writer.writeData(buf);
       assertEquals(32, writer.nextOffset());
     }
   }
@@ -105,7 +105,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     Path path = new Path(HDFS_URI, "writeBufferTest");
     try (HdfsFileWriter writer = new HdfsFileWriter(fs, path, conf)) {
       assertEquals(0, writer.nextOffset());
-      writer.writeData(data);
+      writer.writeData(ByteBuffer.wrap(data));
       assertEquals(32, writer.nextOffset());
     }
 
@@ -130,7 +130,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     Path path = new Path(HDFS_URI, "writeBufferArrayTest");
     try (HdfsFileWriter writer = new HdfsFileWriter(fs, path, conf)) {
       assertEquals(0, writer.nextOffset());
-      writer.writeData(buf.array());
+      writer.writeData(buf);
       assertEquals(20, writer.nextOffset());
     }
 

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.storage.handler.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,13 +111,13 @@ public class LocalFileHandlerTest {
   }
 
   @Test
-  public void writeBigDataTest(@TempDir File tmpDir) throws IOException  {
+  public void writeBigDataTest(@TempDir File tmpDir) throws IOException {
     File writeFile = new File(tmpDir, "writetest");
     LocalFileWriter writer = new LocalFileWriter(writeFile);
     int  size = Integer.MAX_VALUE / 100;
     byte[] data = new byte[size];
     for (int i = 0; i < 200; i++) {
-      writer.writeData(data);
+      writer.writeData(ByteBuffer.wrap(data));
     }
     long totalSize = 200L * size;
     assertEquals(writer.nextOffset(), totalSize);


### PR DESCRIPTION

### What changes were proposed in this pull request?

Use ByteString#asReadOnlyByteBuffer to reduce the memory allocation in GRPC of `sendShuffleData`

### Why are the changes needed?

Fix: #674 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?