### PR TITLE
[MINOR] test: test class name should end with Test

### DIFF
--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerFallbackTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerFallbackTest.java
@@ -34,12 +34,12 @@ import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
-public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
+public class SparkSQLWithDelegationShuffleManagerFallbackTest extends SparkSQLTest {
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     final String candidates = Objects.requireNonNull(
-        SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
+        SparkSQLWithDelegationShuffleManagerTest.class.getClassLoader().getResource("candidates")).getFile();
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setString(
         CoordinatorConf.COORDINATOR_ACCESS_CHECKERS.key(),
@@ -58,6 +58,7 @@ public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
     createShuffleServer(shuffleServerConf);
@@ -67,7 +68,7 @@ public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
 
   @Override
   public void updateRssStorage(SparkConf sparkConf) {
-    sparkConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "test_access_id");
+    sparkConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "wrong_id");
     sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.DelegationRssShuffleManager");
   }
 
@@ -76,4 +77,3 @@ public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
   }
 
 }
-

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerTest.java
@@ -34,12 +34,12 @@ import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
-public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
+public class SparkSQLWithDelegationShuffleManagerTest extends SparkSQLTest {
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     final String candidates = Objects.requireNonNull(
-        SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
+        SparkSQLWithDelegationShuffleManagerTest.class.getClassLoader().getResource("candidates")).getFile();
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setString(
         CoordinatorConf.COORDINATOR_ACCESS_CHECKERS.key(),
@@ -58,7 +58,6 @@ public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
     createShuffleServer(shuffleServerConf);
@@ -68,7 +67,7 @@ public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
 
   @Override
   public void updateRssStorage(SparkConf sparkConf) {
-    sparkConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "wrong_id");
+    sparkConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "test_access_id");
     sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.DelegationRssShuffleManager");
   }
 
@@ -77,3 +76,4 @@ public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
   }
 
 }
+


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Rename some tests:

* SparkSQLWithDelegationShuffleManagerFallback.java => SparkSQLWithDelegationShuffleManagerFallbackTest.java
* SparkSQLWithDelegationShuffleManager.java => SparkSQLWithDelegationShuffleManagerTest.java

### Why are the changes needed?

test class name should end with Test

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.