### PR TITLE
[#794] feat(operator): support delete ShuffleServer pod with Evicted status

### DIFF
--- a/deploy/kubernetes/operator/pkg/webhook/inspector/pod.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/pod.go
@@ -59,7 +59,7 @@ func (i *inspector) validateDeletingShuffleServer(ar *admissionv1.AdmissionRevie
 		}
 		return util.AdmissionReviewFailed(ar, err)
 	}
-	// we can only delete shuffle server pods when rss is in upgrading phase.
+	// we can only delete shuffle server pods when rss is in upgrading phase or pod is in failed status.
 	if rss.Status.Phase != unifflev1alpha1.RSSUpgrading && rss.Status.Phase != unifflev1alpha1.RSSTerminating &&
 		pod.Status.Phase != corev1.PodFailed {
 		message := fmt.Sprintf("can not delete the shuffle server pod (%v) directly, status:(%v)",

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/pod.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/pod.go
@@ -60,9 +60,10 @@ func (i *inspector) validateDeletingShuffleServer(ar *admissionv1.AdmissionRevie
 		return util.AdmissionReviewFailed(ar, err)
 	}
 	// we can only delete shuffle server pods when rss is in upgrading phase.
-	if rss.Status.Phase != unifflev1alpha1.RSSUpgrading && rss.Status.Phase != unifflev1alpha1.RSSTerminating {
-		message := fmt.Sprintf("can not delete the shuffle server pod (%v) directly",
-			utils.UniqueName(pod))
+	if rss.Status.Phase != unifflev1alpha1.RSSUpgrading && rss.Status.Phase != unifflev1alpha1.RSSTerminating &&
+		pod.Status.Phase != corev1.PodFailed {
+		message := fmt.Sprintf("can not delete the shuffle server pod (%v) directly, status:(%v)",
+			utils.UniqueName(pod), pod.Status.Phase)
 		klog.V(4).Info(message)
 		return util.AdmissionReviewForbidden(ar, message)
 	}

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	
+
 	uniffleapi "github.com/apache/incubator-uniffle/deploy/kubernetes/operator/api/uniffle/v1alpha1"
 	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/constants"
 	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/webhook/config"

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
@@ -20,13 +20,14 @@ package inspector
 import (
 	"testing"
 
-	uniffleapi "github.com/apache/incubator-uniffle/deploy/kubernetes/operator/api/uniffle/v1alpha1"
-	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/constants"
-	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/webhook/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	
+	uniffleapi "github.com/apache/incubator-uniffle/deploy/kubernetes/operator/api/uniffle/v1alpha1"
+	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/constants"
+	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/webhook/config"
 )
 
 // TestDeletingShuffleServer tests delete shuffle server in rss-webhook.

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/pod_test.go
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inspector
+
+import (
+	"testing"
+
+	uniffleapi "github.com/apache/incubator-uniffle/deploy/kubernetes/operator/api/uniffle/v1alpha1"
+	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/constants"
+	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/webhook/config"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// TestDeletingShuffleServer tests delete shuffle server in rss-webhook.
+func TestDeletingShuffleServer(t *testing.T) {
+	testInspector := newInspector(&config.Config{}, nil)
+
+	rssWithCooNodePort := wrapRssObj(func(rss *uniffleapi.RemoteShuffleService) {
+		rss.Spec.Coordinator.Count = pointer.Int32(2)
+		rss.Spec.Coordinator.RPCNodePort = []int32{30001, 30002}
+		rss.Spec.Coordinator.HTTPNodePort = []int32{30011, 30012}
+		rss.Spec.Coordinator.ExcludeNodesFilePath = ""
+	})
+
+	rssWithoutRunningStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutRunningStatus.Status.Phase = uniffleapi.RSSRunning
+
+	rssWithoutTerminatingStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutTerminatingStatus.Status.Phase = uniffleapi.RSSTerminating
+
+	rssWithoutUpgradingStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutUpgradingStatus.Status.Phase = uniffleapi.RSSUpgrading
+
+	testInspector.rssInformer.GetIndexer().Add(rssWithCooNodePort)
+	for _, tt := range []struct {
+		name    string
+		rss     *uniffleapi.RemoteShuffleService
+		pod     *corev1.Pod
+		allowed bool
+	}{
+		{
+			name:    "delete pod in running status on rss in running status",
+			rss:     rssWithoutRunningStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: false,
+		},
+		{
+			name:    "delete pod in failed statuson rss in running status",
+			rss:     rssWithoutRunningStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in running status on rss in terminating status",
+			rss:     rssWithoutTerminatingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in failed statuson rss in terminating status",
+			rss:     rssWithoutTerminatingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in running status on rss in upgrading status",
+			rss:     rssWithoutUpgradingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in failed statuson rss in upgrading status",
+			rss:     rssWithoutUpgradingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+	} {
+		t.Run(tt.name, func(tc *testing.T) {
+			canBeDeleted := testInspector.ifShuffleServerCanBeDeleted(tt.rss, tt.pod)
+			if canBeDeleted != tt.allowed {
+				tc.Errorf("invalid 'allowed' field in response: %v <> %v", canBeDeleted, tt.allowed)
+			}
+		})
+	}
+}
+
+func buildTestShuffleServerPod(podPhase corev1.PodPhase) *corev1.Pod {
+	testShuffleServerPodName := constants.RSSShuffleServer + "-test-0"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testShuffleServerPodName,
+			Namespace: corev1.NamespaceDefault,
+			Annotations: map[string]string{
+				constants.AnnotationShuffleServerPort: "8080",
+				constants.AnnotationRssName:           "rss",
+			},
+			Labels: map[string]string{
+				appsv1.ControllerRevisionHashLabelKey: "test-revision-1",
+				constants.LabelShuffleServer:          "true",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "xxx.xxx.xxx.xxx",
+			Phase: podPhase,
+		},
+	}
+}

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/rss_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/rss_test.go
@@ -19,6 +19,9 @@ package inspector
 
 import (
 	"encoding/json"
+	"github.com/apache/incubator-uniffle/deploy/kubernetes/operator/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +65,21 @@ func convertRssToRawExtension(rss *uniffleapi.RemoteShuffleService) (runtime.Raw
 	}, nil
 }
 
+// convertPodToRawExtension converts a pod object to runtime.RawExtension for testing.
+func convertPodToRawExtension(rss *corev1.Pod) (runtime.RawExtension, error) {
+	if rss == nil {
+		return convertPodToRawExtension(&corev1.Pod{})
+	}
+	body, err := json.Marshal(rss)
+	if err != nil {
+		return runtime.RawExtension{}, err
+	}
+	return runtime.RawExtension{
+		Raw:    body,
+		Object: rss,
+	}, nil
+}
+
 // buildTestAdmissionReview builds an AdmissionReview object for testing.
 func buildTestAdmissionReview(op admissionv1.Operation,
 	oldRss, newRss *uniffleapi.RemoteShuffleService) *admissionv1.AdmissionReview {
@@ -79,6 +97,49 @@ func buildTestAdmissionReview(op admissionv1.Operation,
 			Operation: op,
 			Object:    object,
 			OldObject: oldObject,
+		},
+	}
+}
+
+// buildPodTestAdmissionReview builds an AdmissionReview object for pod testing.
+func buildPodTestAdmissionReview(op admissionv1.Operation,
+	oldPod, newPod *corev1.Pod) *admissionv1.AdmissionReview {
+	oldObject, err := convertPodToRawExtension(oldPod)
+	if err != nil {
+		panic(err)
+	}
+	var object runtime.RawExtension
+	object, err = convertPodToRawExtension(newPod)
+	if err != nil {
+		panic(err)
+	}
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Operation: op,
+			Object:    object,
+			OldObject: oldObject,
+		},
+	}
+}
+
+func buildTestShuffleServerPod(podPhase corev1.PodPhase) *corev1.Pod {
+	testShuffleServerPodName := constants.RSSShuffleServer + "-test-0"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testShuffleServerPodName,
+			Namespace: corev1.NamespaceDefault,
+			Annotations: map[string]string{
+				constants.AnnotationShuffleServerPort: "8080",
+				constants.AnnotationRssName:           "rss",
+			},
+			Labels: map[string]string{
+				appsv1.ControllerRevisionHashLabelKey: "test-revision-1",
+				constants.LabelShuffleServer:          "true",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "xxx.xxx.xxx.xxx",
+			Phase: podPhase,
 		},
 	}
 }
