### PR TITLE
[#669] improvement: refresh application when reading memory data

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -434,7 +434,6 @@ public class QuorumTest extends ShuffleReadWriteBase {
       Sets.newHashSet(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2),
       testAppId, 0, 0);
     assertEquals(report, blockIdBitmap);
-    shuffleServers.get(1).start();
   }
 
   @Test

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -434,6 +434,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
       Sets.newHashSet(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2),
       testAppId, 0, 0);
     assertEquals(report, blockIdBitmap);
+    shuffleServers.get(1).start();
   }
 
   @Test

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -453,6 +453,7 @@ public class ShuffleTaskManager {
   public ShuffleDataResult getInMemoryShuffleData(
       String appId, Integer shuffleId, Integer partitionId, long blockId, int readBufferSize,
       Roaring64NavigableMap expectedTaskIds) {
+    refreshAppId(appId);
     return shuffleBufferManager.getShuffleData(appId,
         shuffleId, partitionId, blockId, readBufferSize, expectedTaskIds);
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Refresh application when reading memory data.

### Why are the changes needed?

In the current logic, application will not be refreshed when reading memory data. In this case, If timeout occurs when spark driver sends heartbeat to shuffle server, the application will be expired.

Fix: #669 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need,
