### PR TITLE
[MINOR] chore(ci): test compile in java 11 and 17 with source/target version set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -DskipTests
+      maven-args: package -DskipTests -Djava.version=11
       cache-key: package
       java-version: '11'
 
@@ -61,7 +61,7 @@ jobs:
     name: 'compile'
     uses: ./.github/workflows/sequential.yml
     with:
-      maven-args: package -DskipTests
+      maven-args: package -DskipTests -Djava.version=17
       cache-key: package
       java-version: '17'
 

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Bump `maven-shade-plugin` to `3.4.1`.
Test compile with `java.version` set to `11` and `17` in CI.

### Why are the changes needed?

Test build in java 11 and java 17.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.