### PR TITLE
[MINOR] test: fix tempdir leak in KerberizedHdfs tests

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfs.java
@@ -25,8 +25,6 @@ import java.io.Serializable;
 import java.net.BindException;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,8 +73,7 @@ public class KerberizedHdfs implements Serializable {
 
   private MiniKdc kdc;
   private File workDir;
-  private Path tempDir;
-  private Path kerberizedDfsBaseDir;
+  private File kerberizedDfsBaseDir;
 
   private MiniDFSCluster kerberizedDfsCluster;
 
@@ -91,9 +88,12 @@ public class KerberizedHdfs implements Serializable {
   // krb5.conf file path
   private String krb5ConfFile;
 
+  KerberizedHdfs(File workDir, File kerberizedDfsBaseDir) {
+    this.workDir = workDir;
+    this.kerberizedDfsBaseDir = kerberizedDfsBaseDir;
+  }
+
   protected void setup() throws Exception {
-    tempDir = Files.createTempDirectory("tempDir").toFile().toPath();
-    kerberizedDfsBaseDir = Files.createTempDirectory("kerberizedDfsBaseDir").toFile().toPath();
 
     startKDC();
     try {
@@ -159,7 +159,7 @@ public class KerberizedHdfs implements Serializable {
         CommonConfigurationKeysPublic.HADOOP_SECURITY_IMPERSONATION_PROVIDER_CLASS,
         TestDummyImpersonationProvider.class.getName());
 
-    String keystoresDir = kerberizedDfsBaseDir.toFile().getAbsolutePath();
+    String keystoresDir = kerberizedDfsBaseDir.getAbsolutePath();
     String sslConfDir = KeyStoreTestUtil.getClasspathDir(testRunnerCls);
     KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
 
@@ -222,7 +222,6 @@ public class KerberizedHdfs implements Serializable {
     kdcConf.setProperty(MiniKdc.ORG_DOMAIN, "COM");
     kdcConf.setProperty(MiniKdc.KDC_BIND_ADDRESS, hostName);
     kdcConf.setProperty(MiniKdc.KDC_PORT, "0");
-    workDir = tempDir.toFile();
     kdc = new MiniKdc(kdcConf, workDir);
     kdc.start();
 

--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfsBase.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfsBase.java
@@ -23,6 +23,9 @@ import org.apache.uniffle.common.security.HadoopSecurityContext;
 import org.apache.uniffle.common.security.NoOpSecurityContext;
 import org.apache.uniffle.common.security.SecurityConfig;
 import org.apache.uniffle.common.security.SecurityContextFactory;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -30,8 +33,13 @@ public class KerberizedHdfsBase {
   protected static KerberizedHdfs kerberizedHdfs;
   protected static Class<?> testRunner = KerberizedHdfsBase.class;
 
+  @TempDir
+  private static File workDir;
+  @TempDir
+  private static File kerberizedDfsBaseDir;
+
   public static void init() throws Exception {
-    kerberizedHdfs = new KerberizedHdfs();
+    kerberizedHdfs = new KerberizedHdfs(workDir, kerberizedDfsBaseDir);
     kerberizedHdfs.setTestRunner(testRunner);
     kerberizedHdfs.setup();
   }

--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHdfsBase.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHdfsBase.java
@@ -17,15 +17,15 @@
 
 package org.apache.uniffle.common;
 
+import java.io.File;
+
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.uniffle.common.security.HadoopSecurityContext;
 import org.apache.uniffle.common.security.NoOpSecurityContext;
 import org.apache.uniffle.common.security.SecurityConfig;
 import org.apache.uniffle.common.security.SecurityContextFactory;
-import org.junit.jupiter.api.io.TempDir;
-
-import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Use JUnit 5 managed `@TempDir` in `KerberizedHdfs` test.

### Why are the changes needed?

The tempdir created by `KerberizedHdfs` is leaking.
It may cause test failures in some condition.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Before:

```console
$ mvn test -Dtest=HadoopFilesystemProviderTest
...
$ find . -name 'serverKS.jks'
./common/target/tmp/kerberizedDfsBaseDir1821275617120252168/serverKS.jks
```

After:

```console
$ mvn test -Dtest=HadoopFilesystemProviderTest
...
$ find . -name 'serverKS.jks'
```