@@ -214,6 +275,79 @@ func TestValidateRSS(t *testing.T) {
 			}
 			if updatedAR.Response.Allowed != tt.allowed {
 				tc.Errorf("invalid 'allowed' field in response: %v <> %v", updatedAR.Response.Allowed, tt.allowed)
+			}
+		})
+	}
+}
+
+// TestDeletingShuffleServer tests delete shuffle server in rss-webhook.
+func TestDeletingShuffleServer(t *testing.T) {
+	testInspector := newInspector(&config.Config{}, nil)
+
+	rssWithCooNodePort := wrapRssObj(func(rss *uniffleapi.RemoteShuffleService) {
+		rss.Spec.Coordinator.Count = pointer.Int32(2)
+		rss.Spec.Coordinator.RPCNodePort = []int32{30001, 30002}
+		rss.Spec.Coordinator.HTTPNodePort = []int32{30011, 30012}
+		rss.Spec.Coordinator.ExcludeNodesFilePath = ""
+	})
+
+	rssWithoutRunningStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutRunningStatus.Status.Phase = uniffleapi.RSSRunning
+
+	rssWithoutTerminatingStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutTerminatingStatus.Status.Phase = uniffleapi.RSSTerminating
+
+	rssWithoutUpgradingStatus := rssWithCooNodePort.DeepCopy()
+	rssWithoutUpgradingStatus.Status.Phase = uniffleapi.RSSUpgrading
+
+	testInspector.rssInformer.GetIndexer().Add(rssWithCooNodePort)
+	for _, tt := range []struct {
+		name    string
+		rss     *uniffleapi.RemoteShuffleService
+		pod     *corev1.Pod
+		allowed bool
+	}{
+		{
+			name:    "delete pod in running status on rss in running status",
+			rss:     rssWithoutRunningStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: false,
+		},
+		{
+			name:    "delete pod in failed statuson rss in running status",
+			rss:     rssWithoutRunningStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in running status on rss in terminating status",
+			rss:     rssWithoutTerminatingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in failed statuson rss in terminating status",
+			rss:     rssWithoutTerminatingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in running status on rss in upgrading status",
+			rss:     rssWithoutUpgradingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodRunning),
+			allowed: true,
+		},
+		{
+			name:    "delete pod in failed statuson rss in upgrading status",
+			rss:     rssWithoutUpgradingStatus,
+			pod:     buildTestShuffleServerPod(corev1.PodFailed),
+			allowed: true,
+		},
+	} {
+		t.Run(tt.name, func(tc *testing.T) {
+			canBeDeleted := testInspector.ifShuffleServerCanBeDeleted(tt.rss, tt.pod)
+			if canBeDeleted != tt.allowed {
+				tc.Errorf("invalid 'allowed' field in response: %v <> %v", canBeDeleted, tt.allowed)
 			}
 		})
 	}

