### PR TITLE
[#799] feat: use storage host label for remote storage write metrics

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HdfsStorageManager.java
@@ -131,8 +131,6 @@ public class HdfsStorageManager extends SingleStorageManager {
         }
       }
       HdfsStorage hdfsStorage = new HdfsStorage(remoteStorage, remoteStorageHadoopConf);
-      String storageHost = hdfsStorage.getStorageHost();
-      ShuffleServerMetrics.addDynamicCounterForRemoteStorage(storageHost);
       return hdfsStorage;
     });
     appIdToStorages.computeIfAbsent(appId, key -> pathToStorages.get(remoteStorage));

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -186,10 +186,10 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     storageManager.registerRemoteStorage(appId, remoteStorage);
     String storageHost = cluster.getURI().getHost();
-    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.get(storageHost).get(), 0.5);
-    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageRetryWrite.get(storageHost).get(), 0.5);
-    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageFailedWrite.get(storageHost).get(), 0.5);
-    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageSuccessWrite.get(storageHost).get(), 0.5);
+    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.labels(storageHost).get(), 0.5);
+    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageRetryWrite.labels(storageHost).get(), 0.5);
+    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageFailedWrite.labels(storageHost).get(), 0.5);
+    assertEquals(0.0, ShuffleServerMetrics.counterRemoteStorageSuccessWrite.labels(storageHost).get(), 0.5);
     ShuffleFlushManager manager =
         new ShuffleFlushManager(shuffleServerConf, mockShuffleServer, storageManager);
     ShuffleDataFlushEvent event1 =
@@ -214,8 +214,8 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
     validate(appId, 2, 2, blocks21, 1, remoteStorage.getPath());
     assertEquals(blocks21.size(), manager.getCommittedBlockIds(appId, 2).getLongCardinality());
 
-    assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.get(storageHost).get(), 0.5);
-    assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageSuccessWrite.get(storageHost).get(), 0.5);
+    assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageTotalWrite.labels(storageHost).get(), 0.5);
+    assertEquals(3.0, ShuffleServerMetrics.counterRemoteStorageSuccessWrite.labels(storageHost).get(), 0.5);
 
     // test case for process event whose related app was cleared already
     assertEquals(0, ShuffleServerMetrics.gaugeWriteHandler.get(), 0.5);


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. replace dynamic counter with counter with label

### Why are the changes needed?
Fix: #799 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs.