### PR TITLE
[#625] Package sun.security.krb5 is not visible in Java 11 and 17.

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -56,7 +56,6 @@ public class HadoopSecurityContext implements SecurityContext {
 
     if (StringUtils.isNotEmpty(krb5ConfPath)) {
       System.setProperty(KRB5_CONF_KEY, krb5ConfPath);
-      sun.security.krb5.Config.refresh();
     }
 
     Configuration conf = new Configuration(false);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Try remove `sun.security.krb5.Config.refresh();`

### Why are the changes needed?

`sun.security.krb5` is not visible in Java 11 and 17. We need to compile on JDK11 and JDK17

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test verification.