--- a/deploy/kubernetes/operator/pkg/webhook/inspector/rss_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/inspector/rss_test.go
@@ -101,27 +101,6 @@ func buildTestAdmissionReview(op admissionv1.Operation,
 	}
 }
 
-// buildPodTestAdmissionReview builds an AdmissionReview object for pod testing.
-func buildPodTestAdmissionReview(op admissionv1.Operation,
-	oldPod, newPod *corev1.Pod) *admissionv1.AdmissionReview {
-	oldObject, err := convertPodToRawExtension(oldPod)
-	if err != nil {
-		panic(err)
-	}
-	var object runtime.RawExtension
-	object, err = convertPodToRawExtension(newPod)
-	if err != nil {
-		panic(err)
-	}
-	return &admissionv1.AdmissionReview{
-		Request: &admissionv1.AdmissionRequest{
-			Operation: op,
-			Object:    object,
-			OldObject: oldObject,
-		},
-	}
-}
-
 func buildTestShuffleServerPod(podPhase corev1.PodPhase) *corev1.Pod {
 	testShuffleServerPodName := constants.RSSShuffleServer + "-test-0"
 	return &corev1.Pod{


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support delete ShuffleServer pod with Evicted status

### Why are the changes needed?

When ShuffleServer pod is Evicted, we can't delete it.
Fix: #794 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual testing