### PR TITLE
[MINOR] test: fix CoordinatorGrpcTest#shuffleServerHeartbeatTest on Linux SSD platform

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
@@ -237,7 +237,9 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
     ServerNode node = nodes.get(0);
     assertEquals(1, node.getStorageInfo().size());
     StorageInfo infoHead = node.getStorageInfo().values().iterator().next();
-    assertEquals(StorageMedia.HDD, infoHead.getType());
+    final StorageInfo expectedStorageInfo = shuffleServers.get(1)
+        .getStorageManager().getStorageInfo().values().iterator().next();
+    assertEquals(expectedStorageInfo, infoHead);
     assertEquals(StorageStatus.NORMAL, infoHead.getStatus());
     assertTrue(node.getTags().contains(Constants.SHUFFLE_SERVER_VERSION));
     assertTrue(scm.getTagToNodes().get(Constants.SHUFFLE_SERVER_VERSION).contains(node));


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix CoordinatorGrpcTest#shuffleServerHeartbeatTest on Linux SSD platform

### Why are the changes needed?

```
[INFO] Results:                                                                                                                     
[INFO]                                                                                                                              
[ERROR] Failures:                                                                                                                   
[ERROR]   CoordinatorGrpcTest.shuffleServerHeartbeatTest:240 expected: <HDD> but was: <SSD>                                         
[ERROR] Errors:                                                                                                                     
[ERROR]   CoordinatorGrpcTest.getShuffleAssignmentsTest:125 » Runtime No shuffle server ...                                         
[ERROR]   CoordinatorGrpcTest.rpcMetricsTest:274 » Runtime No shuffle server connected                                              
[INFO]                                                                                                                              
[ERROR] Tests run: 6, Failures: 1, Errors: 2, Skipped: 0                                                                            
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
[INFO] Running org.apache.uniffle.test.CoordinatorGrpcTest                                                                          
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.622 s - in org.apache.uniffle.test.CoordinatorGrpcTest    
[INFO]                                                                                                                              
[INFO] Results:                                                                                                                     
[INFO]                                                                                                                              
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0                                                                             
[INFO] 
```