### PR TITLE
[MINOR] chore:correct the format of go files

### DIFF
--- a/deploy/kubernetes/operator/api/uniffle/v1alpha1/groupversion_info.go
+++ b/deploy/kubernetes/operator/api/uniffle/v1alpha1/groupversion_info.go
@@ -16,8 +16,8 @@
  */
 
 // Package v1alpha1 contains API Schema definitions for the uniffle v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=uniffle.apache.org
+// +kubebuilder:object:generate=true
+// +groupName=uniffle.apache.org
 package v1alpha1
 
 import (

--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator.go
@@ -136,7 +136,7 @@ func GenerateHeadlessSvc(rss *unifflev1alpha1.RemoteShuffleService, index int) *
 }
 
 // GenerateSvc generates NodePort service used by specific coordinator. If no RPCNodePort/HTTPNodePort is specified,
-//   this function is skipped.
+// this function is skipped.
 func GenerateSvc(rss *unifflev1alpha1.RemoteShuffleService, index int) *corev1.Service {
 	name := GenerateNameByIndex(rss, index)
 	svc := &corev1.Service{

--- a/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/coordinator/coordinator_test.go
@@ -447,7 +447,7 @@ func TestGenerateDeploy(t *testing.T) {
 }
 
 // generateServiceCuntMap generates a map with service type and its corresponding count. The headless svc is treated
-//   differently: the service type for headless is treated as an empty service.
+// differently: the service type for headless is treated as an empty service.
 func generateServiceCountMap(services []*corev1.Service) map[corev1.ServiceType]int {
 	result := make(map[corev1.ServiceType]int)
 	var empty corev1.ServiceType

--- a/deploy/kubernetes/operator/pkg/generated/clientset/versioned/fake/register.go
+++ b/deploy/kubernetes/operator/pkg/generated/clientset/versioned/fake/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/deploy/kubernetes/operator/pkg/generated/clientset/versioned/fake/register.go
+++ b/deploy/kubernetes/operator/pkg/generated/clientset/versioned/fake/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//  import (
+//    "k8s.io/client-go/kubernetes"
+//    clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//    aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//  )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//  kclientset, _ := kubernetes.NewForConfig(c)
+//  _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/deploy/kubernetes/operator/pkg/generated/clientset/versioned/scheme/register.go
+++ b/deploy/kubernetes/operator/pkg/generated/clientset/versioned/scheme/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/deploy/kubernetes/operator/pkg/generated/clientset/versioned/scheme/register.go
+++ b/deploy/kubernetes/operator/pkg/generated/clientset/versioned/scheme/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//  import (
+//    "k8s.io/client-go/kubernetes"
+//    clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//    aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//  )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//  kclientset, _ := kubernetes.NewForConfig(c)
+//  _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Correct the format fo go files.

### Why are the changes needed?

`build-operator.sh` cannot be executed normally.

build logs as follow:
```
image version release.0.4.0.453.g567872b8.dirty is dirty, dirty files:
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need.
