### PR TITLE
[MINOR] chore(spark): remove noisy log in client side

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -297,7 +297,7 @@ public class WriteBufferManager extends MemoryConsumer {
       shuffleBlockInfosPerEvent.add(sbi);
       // split shuffle data according to the size
       if (totalSize > sendSizeLimit) {
-        LOG.info("Build event with " + shuffleBlockInfosPerEvent.size()
+        LOG.debug("Build event with " + shuffleBlockInfosPerEvent.size()
             + " blocks and " + totalSize + " bytes");
         // Use final temporary variables for closures
         final long _memoryUsed = memoryUsed;
@@ -310,7 +310,7 @@ public class WriteBufferManager extends MemoryConsumer {
       }
     }
     if (!shuffleBlockInfosPerEvent.isEmpty()) {
-      LOG.info("Build event with " + shuffleBlockInfosPerEvent.size()
+      LOG.debug("Build event with " + shuffleBlockInfosPerEvent.size()
           + " blocks and " + totalSize + " bytes");
       // Use final temporary variables for closures
       final long _memoryUsed = memoryUsed;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -415,7 +415,6 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     } catch (Exception e) {
       LOG.error("Error on getting user from ugi.", e);
     }
-    LOG.info("User: {}", user);
 
     RssRegisterShuffleRequest request =
         new RssRegisterShuffleRequest(appId, shuffleId, partitionRanges, remoteStorage, user, dataDistributionType);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHdfsShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHdfsShuffleWriteHandler.java
@@ -50,7 +50,7 @@ public class PooledHdfsShuffleWriteHandler implements ShuffleWriteHandler {
   @VisibleForTesting
   public PooledHdfsShuffleWriteHandler(LinkedBlockingDeque<ShuffleWriteHandler> queue) {
     this.queue = queue;
-    this.maxConcurrency =  queue.size();
+    this.maxConcurrency = queue.size();
     this.basePath = StringUtils.EMPTY;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Remove unnecessary log
2. Make some unimportant log with debug level.
3. Remove extra spaces

### Why are the changes needed?

Avoid too much noisy log in client side when running spark jobs

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Don't need
