### PR TITLE
[#596] Use off heap memory to read HDFS data

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -17,13 +17,14 @@
 
 package org.apache.uniffle.common;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 
 public class ShuffleDataResult {
 
-  private final byte[] data;
+  private final ByteBuffer data;
   private final List<BufferSegment> bufferSegments;
 
   public ShuffleDataResult() {
@@ -35,11 +36,15 @@ public class ShuffleDataResult {
   }
 
   public ShuffleDataResult(byte[] data, List<BufferSegment> bufferSegments) {
-    this.data = data;
+    this.data = ByteBuffer.wrap(data);
     this.bufferSegments = bufferSegments;
   }
 
   public byte[] getData() {
+    return data.array();
+  }
+
+  public ByteBuffer getDataBuffer() {
     return data;
   }
 
@@ -48,7 +53,7 @@ public class ShuffleDataResult {
   }
 
   public boolean isEmpty() {
-    return bufferSegments == null || bufferSegments.isEmpty() || data == null || data.length == 0;
+    return bufferSegments == null || bufferSegments.isEmpty() || data == null || data.capacity() == 0;
   }
 
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -31,6 +31,7 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -46,6 +47,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.unix.Errors;
 import org.eclipse.jetty.util.MultiException;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
@@ -363,5 +365,9 @@ public class RssUtils {
     } else {
       return conf.get(RssBaseConf.RSS_STORAGE_BASE_PATH);
     }
+  }
+
+  public static boolean releaseByteBuffer(ByteBuffer byteBuffer) {
+    return Unpooled.wrappedBuffer(byteBuffer).release();
   }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/api/FileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/api/FileReader.java
@@ -17,9 +17,15 @@
 
 package org.apache.uniffle.storage.api;
 
+import java.nio.ByteBuffer;
+
 public interface FileReader {
 
   byte[] read(long offset, int length);
 
   byte[] read();
+
+  ByteBuffer readByteBuffer(long offset, int length);
+
+  ByteBuffer readByteBuffer();
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsFileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsFileReader.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.storage.handler.impl;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -77,6 +78,34 @@ public class HdfsFileReader implements FileReader, Closeable {
       LOG.error("Fail to read all data from {}", path, e);
       return new byte[0];
     }
+  }
+
+  @Override
+  public ByteBuffer readByteBuffer(long offset, int length) {
+    try {
+      fsDataInputStream.seek(offset);
+      ByteBuffer buffer = ByteBuffer.allocateDirect(length);
+      readFully(buffer);
+      buffer.flip();
+      return buffer;
+    } catch (Exception e) {
+      LOG.warn("Can't read buffer data for path:" + path + " with offset[" + offset + "], length[" + length + "]", e);
+      return ByteBuffer.allocateDirect(0);
+    }
+  }
+
+  private void readFully(ByteBuffer buffer) throws IOException {
+    while (buffer.hasRemaining()) {
+      int result = fsDataInputStream.read(buffer);
+      if (result < 0) {
+        return;
+      }
+    }
+  }
+
+  @Override
+  public ByteBuffer readByteBuffer() {
+    return null;
   }
 
   public long getOffset() throws IOException {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HdfsShuffleReadHandler.java
@@ -168,7 +168,4 @@ public class HdfsShuffleReadHandler extends DataSkippableReadHandler {
     return shuffleDataSegments;
   }
 
-  public String getFilePrefix() {
-    return filePrefix;
-  }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileReader.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -74,6 +75,16 @@ public class LocalFileReader implements FileReader, Closeable {
       LOG.error("Fail to read all data from {}", path, e);
       return new byte[0];
     }
+  }
+
+  @Override
+  public ByteBuffer readByteBuffer(long offset, int length) {
+    throw new UnsupportedOperationException("Local file reader don't support off heap read now");
+  }
+
+  @Override
+  public ByteBuffer readByteBuffer() {
+    throw new UnsupportedOperationException("Local file reader don't support off heap read now");
   }
 
   @Override

--- a/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/util/ShuffleStorageUtils.java
@@ -120,14 +120,6 @@ public class ShuffleStorageUtils {
         String.join(HDFS_DIRNAME_SEPARATOR, String.valueOf(start), String.valueOf(end)));
   }
 
-  public static String getUploadShuffleDataPath(String appId, int shuffleId, int partitionId) {
-    return String.join(
-        HDFS_PATH_SEPARATOR,
-        appId,
-        String.valueOf(shuffleId),
-        String.valueOf(partitionId));
-  }
-
   public static String getCombineDataPath(String appId, int shuffleId) {
     return String.join(
         HDFS_PATH_SEPARATOR,
@@ -193,10 +185,6 @@ public class ShuffleStorageUtils {
     }
   }
 
-  // index file header is $PartitionNum | [($PartitionId | $PartitionFileLength | $PartitionDataFileLength), ] | $CRC
-  public static long getIndexFileHeaderLen(int partitionNum) {
-    return 4 + (4 + 8 + 8) * (long) partitionNum + 8;
-  }
 
   public static long uploadFile(File file, HdfsFileWriter writer, int bufferSize) throws IOException {
     try (FileInputStream inputStream = new FileInputStream(file)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use off heap memory to read HDFS data

### Why are the changes needed?
Fix: #596 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass origin tests.
