### PR TITLE
[#733] test: fix LocalStorageManagerTest#testGetLocalStorageInfo on Linux SSD platform

### DIFF
--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -244,15 +244,12 @@ public class LocalStorageManagerTest {
       assertNotNull(storageInfo.get(mountPoint));
       // on Linux environment, it can detect SSD as local storage type
       if (SystemUtils.IS_OS_LINUX) {
-        String[] cmd = {
-            "bash", "-c",
-            String.format("%s | %s | %s",
-                "lsblk -a -o name,rota",
-                "grep $(df " + path + " | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')",
-                "awk '{print $2}'"
-            )
-        };
-        Process process = Runtime.getRuntime().exec(cmd);
+        final String cmd = String.format("%s | %s | %s",
+            "lsblk -a -o name,rota",
+            "grep $(df " + path + " | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')",
+            "awk '{print $2}'"
+        );
+        Process process = Runtime.getRuntime().exec(new String[]{"bash", "-c", cmd});
         BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
         final String line = br.readLine();
         br.close();

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -246,14 +246,14 @@ public class LocalStorageManagerTest {
       if (SystemUtils.IS_OS_LINUX) {
         final String cmd = String.format("%s | %s | %s",
             "lsblk -a -o name,rota",
-            "grep $(df " + path + " | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')",
+            "grep $(df --output=source " + path + " | tail -n 1 | sed -E 's_^.+/__')",
             "awk '{print $2}'"
         );
         Process process = Runtime.getRuntime().exec(new String[]{"bash", "-c", cmd});
         BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
         final String line = br.readLine();
         br.close();
-        final StorageMedia expected = line != null && line.equals("0") ? StorageMedia.SSD : StorageMedia.HDD;
+        final StorageMedia expected = "0".equals(line) ? StorageMedia.SSD : StorageMedia.HDD;
         assertEquals(expected, storageInfo.get(mountPoint).getType());
       } else {
         assertEquals(StorageMedia.HDD, storageInfo.get(mountPoint).getType());

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -248,7 +248,7 @@ public class LocalStorageManagerTest {
             "bash", "-c",
             String.format("%s | %s | %s",
                 "lsblk -a -o name,rota",
-                String.format("grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's/^.+\\///')", path),
+                String.format("grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')", path),
                 "awk '{print $2}'"
             )
         };

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -248,7 +248,7 @@ public class LocalStorageManagerTest {
             "bash", "-c",
             String.format("%s | %s | %s",
                 "lsblk -a -o name,rota",
-                String.format("grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')", path),
+                "grep $(df " + path + " | tail -n 1 | awk '{print $1}' | sed -E 's_^.+/__')",
                 "awk '{print $2}'"
             )
         };

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -17,14 +17,17 @@
 
 package org.apache.uniffle.server.storage;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.SystemUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,6 +47,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -236,10 +240,27 @@ public class LocalStorageManagerTest {
     Map<String, StorageInfo> storageInfo = localStorageManager.getStorageInfo();
     assertEquals(1, storageInfo.size());
     try {
-      String mountPoint = Files.getFileStore(new File("/tmp").toPath()).name();
+      final String path = "/tmp";
+      final String mountPoint = Files.getFileStore(new File(path).toPath()).name();
       assertNotNull(storageInfo.get(mountPoint));
-      // by default, it should report HDD as local storage type
-      assertEquals(StorageMedia.HDD, storageInfo.get(mountPoint).getType());
+      // on Linux environment, it can detect SSD as local storage type
+      if (SystemUtils.IS_OS_LINUX) {
+        // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
+        String[] cmd = {
+            "bash",
+            "-c",
+            String.format("lsblk -a -o name,rota | grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's/^.+\\///') | awk '{print $2}'", path)
+        };
+        // CHECKSTYLE.ON: LineLengthExceed
+        Process process = Runtime.getRuntime().exec(cmd);
+        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        final String line = br.readLine();
+        br.close();
+        final StorageMedia expected = line != null && line.equals("0") ? StorageMedia.SSD : StorageMedia.HDD;
+        assertEquals(expected, storageInfo.get(mountPoint).getType());
+      } else {
+        assertEquals(StorageMedia.HDD, storageInfo.get(mountPoint).getType());
+      }
       assertEquals(StorageStatus.NORMAL, storageInfo.get(mountPoint).getStatus());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -47,7 +47,6 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -245,13 +244,14 @@ public class LocalStorageManagerTest {
       assertNotNull(storageInfo.get(mountPoint));
       // on Linux environment, it can detect SSD as local storage type
       if (SystemUtils.IS_OS_LINUX) {
-        // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
         String[] cmd = {
-            "bash",
-            "-c",
-            String.format("lsblk -a -o name,rota | grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's/^.+\\///') | awk '{print $2}'", path)
+            "bash", "-c",
+            String.format("%s | %s | %s",
+                "lsblk -a -o name,rota",
+                String.format("grep $(df %s | tail -n 1 | awk '{print $1}' | sed -E 's/^.+\\///')", path),
+                "awk '{print $2}'"
+            )
         };
-        // CHECKSTYLE.ON: LineLengthExceed
         Process process = Runtime.getRuntime().exec(cmd);
         BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
         final String line = br.readLine();


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Detect SSD on Linux platform, and Assert local storage info accordingly.

### Why are the changes needed?

Fix: #733

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested on Linux+SSD, Linux+HDD, and macOS+SSD.

```console
$ mvn test -Dtest=LocalStorageManagerTest
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.uniffle.server.storage.LocalStorageManagerTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.843 s - in org.apache.uniffle.server.storage.LocalStorageManagerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
...
```