### PR TITLE
[#729] improvement: use foreach when iterate over Roaring64NavigableMap for better performance

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,10 +155,7 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
 
   private List<Long> getExpectedTaskIds(Roaring64NavigableMap expectTaskIds) {
     List<Long> taskIds = new ArrayList<>();
-    LongIterator iterator = expectTaskIds.getLongIterator();
-    while (iterator.hasNext()) {
-      taskIds.add(iterator.next());
-    }
+    expectTaskIds.forEach(value -> taskIds.add(value));
     return taskIds;
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Queues;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
-import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -441,15 +440,13 @@ public class ShuffleTaskManager {
   // filter the specific partition blockId in the bitmap to the resultBitmap
   protected Roaring64NavigableMap getBlockIdsByPartitionId(Set<Integer> requestPartitions,
       Roaring64NavigableMap bitmap, Roaring64NavigableMap resultBitmap) {
-    LongIterator iter = bitmap.getLongIterator();
-    long mask = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
-    while (iter.hasNext()) {
-      long blockId = iter.next();
+    final long mask = (1L << Constants.PARTITION_ID_MAX_LENGTH) - 1;
+    bitmap.forEach(blockId -> {
       int partitionId = Math.toIntExact((blockId >> Constants.TASK_ATTEMPT_ID_MAX_LENGTH) & mask);
       if (requestPartitions.contains(partitionId)) {
         resultBitmap.addLong(blockId);
       }
-    }
+    });
     return resultBitmap;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

use foreach when iterate over Roaring64NavigableMap for better performance

### Why are the changes needed?

From the doc of https://github.com/RoaringBitmap/RoaringBitmap/issues/44, it will reduce gc footprint and be faster when using the `foreach`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Don't need.