### PR TITLE
[#772] fix(kerberos): cache proxy user ugi to avoid memory leak

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -117,6 +118,12 @@ public class HadoopSecurityContext implements SecurityContext {
 
   private <T> T executeWithUgiWrapper(UserGroupInformation ugi, Callable<T> callable) throws Exception {
     return ugi.doAs((PrivilegedExceptionAction<T>) callable::call);
+  }
+
+  // Only for tests
+  @VisibleForTesting
+  public Map<String, UserGroupInformation> getProxyUserUgiPool() {
+    return proxyUserUgiPool;
   }
 
   @Override

--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -42,10 +42,10 @@ public class HadoopSecurityContext implements SecurityContext {
   private UserGroupInformation loginUgi;
   private ScheduledExecutorService refreshScheduledExecutor;
 
-  // The cache of proxy user ugi is to avoid creating the different cache keys of
-  // Hadoop filesystem for the same user, scheme and authority, this will cache too
-  // much unnecessary filesystem instances in memory and then cause memory leak.
-  // See details in issue #706
+  // The purpose of the proxy user ugi cache is to prevent the creation of
+  // multiple cache keys for the same user, scheme, and authority in the Hadoop filesystem.
+  // Without this cache, large amounts of unnecessary filesystem instances could be stored in memory,
+  // leading to potential memory leaks. For more information on this issue, refer to #706.
   private Map<String, UserGroupInformation> proxyUserUgiPool;
 
   public HadoopSecurityContext(

--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -127,7 +127,7 @@ public class HadoopSecurityContext implements SecurityContext {
 
   // Only for tests
   @VisibleForTesting
-  public Map<String, UserGroupInformation> getProxyUserUgiPool() {
+  Map<String, UserGroupInformation> getProxyUserUgiPool() {
     return proxyUserUgiPool;
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -41,6 +41,11 @@ public class HadoopSecurityContext implements SecurityContext {
 
   private UserGroupInformation loginUgi;
   private ScheduledExecutorService refreshScheduledExecutor;
+
+  // The cache of proxy user ugi is to avoid creating the different cache keys of
+  // Hadoop filesystem for the same user, scheme and authority, this will cache too
+  // much unnecessary filesystem instances in memory and then cause memory leak.
+  // See details in issue #706
   private Map<String, UserGroupInformation> proxyUserUgiPool;
 
   public HadoopSecurityContext(

--- a/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/HadoopSecurityContext.java
@@ -25,13 +25,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
 
 public class HadoopSecurityContext implements SecurityContext {
@@ -78,7 +78,7 @@ public class HadoopSecurityContext implements SecurityContext {
         refreshIntervalSec,
         refreshIntervalSec,
         TimeUnit.SECONDS);
-    proxyUserUgiPool = Maps.newConcurrentMap();
+    proxyUserUgiPool = JavaUtils.newConcurrentMap();
   }
 
   private void authRefresh() {

--- a/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
@@ -85,12 +85,12 @@ public class HadoopSecurityContextTest extends KerberizedHdfsBase {
         ugi2.set(UserGroupInformation.getCurrentUser());
         return null;
       });
-      assertEquals(ugi1.get(), ugi2.get());
-      assertEquals(ugi1.get(), context.getProxyUserUgiPool().get("alex"));
+      assertTrue(ugi1.get() == ugi2.get());
+      assertTrue(ugi1.get() == context.getProxyUserUgiPool().get("alex"));
 
       FileSystem fileSystem1 = context.runSecured("alex", () -> FileSystem.get(kerberizedHdfs.getConf()));
       FileSystem fileSystem2 = context.runSecured("alex", () -> FileSystem.get(kerberizedHdfs.getConf()));
-      assertEquals(fileSystem1, fileSystem2);
+      assertTrue(fileSystem1 == fileSystem2);
     }
   }
 

--- a/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
@@ -71,9 +71,9 @@ public class HadoopSecurityContextTest extends KerberizedHdfsBase {
 
       // case3: run by the proxy user
       Path pathWithAlexUser = new Path("/alex/HadoopSecurityContextTest");
-      AtomicReference<UserGroupInformation> ugi$1 = new AtomicReference<>();
+      AtomicReference<UserGroupInformation> ugi1 = new AtomicReference<>();
       context.runSecured("alex", (Callable<Void>) () -> {
-        ugi$1.set(UserGroupInformation.getCurrentUser());
+        ugi1.set(UserGroupInformation.getCurrentUser());
         kerberizedHdfs.getFileSystem().mkdirs(pathWithAlexUser);
         return null;
       });
@@ -82,13 +82,13 @@ public class HadoopSecurityContextTest extends KerberizedHdfsBase {
 
       // case4: run by the proxy user again, it will always return the same
       // ugi.
-      AtomicReference<UserGroupInformation> ugi$2 = new AtomicReference<>();
+      AtomicReference<UserGroupInformation> ugi2 = new AtomicReference<>();
       context.runSecured("alex", (Callable<Void>) () -> {
-        ugi$2.set(UserGroupInformation.getCurrentUser());
+        ugi2.set(UserGroupInformation.getCurrentUser());
         return null;
       });
-      assertEquals(ugi$1.get(), ugi$2.get());
-      assertEquals(ugi$1.get(), context.getProxyUserUgiPool().get("alex"));
+      assertEquals(ugi1.get(), ugi2.get());
+      assertEquals(ugi1.get(), context.getProxyUserUgiPool().get("alex"));
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. To avoid memory leak by caching of proxy user UGI.

### Why are the changes needed?

Fix: #772 

The Hadoop filesystem instance will be created too many time in cache, 
which will cause the shuffle server memory leak.

As we know, the filesystem cache's key is built by the scheme、authority and UGI. 
The scheme and authority are not changed every time. But for UGI, if we invoke the 
createProxyUser, it will always create a new one, that means the every invoking `Filesystem.get()`,
it will be cached due to different key.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
1. Existing UTs
2. Added tests