### PR TITLE
[BUG][MINOR] Fix scripts compatible with jdk8 & jdk11

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -56,6 +56,7 @@ echo "class path is $CLASSPATH"
 JVM_ARGS=" -server \
           -Xmx${XMX_SIZE:-8g} \
           -Xms${XMX_SIZE:-8g} \
+          -XX:+IgnoreUnrecognizedVMOptions \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
@@ -66,6 +67,7 @@ JVM_ARGS=" -server \
           -XX:+PrintGCDateStamps \
           -XX:+PrintGCTimeStamps \
           -XX:+PrintGCDetails \
+          -Xlog:gc:tags,time,uptime,level \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 ARGS=""

--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -56,7 +56,6 @@ echo "class path is $CLASSPATH"
 JVM_ARGS=" -server \
           -Xmx${XMX_SIZE:-8g} \
           -Xms${XMX_SIZE:-8g} \
-          -XX:+IgnoreUnrecognizedVMOptions \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
@@ -67,8 +66,10 @@ JVM_ARGS=" -server \
           -XX:+PrintGCDateStamps \
           -XX:+PrintGCTimeStamps \
           -XX:+PrintGCDetails \
-          -Xlog:gc:tags,time,uptime,level \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
+
+JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
+          -Xlog:gc:tags,time,uptime,level"
 
 ARGS=""
 
@@ -79,7 +80,7 @@ else
   exit 1
 fi
 
-$RUNNER $ARGS $JVM_ARGS -cp $CLASSPATH $MAIN_CLASS --conf "$COORDINATOR_CONF_FILE" $@ &> $OUT_PATH &
+$RUNNER $ARGS $JVM_ARGS $JAVA11_EXTRA_ARGS -cp $CLASSPATH $MAIN_CLASS --conf "$COORDINATOR_CONF_FILE" $@ &> $OUT_PATH &
 
 get_pid_file_name coordinator
 echo $! >${RSS_PID_DIR}/${pid_file}

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -73,6 +73,7 @@ JVM_ARGS=" -server \
           -Xmx${XMX_SIZE} \
           -Xms${XMX_SIZE} \
           ${MAX_DIRECT_MEMORY_OPTS} \
+          -XX:+IgnoreUnrecognizedVMOptions \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
@@ -86,6 +87,7 @@ JVM_ARGS=" -server \
           -XX:+PrintGCDateStamps \
           -XX:+PrintGCTimeStamps \
           -XX:+PrintGCDetails \
+          -Xlog:gc:tags,time,uptime,level \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 ARGS=""

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -73,7 +73,6 @@ JVM_ARGS=" -server \
           -Xmx${XMX_SIZE} \
           -Xms${XMX_SIZE} \
           ${MAX_DIRECT_MEMORY_OPTS} \
-          -XX:+IgnoreUnrecognizedVMOptions \
           -XX:+UseG1GC \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
@@ -87,8 +86,10 @@ JVM_ARGS=" -server \
           -XX:+PrintGCDateStamps \
           -XX:+PrintGCTimeStamps \
           -XX:+PrintGCDetails \
-          -Xlog:gc:tags,time,uptime,level \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
+
+JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
+          -Xlog:gc:tags,time,uptime,level"
 
 ARGS=""
 
@@ -99,7 +100,7 @@ else
   exit 1
 fi
 
-$RUNNER $ARGS $JVM_ARGS $JAVA_LIB_PATH -cp $CLASSPATH $MAIN_CLASS --conf "$SHUFFLE_SERVER_CONF_FILE" $@ &> $OUT_PATH &
+$RUNNER $ARGS $JVM_ARGS $JAVA11_EXTRA_ARGS $JAVA_LIB_PATH -cp $CLASSPATH $MAIN_CLASS --conf "$SHUFFLE_SERVER_CONF_FILE" $@ &> $OUT_PATH &
 
 get_pid_file_name shuffle-server
 echo $! >${RSS_PID_DIR}/${pid_file}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ignore unrecognized jvm options and use some gc options in jdk11 to replace that of jdk8

### Why are the changes needed?
When use jdk11, the startup scripts will fail 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Just use jdk11 & jdk8 to startup the scripts without any failure
