### PR TITLE
[#762] If the storage path is not exist, get file store for its parent.

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
@@ -63,7 +63,7 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
         File baseFile = new File(baseDir);
         FileStore store = getFileStore(baseFile.toPath());
         if (store == null) {
-          throw new IOException("Can't get file for path:" + baseFile.getAbsolutePath());
+          throw new IOException("Can't get FileStore for path:" + baseFile.getAbsolutePath());
         }
         String deviceName = getDeviceName(store.name());
         File blockFile = new File(String.format(BLOCK_PATH_FORMAT, deviceName));

--- a/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
@@ -60,7 +61,7 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
       // `/sys/block/sdx/queue/rotational`.
       try {
         File baseFile = new File(baseDir);
-        FileStore store = Files.getFileStore(baseFile.toPath());
+        FileStore store = getFileStore(baseFile.toPath());
         String deviceName = getDeviceName(store.name());
         File blockFile = new File(String.format(BLOCK_PATH_FORMAT, deviceName));
         if (blockFile.exists()) {
@@ -81,6 +82,14 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
     }
     logger.info("Default storage type provider returns HDD by default");
     return StorageMedia.HDD;
+  }
+
+  @VisibleForTesting
+  FileStore getFileStore(Path path) throws IOException {
+    while (!Files.exists(path)) {
+      path = path.getParent();
+    }
+    return Files.getFileStore(path);
   }
 
   @VisibleForTesting

--- a/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/DefaultStorageMediaProvider.java
@@ -62,6 +62,9 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
       try {
         File baseFile = new File(baseDir);
         FileStore store = getFileStore(baseFile.toPath());
+        if (store == null) {
+          throw new IOException("Can't get file for path:" + baseFile.getAbsolutePath());
+        }
         String deviceName = getDeviceName(store.name());
         File blockFile = new File(String.format(BLOCK_PATH_FORMAT, deviceName));
         if (blockFile.exists()) {
@@ -88,6 +91,9 @@ public class DefaultStorageMediaProvider implements StorageMediaProvider {
   FileStore getFileStore(Path path) throws IOException {
     while (!Files.exists(path)) {
       path = path.getParent();
+      if (path == null) {
+        return null;
+      }
     }
     return Files.getFileStore(path);
   }

--- a/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/DefaultStorageMediaProviderTest.java
@@ -17,11 +17,16 @@
 
 package org.apache.uniffle.storage.common;
 
+import java.io.File;
+import java.nio.file.FileStore;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.uniffle.common.storage.StorageMedia;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DefaultStorageMediaProviderTest {
   @Test
@@ -46,5 +51,12 @@ public class DefaultStorageMediaProviderTest {
     assertEquals("rootfs", DefaultStorageMediaProvider.getDeviceName("rootfs"));
     assertEquals("sda", DefaultStorageMediaProvider.getDeviceName("/dev/sda1"));
     assertEquals("cl-home", DefaultStorageMediaProvider.getDeviceName("/dev/mapper/cl-home"));
+  }
+
+  @Test
+  public void getGetFileStore(@TempDir File tempDir) throws Exception {
+    DefaultStorageMediaProvider provider = new DefaultStorageMediaProvider();
+    FileStore fileStore = provider.getFileStore(new File(tempDir, "/q/w").toPath());
+    assertNotNull(fileStore);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

If the storage path is not exist, get file store for its parent.

### Why are the changes needed?

Fix: #762 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT
