### PR TITLE
[MINOR] test: do not wrap test in try-catch block

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/util/ExitUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/ExitUtilsTest.java
@@ -27,28 +27,22 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ExitUtilsTest {
 
   @Test
-  public void test() {
+  public void test() throws Exception {
+    final int status = -1;
+    final String testExitMessage = "testExitMessage";
     try {
-      final int status = -1;
-      final String testExitMessage = "testExitMessage";
-      try {
-        ExitUtils.disableSystemExit();
-        ExitUtils.terminate(status, testExitMessage, null, null);
-        fail();
-      } catch (ExitException e) {
-        assertEquals(status, e.getStatus());
-        assertEquals(testExitMessage, e.getMessage());
-      }
-
-      final Thread t = new Thread(null, () -> {
-        throw new AssertionError("TestUncaughtException");
-      }, "testThread");
-      t.start();
-      t.join();
-    } catch (Exception e) {
-      e.printStackTrace();
+      ExitUtils.disableSystemExit();
+      ExitUtils.terminate(status, testExitMessage, null, null);
       fail();
+    } catch (ExitException e) {
+      assertEquals(status, e.getStatus());
+      assertEquals(testExitMessage, e.getMessage());
     }
 
+    final Thread t = new Thread(null, () -> {
+      throw new AssertionError("TestUncaughtException");
+    }, "testThread");
+    t.start();
+    t.join();
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/web/JettyServerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/web/JettyServerTest.java
@@ -32,7 +32,6 @@ import org.apache.uniffle.common.util.ExitUtils.ExitException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class JettyServerTest {
 
@@ -60,33 +59,27 @@ public class JettyServerTest {
 
   @Test
   public void jettyServerStartTest() throws Exception {
+    RssBaseConf conf = new RssBaseConf();
+    conf.setString("rss.jetty.http.port", "9527");
+    JettyServer jettyServer1 = new JettyServer(conf);
+    JettyServer jettyServer2 = new JettyServer(conf);
+    jettyServer1.start();
+
+    ExitUtils.disableSystemExit();
+    final String expectMessage = "Fail to start jetty http server";
+    final int expectStatus = 1;
     try {
-      RssBaseConf conf = new RssBaseConf();
-      conf.setString("rss.jetty.http.port", "9527");
-      JettyServer jettyServer1 = new JettyServer(conf);
-      JettyServer jettyServer2 = new JettyServer(conf);
-      jettyServer1.start();
-
-      ExitUtils.disableSystemExit();
-      final String expectMessage = "Fail to start jetty http server";
-      final int expectStatus = 1;
-      try {
-        jettyServer2.start();
-      } catch (Exception e) {
-        assertEquals(expectMessage, e.getMessage());
-        assertEquals(expectStatus, ((ExitException) e).getStatus());
-      }
-
-      final Thread t = new Thread(null, () -> {
-        throw new AssertionError("TestUncaughtException");
-      }, "testThread");
-      t.start();
-      t.join();
+      jettyServer2.start();
     } catch (Exception e) {
-      e.printStackTrace();
-      fail();
+      assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
 
+    final Thread t = new Thread(null, () -> {
+      throw new AssertionError("TestUncaughtException");
+    }, "testThread");
+    t.start();
+    t.join();
   }
 
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
@@ -23,54 +23,45 @@ import org.apache.uniffle.common.util.ExitUtils;
 import org.apache.uniffle.common.util.ExitUtils.ExitException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class CoordinatorServerTest {
 
   @Test
-  public void test() {
+  public void test() throws Exception {
+    CoordinatorConf coordinatorConf = new CoordinatorConf();
+    coordinatorConf.setInteger("rss.rpc.server.port", 9537);
+    coordinatorConf.setInteger("rss.jetty.http.port", 9528);
+    coordinatorConf.setInteger("rss.rpc.executor.size", 10);
+
+    CoordinatorServer cs1 = new CoordinatorServer(coordinatorConf);
+    CoordinatorServer cs2 = new CoordinatorServer(coordinatorConf);
+    cs1.start();
+
+    ExitUtils.disableSystemExit();
+    String expectMessage = "Fail to start jetty http server";
+    final int expectStatus = 1;
     try {
-      CoordinatorConf coordinatorConf = new CoordinatorConf();
-      coordinatorConf.setInteger("rss.rpc.server.port", 9537);
-      coordinatorConf.setInteger("rss.jetty.http.port", 9528);
-      coordinatorConf.setInteger("rss.rpc.executor.size", 10);
-
-      CoordinatorServer cs1 = new CoordinatorServer(coordinatorConf);
-      CoordinatorServer cs2 = new CoordinatorServer(coordinatorConf);
-      cs1.start();
-
-      ExitUtils.disableSystemExit();
-      String expectMessage = "Fail to start jetty http server";
-      final int expectStatus = 1;
-      try {
-        cs2.start();
-      } catch (Exception e) {
-        assertEquals(expectMessage, e.getMessage());
-        assertEquals(expectStatus, ((ExitException) e).getStatus());
-      }
-
-      coordinatorConf.setInteger("rss.jetty.http.port", 9529);
-      cs2 = new CoordinatorServer(coordinatorConf);
-      expectMessage = "Fail to start grpc server";
-      try {
-        cs2.start();
-      } catch (Exception e) {
-        assertEquals(expectMessage, e.getMessage());
-        assertEquals(expectStatus, ((ExitException) e).getStatus());
-      }
-
-      final Thread t = new Thread(null, () -> {
-        throw new AssertionError("TestUncaughtException");
-      }, "testThread");
-      t.start();
-      t.join();
-
-
-
+      cs2.start();
     } catch (Exception e) {
-      e.printStackTrace();
-      fail();
+      assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
+
+    coordinatorConf.setInteger("rss.jetty.http.port", 9529);
+    cs2 = new CoordinatorServer(coordinatorConf);
+    expectMessage = "Fail to start grpc server";
+    try {
+      cs2.start();
+    } catch (Exception e) {
+      assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectStatus, ((ExitException) e).getStatus());
+    }
+
+    final Thread t = new Thread(null, () -> {
+      throw new AssertionError("TestUncaughtException");
+    }, "testThread");
+    t.start();
+    t.join();
   }
 
 }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
@@ -45,43 +45,37 @@ public class ShuffleServerTest {
   private File tempDir;
 
   @Test
-  public void startTest() {
+  public void startTest() throws Exception {
+    ShuffleServerConf serverConf = createShuffleServerConf();
+    ShuffleServer ss1 = new ShuffleServer(serverConf);
+    ss1.start();
+    ExitUtils.disableSystemExit();
+    ShuffleServer ss2 = new ShuffleServer(serverConf);
+    String expectMessage = "Fail to start jetty http server";
+    final int expectStatus = 1;
     try {
-      ShuffleServerConf serverConf = createShuffleServerConf();
-      ShuffleServer ss1 = new ShuffleServer(serverConf);
-      ss1.start();
-      ExitUtils.disableSystemExit();
-      ShuffleServer ss2 = new ShuffleServer(serverConf);
-      String expectMessage = "Fail to start jetty http server";
-      final int expectStatus = 1;
-      try {
-        ss2.start();
-      } catch (Exception e) {
-        assertEquals(expectMessage, e.getMessage());
-        assertEquals(expectStatus, ((ExitException) e).getStatus());
-      }
-
-      serverConf.setInteger("rss.jetty.http.port", 9529);
-      ss2 = new ShuffleServer(serverConf);
-      expectMessage = "Fail to start grpc server";
-      try {
-        ss2.start();
-      } catch (Exception e) {
-        assertEquals(expectMessage, e.getMessage());
-        assertEquals(expectStatus, ((ExitException) e).getStatus());
-      }
-      ss1.stopServer();
-
-      final Thread t = new Thread(null, () -> {
-        throw new AssertionError("TestUncaughtException");
-      }, "testThread");
-      t.start();
-      t.join();
+      ss2.start();
     } catch (Exception e) {
-      e.printStackTrace();
-      fail();
+      assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
 
+    serverConf.setInteger("rss.jetty.http.port", 9529);
+    ss2 = new ShuffleServer(serverConf);
+    expectMessage = "Fail to start grpc server";
+    try {
+      ss2.start();
+    } catch (Exception e) {
+      assertEquals(expectMessage, e.getMessage());
+      assertEquals(expectStatus, ((ExitException) e).getStatus());
+    }
+    ss1.stopServer();
+
+    final Thread t = new Thread(null, () -> {
+      throw new AssertionError("TestUncaughtException");
+    }, "testThread");
+    t.start();
+    t.join();
   }
 
   @ParameterizedTest

--- a/storage/src/test/java/org/apache/uniffle/storage/common/ShuffleFileInfoTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/ShuffleFileInfoTest.java
@@ -23,26 +23,20 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleFileInfoTest {
 
   @Test
-  public void test() {
-    try {
-      ShuffleFileInfo shuffleFileInfo = new ShuffleFileInfo();
-      shuffleFileInfo.getDataFiles().add(File.createTempFile("dummy-data-file", ".data"));
-      shuffleFileInfo.setKey("key");
-      assertFalse(shuffleFileInfo.isValid());
+  public void test() throws Exception {
+    ShuffleFileInfo shuffleFileInfo = new ShuffleFileInfo();
+    shuffleFileInfo.getDataFiles().add(File.createTempFile("dummy-data-file", ".data"));
+    shuffleFileInfo.setKey("key");
+    assertFalse(shuffleFileInfo.isValid());
 
-      shuffleFileInfo.getIndexFiles().add(File.createTempFile("dummy-data-file", ".index"));
-      shuffleFileInfo.getPartitions().add(12);
-      shuffleFileInfo.setSize(1024 * 1024 * 32);
-      assertTrue(shuffleFileInfo.isValid());
-      assertFalse(shuffleFileInfo.shouldCombine(32));
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
+    shuffleFileInfo.getIndexFiles().add(File.createTempFile("dummy-data-file", ".index"));
+    shuffleFileInfo.getPartitions().add(12);
+    shuffleFileInfo.setSize(1024 * 1024 * 32);
+    assertTrue(shuffleFileInfo.isValid());
+    assertFalse(shuffleFileInfo.shouldCombine(32));
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HdfsClientReadHandlerTest.java
@@ -45,100 +45,96 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class HdfsClientReadHandlerTest extends HdfsTestBase {
 
-  public static void createAndRunCases(String clusterPathPrefix, Configuration hadoopConf, String writeUser) {
-    try {
-      String basePath = clusterPathPrefix + "clientReadTest1";
-      HdfsShuffleWriteHandler writeHandler =
-          new HdfsShuffleWriteHandler(
-              "appId",
-              0,
-              1,
-              1,
-              basePath,
-              "test",
-              hadoopConf,
-              writeUser);
+  public static void createAndRunCases(String clusterPathPrefix, Configuration hadoopConf, String writeUser)
+      throws Exception {
+    String basePath = clusterPathPrefix + "clientReadTest1";
+    HdfsShuffleWriteHandler writeHandler =
+        new HdfsShuffleWriteHandler(
+            "appId",
+            0,
+            1,
+            1,
+            basePath,
+            "test",
+            hadoopConf,
+            writeUser);
 
-      Map<Long, byte[]> expectedData = Maps.newHashMap();
-      Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
 
-      int readBufferSize = 13;
-      int total = 0;
-      int totalBlockNum = 0;
-      int expectTotalBlockNum = 0;
+    int readBufferSize = 13;
+    int total = 0;
+    int totalBlockNum = 0;
+    int expectTotalBlockNum = 0;
 
-      for (int i = 0; i < 5; i++) {
-        writeHandler.setFailTimes(i);
-        int num = new Random().nextInt(17);
-        writeTestData(writeHandler,  num, 3, 0, expectedData);
-        total += calcExpectedSegmentNum(num, 3, readBufferSize);
-        expectTotalBlockNum += num;
-        expectedData.forEach((id, block) -> expectBlockIds.addLong(id));
-      }
-
-      /**
-       * This part is to check the fault tolerance of reading HDFS incomplete index file
-       */
-      String indexFileName = ShuffleStorageUtils.generateIndexFileName("test_0");
-      HdfsFileWriter indexWriter = writeHandler.createWriter(indexFileName);
-      indexWriter.writeData(ByteBuffer.allocate(4).putInt(169560).array());
-      indexWriter.writeData(ByteBuffer.allocate(4).putInt(999).array());
-      indexWriter.close();
-
-      Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
-
-      HdfsShuffleReadHandler indexReader = new HdfsShuffleReadHandler(
-          "appId", 0, 1, basePath + "/appId/0/1-1/test_0",
-          readBufferSize, expectBlockIds, processBlockIds, hadoopConf);
-      try {
-        ShuffleIndexResult indexResult = indexReader.readShuffleIndex();
-        assertEquals(0, indexResult.getIndexData().length % FileBasedShuffleSegment.SEGMENT_SIZE);
-      } catch (Exception e) {
-        fail();
-      }
-
-      HdfsClientReadHandler handler = new HdfsClientReadHandler(
-          "appId",
-          0,
-          1,
-          1024 * 10214,
-          1,
-          10,
-          readBufferSize,
-          expectBlockIds,
-          processBlockIds,
-          basePath,
-          hadoopConf);
-      Set<Long> actualBlockIds = Sets.newHashSet();
-
-      for (int i = 0; i < total; ++i) {
-        ShuffleDataResult shuffleDataResult = handler.readShuffleData();
-        totalBlockNum += shuffleDataResult.getBufferSegments().size();
-        checkData(shuffleDataResult, expectedData);
-        for (BufferSegment bufferSegment : shuffleDataResult.getBufferSegments()) {
-          actualBlockIds.add(bufferSegment.getBlockId());
-        }
-      }
-
-      assertTrue(handler.readShuffleData().isEmpty());
-      assertEquals(
-          total,
-          handler.getHdfsShuffleFileReadHandlers()
-              .stream()
-              .mapToInt(i -> i.getShuffleDataSegments().size())
-              .sum());
-      assertEquals(expectTotalBlockNum, totalBlockNum);
-      assertEquals(expectedData.keySet(), actualBlockIds);
-      assertEquals(5, handler.getReadHandlerIndex());
-      handler.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+    for (int i = 0; i < 5; i++) {
+      writeHandler.setFailTimes(i);
+      int num = new Random().nextInt(17);
+      writeTestData(writeHandler,  num, 3, 0, expectedData);
+      total += calcExpectedSegmentNum(num, 3, readBufferSize);
+      expectTotalBlockNum += num;
+      expectedData.forEach((id, block) -> expectBlockIds.addLong(id));
     }
+
+    /**
+     * This part is to check the fault tolerance of reading HDFS incomplete index file
+     */
+    String indexFileName = ShuffleStorageUtils.generateIndexFileName("test_0");
+    HdfsFileWriter indexWriter = writeHandler.createWriter(indexFileName);
+    indexWriter.writeData(ByteBuffer.allocate(4).putInt(169560).array());
+    indexWriter.writeData(ByteBuffer.allocate(4).putInt(999).array());
+    indexWriter.close();
+
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
+
+    HdfsShuffleReadHandler indexReader = new HdfsShuffleReadHandler(
+        "appId", 0, 1, basePath + "/appId/0/1-1/test_0",
+        readBufferSize, expectBlockIds, processBlockIds, hadoopConf);
+    try {
+      ShuffleIndexResult indexResult = indexReader.readShuffleIndex();
+      assertEquals(0, indexResult.getIndexData().length % FileBasedShuffleSegment.SEGMENT_SIZE);
+    } catch (Exception e) {
+      fail();
+    }
+
+    HdfsClientReadHandler handler = new HdfsClientReadHandler(
+        "appId",
+        0,
+        1,
+        1024 * 10214,
+        1,
+        10,
+        readBufferSize,
+        expectBlockIds,
+        processBlockIds,
+        basePath,
+        hadoopConf);
+    Set<Long> actualBlockIds = Sets.newHashSet();
+
+    for (int i = 0; i < total; ++i) {
+      ShuffleDataResult shuffleDataResult = handler.readShuffleData();
+      totalBlockNum += shuffleDataResult.getBufferSegments().size();
+      checkData(shuffleDataResult, expectedData);
+      for (BufferSegment bufferSegment : shuffleDataResult.getBufferSegments()) {
+        actualBlockIds.add(bufferSegment.getBlockId());
+      }
+    }
+
+    assertTrue(handler.readShuffleData().isEmpty());
+    assertEquals(
+        total,
+        handler.getHdfsShuffleFileReadHandlers()
+            .stream()
+            .mapToInt(i -> i.getShuffleDataSegments().size())
+            .sum());
+    assertEquals(expectTotalBlockNum, totalBlockNum);
+    assertEquals(expectedData.keySet(), actualBlockIds);
+    assertEquals(5, handler.getReadHandlerIndex());
+    handler.close();
   }
 
   @Test
-  public void test() {
+  public void test() throws Exception {
     createAndRunCases(HDFS_URI, conf, StringUtils.EMPTY);
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/KerberizedHdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/KerberizedHdfsClientReadHandlerTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.uniffle.storage.handler.impl;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ public class KerberizedHdfsClientReadHandlerTest extends KerberizedHdfsBase {
   }
 
   @Test
-  public void test() throws IOException {
+  public void test() throws Exception {
     HdfsClientReadHandlerTest.createAndRunCases(
         kerberizedHdfs.getSchemeAndAuthorityPrefix(),
         kerberizedHdfs.getConf(),

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/KerberizedHdfsShuffleReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/KerberizedHdfsShuffleReadHandlerTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.uniffle.storage.handler.impl;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ public class KerberizedHdfsShuffleReadHandlerTest extends KerberizedHdfsBase {
   }
 
   @Test
-  public void test() throws IOException {
+  public void test() throws Exception {
     HdfsShuffleReadHandlerTest.createAndRunCases(
         kerberizedHdfs.getSchemeAndAuthorityPrefix(),
         kerberizedHdfs.getConf(),


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Extract test from unnecessary `try-catch` blocks:

```java
@Test
public void test() throws Exception {
  try {
    // test
  } catch (Exception e) {
    e.printStackTrace();
    fail();
  }
}
```

### Why are the changes needed?

It's unnecessary to wrap tests in `try-catch` block.
And it's hard to see outputs of `e.printStackTrace()` in CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI.