### PR TITLE
[#731] Make blockId layout configured by client side

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
@@ -17,9 +17,14 @@
 
 package org.apache.hadoop.mapreduce;
 
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.util.IdHelper;
 
-public class MRIdHelper implements IdHelper {
+public class MRIdHelper extends IdHelper {
+
+  public MRIdHelper(BlockIdLayoutConfig config) {
+    super(config);
+  }
 
   @Override
   public long getTaskAttemptId(long blockId) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -208,7 +208,7 @@ public class RssMRUtils {
   }
 
   public static long getTaskAttemptId(BlockIdLayoutConfig config, long blockId) {
-    long maxTaskAttemptId = (1 << config.getTaskAttemptIdLength() ) - 1;
+    long maxTaskAttemptId = (1 << config.getTaskAttemptIdLength()) - 1;
     long mapId = blockId & maxTaskAttemptId;
     long attemptId = (blockId >> (config.getTaskAttemptIdLength() + config.getPartitionIdLength()))
         & MAX_ATTEMPT_ID;

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -73,6 +73,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -228,7 +229,8 @@ public class RssMRAppMaster extends MRAppMaster {
               0,
               entry.getValue(),
               remoteStorage,
-              ShuffleDataDistributionType.NORMAL
+              ShuffleDataDistributionType.NORMAL,
+              BlockIdLayoutConfig.from(RssMRConfig.toRssConf(conf))
           ));
           LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
           return shuffleAssignments;

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -34,6 +34,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -296,13 +297,10 @@ public class SortWriteBufferManagerTest {
     }
 
     @Override
-    public void registerShuffle(
-        ShuffleServerInfo shuffleServerInfo,
-        String appId,
-        int shuffleId,
-        List<PartitionRange> partitionRanges,
-        RemoteStorageInfo remoteStorage,
-        ShuffleDataDistributionType distributionType) {
+    public void registerShuffle(ShuffleServerInfo shuffleServerInfo, String appId, int shuffleId,
+        List<PartitionRange> partitionRanges, RemoteStorageInfo remoteStorage,
+        ShuffleDataDistributionType dataDistributionType, BlockIdLayoutConfig blockIdLayoutConfig) {
+
     }
 
     @Override

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -79,6 +79,20 @@ public class RssMRUtilsTest {
   }
 
   @Test
+  public void test1() {
+    int a = 3;
+    System.out.println(a << 2);
+
+    int i = 1;
+    System.out.println(i << 2);
+    int j = (i << 4) + 2;
+    System.out.println(j);
+    int mask = (1 << 4) - 1;
+    System.out.println(mask);
+    System.out.println(j & mask);
+  }
+
+  @Test
   public void partitionIdConvertBlockTest() {
     JobID jobID =  new JobID();
     TaskID taskId =  new TaskID(jobID, TaskType.MAP, 233);

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -79,20 +79,6 @@ public class RssMRUtilsTest {
   }
 
   @Test
-  public void test1() {
-    int a = 3;
-    System.out.println(a << 2);
-
-    int i = 1;
-    System.out.println(i << 2);
-    int j = (i << 4) + 2;
-    System.out.println(j);
-    int mask = (1 << 4) - 1;
-    System.out.println(mask);
-    System.out.println(j & mask);
-  }
-
-  @Test
   public void partitionIdConvertBlockTest() {
     JobID jobID =  new JobID();
     TaskID taskId =  new TaskID(jobID, TaskType.MAP, 233);

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -64,6 +64,7 @@ import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -382,13 +383,9 @@ public class FetcherTest {
     }
 
     @Override
-    public void registerShuffle(
-        ShuffleServerInfo shuffleServerInfo,
-        String appId,
-        int shuffleId,
-        List<PartitionRange> partitionRanges,
-        RemoteStorageInfo storageType,
-        ShuffleDataDistributionType distributionType) {
+    public void registerShuffle(ShuffleServerInfo shuffleServerInfo, String appId, int shuffleId,
+        List<PartitionRange> partitionRanges, RemoteStorageInfo remoteStorage,
+        ShuffleDataDistributionType dataDistributionType, BlockIdLayoutConfig blockIdLayoutConfig) {
 
     }
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -58,6 +58,7 @@ import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -88,6 +89,7 @@ public class RssShuffleManager implements ShuffleManager {
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
+  private final BlockIdLayoutConfig blockIdLayoutConfig;
   private Set<String> failedTaskIds = Sets.newConcurrentHashSet();
   private boolean heartbeatStarted = false;
   private boolean dynamicConfEnabled = false;
@@ -159,6 +161,7 @@ public class RssShuffleManager implements ShuffleManager {
     this.dataReplicaRead = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_READ);
     this.dataTransferPoolSize = sparkConf.get(RssSparkConfig.RSS_DATA_TRANSFER_POOL_SIZE);
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
+    this.blockIdLayoutConfig = BlockIdLayoutConfig.from(RssSparkConfig.toRssConf(sparkConf));
     LOG.info("Check quorum config ["
         + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
@@ -332,7 +335,8 @@ public class RssShuffleManager implements ShuffleManager {
               shuffleId,
               entry.getValue(),
               remoteStorage,
-              ShuffleDataDistributionType.NORMAL
+              ShuffleDataDistributionType.NORMAL,
+              blockIdLayoutConfig
           );
         });
     LOG.info("Finish register shuffleId[" + shuffleId + "] with " + (System.currentTimeMillis() - start) + " ms");

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -45,6 +45,8 @@ import scala.runtime.BoxedUnit;
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.request.CreateShuffleReadClientRequest;
+import org.apache.uniffle.client.util.DefaultIdHelper;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssConf;
 
@@ -118,7 +120,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     CreateShuffleReadClientRequest request = new CreateShuffleReadClientRequest(
         appId, shuffleId, startPartition, storageType, basePath, indexReadLimit, readBufferSize,
         partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap,
-        shuffleServerInfoList, hadoopConf, expectedTaskIdsBitmapFilterEnable);
+        shuffleServerInfoList, hadoopConf, new DefaultIdHelper(BlockIdLayoutConfig.from(rssConf)),
+        expectedTaskIdsBitmapFilterEnable);
     ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
     RssShuffleDataIterator rssShuffleDataIterator = new RssShuffleDataIterator<K, C>(
         shuffleDependency.serializer(), shuffleReadClient,

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -49,6 +49,8 @@ import scala.runtime.BoxedUnit;
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.request.CreateShuffleReadClientRequest;
+import org.apache.uniffle.client.util.DefaultIdHelper;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssConf;
@@ -210,7 +212,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
         CreateShuffleReadClientRequest request = new CreateShuffleReadClientRequest(
             appId, shuffleId, partition, storageType, basePath, indexReadLimit, readBufferSize,
             1, partitionNum, partitionToExpectBlocks.get(partition), taskIdBitmap, shuffleServerInfoList,
-            hadoopConf, dataDistributionType, expectedTaskIdsBitmapFilterEnable);
+            hadoopConf, dataDistributionType, expectedTaskIdsBitmapFilterEnable,
+            new DefaultIdHelper(BlockIdLayoutConfig.from(rssConf)));
         ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
         RssShuffleDataIterator<K, C> iterator = new RssShuffleDataIterator<>(
             shuffleDependency.serializer(), shuffleReadClient,

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.response.SendShuffleDataResult;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -47,7 +48,8 @@ public interface ShuffleWriteClient {
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorage,
-      ShuffleDataDistributionType dataDistributionType);
+      ShuffleDataDistributionType dataDistributionType,
+      BlockIdLayoutConfig blockIdLayoutConfig);
 
   boolean sendCommit(Set<ShuffleServerInfo> shuffleServerInfoSet, String appId, int shuffleId, int numMaps);
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -409,15 +409,15 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorage,
       ShuffleDataDistributionType dataDistributionType) {
-      this.registerShuffle(
-          shuffleServerInfo,
-          appId,
-          shuffleId,
-          partitionRanges,
-          remoteStorage,
-          dataDistributionType,
-          BlockIdLayoutConfig.from()
-      );
+    this.registerShuffle(
+        shuffleServerInfo,
+        appId,
+        shuffleId,
+        partitionRanges,
+        remoteStorage,
+        dataDistributionType,
+        BlockIdLayoutConfig.from()
+    );
   }
 
   @Override

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -401,6 +401,25 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     return successfulCommit.get() == shuffleServerInfoSet.size();
   }
 
+  @VisibleForTesting
+  public void registerShuffle(
+      ShuffleServerInfo shuffleServerInfo,
+      String appId,
+      int shuffleId,
+      List<PartitionRange> partitionRanges,
+      RemoteStorageInfo remoteStorage,
+      ShuffleDataDistributionType dataDistributionType) {
+      this.registerShuffle(
+          shuffleServerInfo,
+          appId,
+          shuffleId,
+          partitionRanges,
+          remoteStorage,
+          dataDistributionType,
+          BlockIdLayoutConfig.from()
+      );
+  }
+
   @Override
   public void registerShuffle(
       ShuffleServerInfo shuffleServerInfo,

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -77,6 +77,7 @@ import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -407,7 +408,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       int shuffleId,
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorage,
-      ShuffleDataDistributionType dataDistributionType) {
+      ShuffleDataDistributionType dataDistributionType,
+      BlockIdLayoutConfig blockIdLayoutConfig) {
     String user = null;
     try {
       user = UserGroupInformation.getCurrentUser().getShortUserName();
@@ -417,7 +419,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     LOG.info("User: {}", user);
 
     RssRegisterShuffleRequest request =
-        new RssRegisterShuffleRequest(appId, shuffleId, partitionRanges, remoteStorage, user, dataDistributionType);
+        new RssRegisterShuffleRequest(
+            appId, shuffleId, partitionRanges, remoteStorage,
+            user, dataDistributionType, blockIdLayoutConfig
+        );
     RssRegisterShuffleResponse response = getShuffleServerClient(shuffleServerInfo).registerShuffle(request);
 
     String msg = "Error happened when registerShuffle with appId[" + appId + "], shuffleId[" + shuffleId

--- a/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
@@ -61,10 +61,10 @@ public class CreateShuffleReadClientRequest {
       List<ShuffleServerInfo> shuffleServerInfoList,
       Configuration hadoopConf,
       ShuffleDataDistributionType dataDistributionType,
-      boolean expectedTaskIdsBitmapFilterEnable) {
+      boolean expectedTaskIdsBitmapFilterEnable, IdHelper idHelper) {
     this(appId, shuffleId, partitionId, storageType, basePath, indexReadLimit, readBufferSize,
         partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
-        hadoopConf, new DefaultIdHelper(), expectedTaskIdsBitmapFilterEnable);
+        hadoopConf, idHelper, expectedTaskIdsBitmapFilterEnable);
     this.shuffleDataDistributionType = dataDistributionType;
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/org/apache/uniffle/client/request/CreateShuffleReadClientRequest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.IdHelper;
@@ -66,26 +65,6 @@ public class CreateShuffleReadClientRequest {
         partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
         hadoopConf, idHelper, expectedTaskIdsBitmapFilterEnable);
     this.shuffleDataDistributionType = dataDistributionType;
-  }
-
-  public CreateShuffleReadClientRequest(
-      String appId,
-      int shuffleId,
-      int partitionId,
-      String storageType,
-      String basePath,
-      int indexReadLimit,
-      int readBufferSize,
-      int partitionNumPerRange,
-      int partitionNum,
-      Roaring64NavigableMap blockIdBitmap,
-      Roaring64NavigableMap taskIdBitmap,
-      List<ShuffleServerInfo> shuffleServerInfoList,
-      Configuration hadoopConf,
-      boolean expectedTaskIdsBitmapFilterEnable) {
-    this(appId, shuffleId, partitionId, storageType, basePath, indexReadLimit, readBufferSize,
-        partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
-        hadoopConf, new DefaultIdHelper(), expectedTaskIdsBitmapFilterEnable);
   }
 
   public CreateShuffleReadClientRequest(

--- a/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
@@ -27,32 +27,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
-import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.storage.util.StorageType;
 
 public class ClientUtils {
 
-  // BlockId is long and composed of partitionId, executorId and AtomicInteger.
-  // AtomicInteger is first 19 bit, max value is 2^19 - 1
-  // partitionId is next 24 bit, max value is 2^24 - 1
-  // taskAttemptId is rest of 20 bit, max value is 2^20 - 1
+  // Only for tests.
   public static Long getBlockId(long partitionId, long taskAttemptId, long atomicInt) {
-    if (atomicInt < 0 || atomicInt > Constants.MAX_SEQUENCE_NO) {
-      throw new IllegalArgumentException("Can't support sequence[" + atomicInt
-          + "], the max value should be " + Constants.MAX_SEQUENCE_NO);
-    }
-    if (partitionId < 0 || partitionId > Constants.MAX_PARTITION_ID) {
-      throw new IllegalArgumentException("Can't support partitionId["
-          + partitionId + "], the max value should be " + Constants.MAX_PARTITION_ID);
-    }
-    if (taskAttemptId < 0 || taskAttemptId > Constants.MAX_TASK_ATTEMPT_ID) {
-      throw new IllegalArgumentException("Can't support taskAttemptId["
-          + taskAttemptId + "], the max value should be " + Constants.MAX_TASK_ATTEMPT_ID);
-    }
-    return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
-        + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) + taskAttemptId;
+    BlockIdLayoutConfig blockIdLayoutConfig = BlockIdLayoutConfig.from();
+    return BlockIdLayoutConfig.createBlockId(
+        blockIdLayoutConfig,
+        partitionId,
+        taskAttemptId,
+        atomicInt
+    );
   }
 
   public static RemoteStorageInfo fetchRemoteStorage(

--- a/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
@@ -17,10 +17,16 @@
 
 package org.apache.uniffle.client.util;
 
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.IdHelper;
 
-public class DefaultIdHelper implements IdHelper {
+public class DefaultIdHelper extends IdHelper {
+
+  public DefaultIdHelper(BlockIdLayoutConfig config) {
+    super(config);
+  }
+
   @Override
   public long getTaskAttemptId(long blockId) {
     return blockId & Constants.MAX_TASK_ATTEMPT_ID;

--- a/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
@@ -35,6 +35,6 @@ public class DefaultIdHelper extends IdHelper {
 
   @Override
   public long getTaskAttemptId(long blockId) {
-    return blockId & ((1 << blockIdLayoutConfig.getTaskAttemptIdLength()) - 1);
+    return blockId & ((1 << getBlockIdLayoutConfig().getTaskAttemptIdLength()) - 1);
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
@@ -20,7 +20,6 @@ package org.apache.uniffle.client.util;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.uniffle.common.BlockIdLayoutConfig;
-import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.IdHelper;
 
 public class DefaultIdHelper extends IdHelper {
@@ -36,6 +35,6 @@ public class DefaultIdHelper extends IdHelper {
 
   @Override
   public long getTaskAttemptId(long blockId) {
-    return blockId & Constants.MAX_TASK_ATTEMPT_ID;
+    return blockId & ((1 << blockIdLayoutConfig.getTaskAttemptIdLength()) - 1);
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/DefaultIdHelper.java
@@ -17,11 +17,18 @@
 
 package org.apache.uniffle.client.util;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.IdHelper;
 
 public class DefaultIdHelper extends IdHelper {
+
+  @VisibleForTesting
+  public DefaultIdHelper() {
+    this(BlockIdLayoutConfig.from());
+  }
 
   public DefaultIdHelper(BlockIdLayoutConfig config) {
     super(config);

--- a/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
@@ -40,6 +40,15 @@ public class BlockIdLayoutConfig {
     return sequenceIdLength;
   }
 
+  @Override
+  public String toString() {
+    return "BlockIdLayoutConfig{"
+        + "partitionIdLength=" + partitionIdLength
+        + ", taskAttemptIdLength=" + taskAttemptIdLength
+        + ", sequenceIdLength=" + sequenceIdLength
+        + '}';
+  }
+
   private static BlockIdLayoutConfig from(Map<String, String> blockIdLayoutMap) {
     String partitionIdRawVal = blockIdLayoutMap.get(PARTITION_ID_LENGTH);
     if (partitionIdRawVal == null) {

--- a/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
@@ -113,9 +113,9 @@ public class BlockIdLayoutConfig {
       throw new IllegalArgumentException(SEQUENCE_ID_LENGTH + " must be configured.");
     }
 
-    int partitionIdLength = Integer.valueOf(partitionIdRawVal);
-    int taskAttemptId = Integer.valueOf(taskAttemptIdRawVal);
-    int seqId = Integer.valueOf(sequenceIdRawVal);
+    int partitionIdLength = Integer.parseInt(partitionIdRawVal);
+    int taskAttemptId = Integer.parseInt(taskAttemptIdRawVal);
+    int seqId = Integer.parseInt(sequenceIdRawVal);
 
     if (partitionIdLength + taskAttemptId + seqId != BLOCK_ID_LENGTH) {
       throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);

--- a/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common;
 
 import java.util.Map;
@@ -49,31 +66,6 @@ public class BlockIdLayoutConfig {
         + '}';
   }
 
-  private static BlockIdLayoutConfig from(Map<String, String> blockIdLayoutMap) {
-    String partitionIdRawVal = blockIdLayoutMap.get(PARTITION_ID_LENGTH);
-    if (partitionIdRawVal == null) {
-      throw new IllegalArgumentException(PARTITION_ID_LENGTH + " must be configured.");
-    }
-    String taskAttemptIdRawVal = blockIdLayoutMap.get(TASK_ATTEMPT_ID_LENGTH);
-    if (taskAttemptIdRawVal == null) {
-      throw new IllegalArgumentException(TASK_ATTEMPT_ID_LENGTH + " must be configured.");
-    }
-    String sequenceIdRawVal = blockIdLayoutMap.get(SEQUENCE_ID_LENGTH);
-    if (sequenceIdRawVal == null) {
-      throw new IllegalArgumentException(SEQUENCE_ID_LENGTH + " must be configured.");
-    }
-
-    int partitionIdLength = Integer.valueOf(partitionIdRawVal);
-    int taskAttemptId = Integer.valueOf(taskAttemptIdRawVal);
-    int seqId = Integer.valueOf(sequenceIdRawVal);
-
-    if (partitionIdLength + taskAttemptId + seqId != BLOCK_ID_LENGTH) {
-      throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);
-    }
-
-    return new BlockIdLayoutConfig(partitionIdLength, taskAttemptId, seqId);
-  }
-
   public static boolean validate(Map<String, String> blockIdLayoutMap) {
     try {
       from(blockIdLayoutMap);
@@ -105,6 +97,31 @@ public class BlockIdLayoutConfig {
       throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);
     }
     return new BlockIdLayoutConfig(partitionIdLength, taskAttemptIdLength, sequenceIdLength);
+  }
+
+  private static BlockIdLayoutConfig from(Map<String, String> blockIdLayoutMap) {
+    String partitionIdRawVal = blockIdLayoutMap.get(PARTITION_ID_LENGTH);
+    if (partitionIdRawVal == null) {
+      throw new IllegalArgumentException(PARTITION_ID_LENGTH + " must be configured.");
+    }
+    String taskAttemptIdRawVal = blockIdLayoutMap.get(TASK_ATTEMPT_ID_LENGTH);
+    if (taskAttemptIdRawVal == null) {
+      throw new IllegalArgumentException(TASK_ATTEMPT_ID_LENGTH + " must be configured.");
+    }
+    String sequenceIdRawVal = blockIdLayoutMap.get(SEQUENCE_ID_LENGTH);
+    if (sequenceIdRawVal == null) {
+      throw new IllegalArgumentException(SEQUENCE_ID_LENGTH + " must be configured.");
+    }
+
+    int partitionIdLength = Integer.valueOf(partitionIdRawVal);
+    int taskAttemptId = Integer.valueOf(taskAttemptIdRawVal);
+    int seqId = Integer.valueOf(sequenceIdRawVal);
+
+    if (partitionIdLength + taskAttemptId + seqId != BLOCK_ID_LENGTH) {
+      throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);
+    }
+
+    return new BlockIdLayoutConfig(partitionIdLength, taskAttemptId, seqId);
   }
 
   // BlockId is long and composed of partitionId, executorId and AtomicInteger.

--- a/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
@@ -1,0 +1,130 @@
+package org.apache.uniffle.common;
+
+import java.util.Map;
+
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.util.Constants;
+
+public class BlockIdLayoutConfig {
+  // BlockId is long and consist of partitionId, taskAttemptId, atomicInt
+  // the length of them are ATOMIC_INT_MAX_LENGTH + PARTITION_ID_MAX_LENGTH + TASK_ATTEMPT_ID_MAX_LENGTH = 63
+  private static final int BLOCK_ID_LENGTH = 63;
+
+  /**
+   * The keys are configured in the conf of BLOCKID_LAYOUT
+   */
+  public static final String PARTITION_ID_LENGTH = "partitionIdLength";
+  public static final String TASK_ATTEMPT_ID_LENGTH = "taskAttemptIdLength";
+  public static final String SEQUENCE_ID_LENGTH = "sequenceIdLength";
+
+  private int partitionIdLength;
+  private int taskAttemptIdLength;
+  private int sequenceIdLength;
+
+  private BlockIdLayoutConfig(int partitionIdLength, int taskAttemptIdLength, int sequenceIdLength) {
+    this.partitionIdLength = partitionIdLength;
+    this.taskAttemptIdLength = taskAttemptIdLength;
+    this.sequenceIdLength = sequenceIdLength;
+  }
+
+  public int getPartitionIdLength() {
+    return partitionIdLength;
+  }
+
+  public int getTaskAttemptIdLength() {
+    return taskAttemptIdLength;
+  }
+
+  public int getSequenceIdLength() {
+    return sequenceIdLength;
+  }
+
+  private static BlockIdLayoutConfig from(Map<String, String> blockIdLayoutMap) {
+    String partitionIdRawVal = blockIdLayoutMap.get(PARTITION_ID_LENGTH);
+    if (partitionIdRawVal == null) {
+      throw new IllegalArgumentException(PARTITION_ID_LENGTH + " must be configured.");
+    }
+    String taskAttemptIdRawVal = blockIdLayoutMap.get(TASK_ATTEMPT_ID_LENGTH);
+    if (taskAttemptIdRawVal == null) {
+      throw new IllegalArgumentException(TASK_ATTEMPT_ID_LENGTH + " must be configured.");
+    }
+    String sequenceIdRawVal = blockIdLayoutMap.get(SEQUENCE_ID_LENGTH);
+    if (sequenceIdRawVal == null) {
+      throw new IllegalArgumentException(SEQUENCE_ID_LENGTH + " must be configured.");
+    }
+
+    int partitionIdLength = Integer.valueOf(partitionIdRawVal);
+    int taskAttemptId = Integer.valueOf(taskAttemptIdRawVal);
+    int seqId = Integer.valueOf(sequenceIdRawVal);
+
+    if (partitionIdLength + taskAttemptId + seqId != BLOCK_ID_LENGTH) {
+      throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);
+    }
+
+    return new BlockIdLayoutConfig(partitionIdLength, taskAttemptId, seqId);
+  }
+
+  public static boolean validate(Map<String, String> blockIdLayoutMap) {
+    try {
+      from(blockIdLayoutMap);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public static BlockIdLayoutConfig from(RssConf rssConf) {
+    Map<String, String> blockIdLayoutMap = rssConf.get(RssClientConf.BLOCKID_LAYOUT);
+    if (blockIdLayoutMap == null || blockIdLayoutMap.isEmpty()) {
+      return from();
+    }
+
+    return from(blockIdLayoutMap);
+  }
+
+  public static BlockIdLayoutConfig from() {
+    return new BlockIdLayoutConfig(
+        Constants.PARTITION_ID_MAX_LENGTH,
+        Constants.TASK_ATTEMPT_ID_MAX_LENGTH,
+        Constants.ATOMIC_INT_MAX_LENGTH
+    );
+  }
+
+  public static BlockIdLayoutConfig from(int partitionIdLength, int taskAttemptIdLength, int sequenceIdLength) {
+    if (partitionIdLength + taskAttemptIdLength + sequenceIdLength != BLOCK_ID_LENGTH) {
+      throw new IllegalArgumentException("The sum of all parts' length should be " + BLOCK_ID_LENGTH);
+    }
+    return new BlockIdLayoutConfig(partitionIdLength, taskAttemptIdLength, sequenceIdLength);
+  }
+
+  // BlockId is long and composed of partitionId, executorId and AtomicInteger.
+  // AtomicInteger is first {x} bit, max value is 2^{x} - 1
+  // partitionId is next {y} bit, max value is 2^{y} - 1
+  // taskAttemptId is rest of {z} bit, max value is 2^{z} - 1
+  // x+y+z = 63, which are configured in BlockIdLayoutConfig.
+  public static long createBlockId(
+      BlockIdLayoutConfig config,
+      long partitionId,
+      long taskAttemptId,
+      long atomicInt) {
+    long maxSeqId = (1 << config.getSequenceIdLength()) - 1;
+    long maxPartitionId = (1 << config.getPartitionIdLength()) - 1;
+    long maxTaskAttemptId = (1 << config.getTaskAttemptIdLength() ) - 1;
+
+    if (atomicInt < 0 || atomicInt > maxSeqId) {
+      throw new IllegalArgumentException("Can't support sequence[" + atomicInt
+          + "], the max value should be " + maxSeqId);
+    }
+    if (partitionId < 0 || partitionId > maxPartitionId) {
+      throw new IllegalArgumentException("Can't support partitionId["
+          + partitionId + "], the max value should be " + maxPartitionId);
+    }
+    if (taskAttemptId < 0 || taskAttemptId > maxTaskAttemptId) {
+      throw new IllegalArgumentException("Can't support taskAttemptId["
+          + taskAttemptId + "], the max value should be " + maxTaskAttemptId);
+    }
+    return (atomicInt << (config.getPartitionIdLength() + config.getTaskAttemptIdLength()))
+        + (partitionId << config.getTaskAttemptIdLength()) + taskAttemptId;
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockIdLayoutConfig.java
@@ -136,7 +136,7 @@ public class BlockIdLayoutConfig {
       long atomicInt) {
     long maxSeqId = (1 << config.getSequenceIdLength()) - 1;
     long maxPartitionId = (1 << config.getPartitionIdLength()) - 1;
-    long maxTaskAttemptId = (1 << config.getTaskAttemptIdLength() ) - 1;
+    long maxTaskAttemptId = (1 << config.getTaskAttemptIdLength()) - 1;
 
     if (atomicInt < 0 || atomicInt > maxSeqId) {
       throw new IllegalArgumentException("Can't support sequence[" + atomicInt

--- a/common/src/main/java/org/apache/uniffle/common/config/ConfigOptions.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/ConfigOptions.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.common.config;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -85,6 +86,13 @@ public class ConfigOptions {
    */
   public static final class OptionBuilder {
     /**
+     * Workaround to reuse the {@link TypedConfigOptionBuilder} for a {@link Map Map&lt;String,
+     * String&gt;}.
+     */
+    @SuppressWarnings("unchecked")
+    private static final Class<Map<String, String>> PROPERTIES_MAP_CLASS =
+        (Class<Map<String, String>>) (Class<?>) Map.class;
+    /**
      * The key for the config option.
      */
     private final String key;
@@ -147,6 +155,14 @@ public class ConfigOptions {
      */
     public <T extends Enum<T>> TypedConfigOptionBuilder<T> enumType(Class<T> enumClass) {
       return new TypedConfigOptionBuilder<>(key, enumClass);
+    }
+
+    /**
+     * Defines that the value of the option should be a set of properties, which can be
+     * represented as {@code Map<String, String>}.
+     */
+    public TypedConfigOptionBuilder<Map<String, String>> mapType() {
+      return new TypedConfigOptionBuilder<>(key, PROPERTIES_MAP_CLASS);
     }
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/config/ConfigUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/ConfigUtils.java
@@ -92,7 +92,7 @@ public class ConfigUtils {
               pair -> {
                 if (pair.length != 2) {
                   throw new IllegalArgumentException(
-                      "Could not parse pair in the map " + pair);
+                      "Could not parse pair in the map " + Arrays.toString(pair));
                 }
               })
           .collect(Collectors.toMap(a -> a[0], a -> a[1]));

--- a/common/src/main/java/org/apache/uniffle/common/config/ConfigUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/ConfigUtils.java
@@ -84,7 +84,7 @@ public class ConfigUtils {
       if (o == null) {
         throw new NullPointerException();
       }
-      String rawValues = StringUtils.trim(o.toString());
+      String rawValues = StringUtils.trim((String) o);
       String[] listOfRawProperties = StringUtils.split(rawValues, ',');
       return Arrays.stream(listOfRawProperties)
           .map(s -> StringUtils.split(s, ':'))

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -17,6 +17,9 @@
 
 package org.apache.uniffle.common.config;
 
+import java.util.Map;
+
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.compression.Codec;
 
@@ -43,4 +46,11 @@ public class RssClientConf {
       .defaultValue(ShuffleDataDistributionType.NORMAL)
       .withDescription("The type of partition shuffle data distribution, including normal and local_order. "
           + "The default value is normal. This config is only valid in Spark3.x");
+
+  public static final ConfigOption<Map<String, String>> BLOCKID_LAYOUT = ConfigOptions
+      .key("rss.client.blockId.layout")
+      .mapType()
+      .checkValue(BlockIdLayoutConfig::validate, "")
+      .noDefaultValue()
+      .withDescription("");
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
@@ -17,7 +17,14 @@
 
 package org.apache.uniffle.common.util;
 
-public interface IdHelper {
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 
-  long getTaskAttemptId(long blockId);
+public abstract class IdHelper {
+  protected BlockIdLayoutConfig blockIdLayoutConfig;
+
+  public IdHelper(BlockIdLayoutConfig config) {
+    this.blockIdLayoutConfig = config;
+  }
+
+  public abstract long getTaskAttemptId(long blockId);
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
@@ -20,11 +20,15 @@ package org.apache.uniffle.common.util;
 import org.apache.uniffle.common.BlockIdLayoutConfig;
 
 public abstract class IdHelper {
-  protected BlockIdLayoutConfig blockIdLayoutConfig;
+  private BlockIdLayoutConfig blockIdLayoutConfig;
 
   protected IdHelper(BlockIdLayoutConfig config) {
     this.blockIdLayoutConfig = config;
   }
 
   public abstract long getTaskAttemptId(long blockId);
+
+  public BlockIdLayoutConfig getBlockIdLayoutConfig() {
+    return blockIdLayoutConfig;
+  }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/IdHelper.java
@@ -22,7 +22,7 @@ import org.apache.uniffle.common.BlockIdLayoutConfig;
 public abstract class IdHelper {
   protected BlockIdLayoutConfig blockIdLayoutConfig;
 
-  public IdHelper(BlockIdLayoutConfig config) {
+  protected IdHelper(BlockIdLayoutConfig config) {
     this.blockIdLayoutConfig = config;
   }
 

--- a/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.uniffle.common.config;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import com.google.common.collect.Lists;
@@ -59,6 +61,35 @@ public class ConfigOptionTest {
   enum TestType {
     TYPE_1,
     TYPE_2,
+  }
+
+  @Test
+  public void testMapType() {
+    final ConfigOption<Map<String, String>> mapConfigOption = ConfigOptions
+        .key("rss.map")
+        .mapType()
+        .noDefaultValue()
+        .withDescription("");
+
+    RssBaseConf conf = new RssBaseConf();
+    // case1: no default value
+    Map<String, String> map = conf.get(mapConfigOption);
+    assertNull(map);
+
+    // case2: set configs with map
+    map = new HashMap<>();
+    map.put("a", "a1");
+    map.put("b", "b1");
+    conf.set(mapConfigOption, map);
+    assertEquals(map, conf.get(mapConfigOption));
+
+    // case3: set configs with string
+    conf = new RssBaseConf();
+    conf.setString(mapConfigOption.key(), "a:a1,b:b1");
+    map = conf.get(mapConfigOption);
+    assertEquals(2, map.size());
+    assertEquals("a1", map.get("a"));
+    assertEquals("b1", map.get("b"));
   }
 
   @Test

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
@@ -52,6 +52,7 @@ import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
 import org.apache.uniffle.client.response.RssGetShuffleResultResponse;
 import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
@@ -116,7 +117,8 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
         0,
         Lists.newArrayList(new PartitionRange(0, 1)),
         new RemoteStorageInfo(""),
-        ShuffleDataDistributionType.NORMAL
+        ShuffleDataDistributionType.NORMAL,
+        BlockIdLayoutConfig.from()
     );
     shuffleWriteClient.registerApplicationInfo("application_clearResourceTest1", 500L, "user");
     shuffleWriteClient.sendAppHeartbeat("application_clearResourceTest1", 500L);

--- a/integration-test/mr/src/test/java/org/apache/uniffle/test/WordCountWithBlockIdTest.java
+++ b/integration-test/mr/src/test/java/org/apache/uniffle/test/WordCountWithBlockIdTest.java
@@ -20,10 +20,15 @@ package org.apache.uniffle.test;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 
+import org.apache.uniffle.common.config.RssClientConf;
+
 public class WordCountWithBlockIdTest extends WordCountTest {
 
   @Override
   protected void updateRssConfiguration(Configuration jobConf) {
-    jobConf.set(MRJobConfig.MR_PREFIX, "partitionIdLength:24,taskAttemptIdLength:20,sequenceIdLength:19");
+    jobConf.set(
+        MRJobConfig.MR_PREFIX + RssClientConf.BLOCKID_LAYOUT.key(),
+        "partitionIdLength:24,taskAttemptIdLength:20,sequenceIdLength:19"
+    );
   }
 }

--- a/integration-test/mr/src/test/java/org/apache/uniffle/test/WordCountWithBlockIdTest.java
+++ b/integration-test/mr/src/test/java/org/apache/uniffle/test/WordCountWithBlockIdTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+
+public class WordCountWithBlockIdTest extends WordCountTest {
+
+  @Override
+  protected void updateRssConfiguration(Configuration jobConf) {
+    jobConf.set(MRJobConfig.MR_PREFIX, "partitionIdLength:24,taskAttemptIdLength:20,sequenceIdLength:19");
+  }
+}

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithBlockIdTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithBlockIdTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import org.apache.spark.SparkConf;
+
+import org.apache.uniffle.common.config.RssClientConf;
+
+public class SparkSQLWithBlockIdTest extends SparkSQLWithMemoryLocalTest {
+
+  @Override
+  public void updateRssStorage(SparkConf sparkConf) {
+    sparkConf.set(
+        "spark." + RssClientConf.BLOCKID_LAYOUT.key(),
+        "partitionIdLength:24,taskAttemptIdLength:20,sequenceIdLength:19"
+    );
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -55,6 +55,7 @@ import org.apache.uniffle.client.response.RssReportShuffleResultResponse;
 import org.apache.uniffle.client.response.RssSendCommitResponse;
 import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -136,13 +137,21 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
       String user,
-      ShuffleDataDistributionType dataDistributionType) {
+      ShuffleDataDistributionType dataDistributionType,
+      BlockIdLayoutConfig blockIdLayoutConfig) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)
         .setShuffleId(shuffleId)
         .setUser(user)
         .setShuffleDataDistribution(RssProtos.DataDistribution.valueOf(dataDistributionType.name()))
+        .setBlockIdLayout(
+            RssProtos.BlockIdLayout.newBuilder()
+                .setPartitionIdLength(blockIdLayoutConfig.getPartitionIdLength())
+                .setTaskAttemptIdLength(blockIdLayoutConfig.getTaskAttemptIdLength())
+                .setSequenceIdLength(blockIdLayoutConfig.getSequenceIdLength())
+                .build()
+        )
         .addAllPartitionRanges(toShufflePartitionRanges(partitionRanges));
     RemoteStorage.Builder rsBuilder = RemoteStorage.newBuilder();
     rsBuilder.setPath(remoteStorageInfo.getPath());
@@ -277,7 +286,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         request.getPartitionRanges(),
         request.getRemoteStorageInfo(),
         request.getUser(),
-        request.getDataDistributionType()
+        request.getDataDistributionType(),
+        request.getBlockIdLayoutConfig()
     );
 
     RssRegisterShuffleResponse response;

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
@@ -33,6 +34,7 @@ public class RssRegisterShuffleRequest {
   private RemoteStorageInfo remoteStorageInfo;
   private String user;
   private ShuffleDataDistributionType dataDistributionType;
+  private BlockIdLayoutConfig blockIdLayoutConfig;
 
   public RssRegisterShuffleRequest(
       String appId,
@@ -40,13 +42,15 @@ public class RssRegisterShuffleRequest {
       List<PartitionRange> partitionRanges,
       RemoteStorageInfo remoteStorageInfo,
       String user,
-      ShuffleDataDistributionType dataDistributionType) {
+      ShuffleDataDistributionType dataDistributionType,
+      BlockIdLayoutConfig blockIdLayoutConfig) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionRanges = partitionRanges;
     this.remoteStorageInfo = remoteStorageInfo;
     this.user = user;
     this.dataDistributionType = dataDistributionType;
+    this.blockIdLayoutConfig = blockIdLayoutConfig;
   }
 
   public RssRegisterShuffleRequest(
@@ -59,7 +63,8 @@ public class RssRegisterShuffleRequest {
         partitionRanges,
         new RemoteStorageInfo(remoteStoragePath),
         StringUtils.EMPTY,
-        ShuffleDataDistributionType.NORMAL
+        ShuffleDataDistributionType.NORMAL,
+        BlockIdLayoutConfig.from()
     );
   }
 
@@ -85,5 +90,9 @@ public class RssRegisterShuffleRequest {
 
   public ShuffleDataDistributionType getDataDistributionType() {
     return dataDistributionType;
+  }
+
+  public BlockIdLayoutConfig getBlockIdLayoutConfig() {
+    return blockIdLayoutConfig;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -17,8 +17,10 @@
 
 package org.apache.uniffle.client.request;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.uniffle.common.BlockIdLayoutConfig;
@@ -35,6 +37,25 @@ public class RssRegisterShuffleRequest {
   private String user;
   private ShuffleDataDistributionType dataDistributionType;
   private BlockIdLayoutConfig blockIdLayoutConfig;
+
+  @VisibleForTesting
+  public RssRegisterShuffleRequest(
+      String appId,
+      int shuffleId,
+      List<PartitionRange> partitionRanges,
+      RemoteStorageInfo remoteStorageInfo,
+      String user,
+      ShuffleDataDistributionType dataDistributionType) {
+    this(
+        appId,
+        shuffleId,
+        partitionRanges,
+        remoteStorageInfo,
+        user,
+        dataDistributionType,
+        BlockIdLayoutConfig.from()
+    );
+  }
 
   public RssRegisterShuffleRequest(
       String appId,

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.client.request;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -174,6 +174,13 @@ message ShuffleRegisterRequest {
   RemoteStorage remoteStorage = 4;
   string user = 5;
   DataDistribution shuffleDataDistribution = 6;
+  BlockIdLayout blockIdLayout = 7;
+}
+
+message BlockIdLayout {
+  int32 partitionIdLength = 1;
+  int32 taskAttemptIdLength = 2;
+  int32 sequenceIdLength = 3;
 }
 
 enum DataDistribution {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -35,6 +35,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -134,6 +135,17 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                     .name()
             );
 
+    // Default value
+    BlockIdLayoutConfig blockIdLayoutConfig = BlockIdLayoutConfig.from();
+    RssProtos.BlockIdLayout layout = req.getBlockIdLayout();
+    if (layout != null) {
+      blockIdLayoutConfig = BlockIdLayoutConfig.from(
+          layout.getPartitionIdLength(),
+          layout.getTaskAttemptIdLength(),
+          layout.getSequenceIdLength()
+      );
+    }
+
     Map<String, String> remoteStorageConf = req
         .getRemoteStorage()
         .getRemoteStorageConfList()
@@ -153,7 +165,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
             partitionRanges,
             new RemoteStorageInfo(remoteStoragePath, remoteStorageConf),
             user,
-            shuffleDataDistributionType
+            shuffleDataDistributionType,
+            blockIdLayoutConfig
         );
 
     reply = ShuffleRegisterResponse

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -75,6 +75,7 @@ public class ShuffleTaskInfo {
     this.cachedBlockIds = Maps.newConcurrentMap();
     this.user = new AtomicReference<>();
     this.dataDistType = new AtomicReference<>();
+    this.blockIdLayoutConfig = new AtomicReference<>();
     this.partitionDataSizes = Maps.newConcurrentMap();
     this.hugePartitionTags = Maps.newConcurrentMap();
     this.existHugePartition = new AtomicBoolean(false);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -30,6 +30,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 
 /**
@@ -53,6 +54,7 @@ public class ShuffleTaskInfo {
   private AtomicReference<String> user;
 
   private AtomicReference<ShuffleDataDistributionType> dataDistType;
+  private AtomicReference<BlockIdLayoutConfig> blockIdLayoutConfig;
 
   private AtomicLong totalDataSize = new AtomicLong(0);
   /**
@@ -111,6 +113,10 @@ public class ShuffleTaskInfo {
     this.dataDistType.set(dataDistType);
   }
 
+  public void setBlockIdLayoutConfig(BlockIdLayoutConfig config) {
+    this.blockIdLayoutConfig.set(config);
+  }
+
   public ShuffleDataDistributionType getDataDistType() {
     return dataDistType.get();
   }
@@ -137,6 +143,10 @@ public class ShuffleTaskInfo {
       return 0L;
     }
     return size;
+  }
+
+  public BlockIdLayoutConfig getBlockIdLayoutConfig() {
+    return blockIdLayoutConfig.get();
   }
 
   public boolean hasHugePartition() {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -42,7 +42,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.jvm.hotspot.opto.Block;
 
 import org.apache.uniffle.common.BlockIdLayoutConfig;
 import org.apache.uniffle.common.PartitionRange;
@@ -55,7 +54,6 @@ import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.FileNotFoundException;
 import org.apache.uniffle.common.rpc.StatusCode;
-import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
 import org.apache.uniffle.server.buffer.PreAllocatedBufferInfo;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make blockId layout configurable by client side.

### Why are the changes needed?

To solve the problem mentioned by #731, this PR introduce the config of `rss.client.blockId.layout` to make it possible to configure on the client side.

### Does this PR introduce _any_ user-facing change?

1. Introducing the config of `rss.client.blockId.layout`

### How was this patch tested?
1. UTs
