### PR TITLE
[MINOR] chore: update import order rule to make scala a separated group

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -270,14 +270,13 @@
         -->
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-             <!-- new add -->
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="specialImportsRegExp" value="^org\.apache\.uniffle"/>
-            <property name="standardPackageRegExp" value="^java\.|^javax\."/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
-            <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+        <module name="ImportOrder">
+            <property name="groups" value="/^javax?\./,scala,/(?!org\.apache\.uniffle\.)/,/org\.apache\.uniffle\./"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="separatedStaticGroups" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
         <module name="MethodParamPad">
             <property name="tokens"

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -19,13 +19,14 @@ package org.apache.spark.shuffle;
 
 import java.util.Set;
 
+import scala.Tuple2;
+import scala.runtime.AbstractFunction1;
+
 import com.google.common.collect.ImmutableSet;
 import org.apache.spark.SparkConf;
 import org.apache.spark.internal.config.ConfigBuilder;
 import org.apache.spark.internal.config.ConfigEntry;
 import org.apache.spark.internal.config.TypedConfigBuilder;
-import scala.Tuple2;
-import scala.runtime.AbstractFunction1;
 
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.config.ConfigOption;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -25,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import scala.Option;
+import scala.reflect.ClassTag;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
@@ -34,8 +37,6 @@ import org.apache.spark.deploy.SparkHadoopUtil;
 import org.apache.spark.storage.BlockManagerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
-import scala.reflect.ClassTag;
 
 import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.factory.CoordinatorClientFactory;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssFetchFailedIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssFetchFailedIterator.java
@@ -20,13 +20,14 @@ package org.apache.spark.shuffle.reader;
 import java.io.IOException;
 import java.util.Objects;
 
+import scala.Product2;
+import scala.collection.AbstractIterator;
+import scala.collection.Iterator;
+
 import org.apache.spark.shuffle.FetchFailedException;
 import org.apache.spark.shuffle.RssSparkShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Product2;
-import scala.collection.AbstractIterator;
-import scala.collection.Iterator;
 
 import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -20,6 +20,12 @@ package org.apache.spark.shuffle.reader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import scala.Product2;
+import scala.Tuple2;
+import scala.collection.AbstractIterator;
+import scala.collection.Iterator;
+import scala.runtime.BoxedUnit;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
@@ -30,11 +36,6 @@ import org.apache.spark.serializer.SerializerInstance;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Product2;
-import scala.Tuple2;
-import scala.collection.AbstractIterator;
-import scala.collection.Iterator;
-import scala.runtime.BoxedUnit;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -28,6 +28,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import scala.reflect.ClassTag$;
+import scala.reflect.ManifestFactory$;
+
 import com.clearspring.analytics.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
@@ -41,8 +44,6 @@ import org.apache.spark.serializer.SerializerInstance;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.reflect.ClassTag$;
-import scala.reflect.ManifestFactory$;
 
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.ShuffleBlockInfo;

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -22,6 +22,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import scala.Product2;
+import scala.collection.Iterator;
+import scala.reflect.ClassTag$;
+
 import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -29,9 +33,6 @@ import org.apache.spark.serializer.SerializationStream;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.serializer.SerializerInstance;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import scala.Product2;
-import scala.collection.Iterator;
-import scala.reflect.ClassTag$;
 
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.ShufflePartitionedBlock;

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.spark.shuffle.writer;
 
+import scala.reflect.ClassTag$;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.SerializationStream;
 import org.apache.spark.serializer.Serializer;
 import org.junit.jupiter.api.Test;
-import scala.reflect.ClassTag$;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -27,6 +27,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.collection.Seq;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -48,10 +53,6 @@ import org.apache.spark.storage.BlockManagerId;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
-import scala.Tuple2;
-import scala.collection.Iterator;
-import scala.collection.Seq;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -19,6 +19,13 @@ package org.apache.spark.shuffle.reader;
 
 import java.util.List;
 
+import scala.Function0;
+import scala.Option;
+import scala.Product2;
+import scala.collection.Iterator;
+import scala.runtime.AbstractFunction0;
+import scala.runtime.BoxedUnit;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.InterruptibleIterator;
 import org.apache.spark.ShuffleDependency;
@@ -35,12 +42,6 @@ import org.apache.spark.util.collection.ExternalSorter;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Function0;
-import scala.Option;
-import scala.Product2;
-import scala.collection.Iterator;
-import scala.runtime.AbstractFunction0;
-import scala.runtime.BoxedUnit;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -27,6 +27,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import scala.Function1;
+import scala.Option;
+import scala.Product2;
+import scala.collection.Iterator;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -45,10 +50,6 @@ import org.apache.spark.shuffle.ShuffleWriter;
 import org.apache.spark.storage.BlockManagerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Function1;
-import scala.Option;
-import scala.Product2;
-import scala.collection.Iterator;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.common.ShuffleBlockInfo;

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import scala.Option;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.spark.ShuffleDependency;
@@ -32,7 +34,6 @@ import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import scala.Option;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssConf;

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -25,6 +25,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import scala.Product2;
+import scala.Tuple2;
+import scala.collection.mutable.MutableList;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -41,9 +45,6 @@ import org.apache.spark.shuffle.RssShuffleHandle;
 import org.apache.spark.shuffle.RssShuffleManager;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.Test;
-import scala.Product2;
-import scala.Tuple2;
-import scala.collection.mutable.MutableList;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.common.ShuffleBlockInfo;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -30,6 +30,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import scala.Tuple2;
+import scala.Tuple3;
+import scala.collection.Iterator;
+import scala.collection.Seq;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -55,10 +60,6 @@ import org.apache.spark.storage.BlockManagerId;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Tuple2;
-import scala.Tuple3;
-import scala.collection.Iterator;
-import scala.collection.Seq;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -20,6 +20,16 @@ package org.apache.spark.shuffle.reader;
 import java.util.List;
 import java.util.Map;
 
+import scala.Function0;
+import scala.Function1;
+import scala.Option;
+import scala.Product2;
+import scala.collection.AbstractIterator;
+import scala.collection.Iterator;
+import scala.runtime.AbstractFunction0;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxedUnit;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -36,15 +46,6 @@ import org.apache.spark.util.collection.ExternalSorter;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Function0;
-import scala.Function1;
-import scala.Option;
-import scala.Product2;
-import scala.collection.AbstractIterator;
-import scala.collection.Iterator;
-import scala.runtime.AbstractFunction0;
-import scala.runtime.AbstractFunction1;
-import scala.runtime.BoxedUnit;
 
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -28,6 +28,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import scala.Function1;
+import scala.Option;
+import scala.Product2;
+import scala.collection.Iterator;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -45,10 +50,6 @@ import org.apache.spark.shuffle.ShuffleWriter;
 import org.apache.spark.storage.BlockManagerId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Function1;
-import scala.Option;
-import scala.Product2;
-import scala.collection.Iterator;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.common.ShuffleBlockInfo;

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import scala.Option;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.spark.ShuffleDependency;
@@ -33,7 +35,6 @@ import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import scala.Option;
 
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -26,6 +26,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import scala.Product2;
+import scala.Tuple2;
+import scala.collection.mutable.MutableList;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -44,9 +48,6 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.TestUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import scala.Product2;
-import scala.Tuple2;
-import scala.collection.mutable.MutableList;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.common.ShuffleBlockInfo;

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/CombineByKeyTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/CombineByKeyTest.java
@@ -19,11 +19,12 @@ package org.apache.uniffle.test;
 
 import java.util.Map;
 
+import scala.Tuple2;
+
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 public class CombineByKeyTest extends SimpleTestBase {
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/GroupByKeyTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/GroupByKeyTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.uniffle.test;
 
-
 import java.util.Map;
+
+import scala.Tuple2;
 
 import com.google.common.collect.Lists;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 public class GroupByKeyTest extends SimpleTestBase {
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/NullOfKeyOrValueTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/NullOfKeyOrValueTest.java
@@ -19,12 +19,13 @@ package org.apache.uniffle.test;
 
 import java.util.Map;
 
+import scala.Tuple2;
+
 import com.google.common.collect.Lists;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 /**
  * This class is to test whether the RSS keep consistent with the vanilla spark shuffle when

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
 
+import scala.Tuple2;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -33,7 +35,6 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Tuple2;
 
 public abstract class RepartitionTest extends SparkIntegrationTestBase {
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import scala.Option;
+
 import com.google.common.collect.Maps;
 import org.apache.spark.MapOutputTrackerMaster;
 import org.apache.spark.SparkConf;
@@ -31,7 +33,6 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.Option;
 
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.coordinator.CoordinatorConf;

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHdfsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHdfsTest.java
@@ -19,6 +19,8 @@ package org.apache.uniffle.test;
 
 import java.util.Map;
 
+import scala.Tuple2;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.fs.Path;
@@ -29,7 +31,6 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
@@ -20,6 +20,8 @@ package org.apache.uniffle.test;
 import java.io.File;
 import java.util.Map;
 
+import scala.Tuple2;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.spark.SparkConf;
@@ -29,7 +31,6 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.coordinator.CoordinatorConf;

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkIntegrationTestBase.java
@@ -20,13 +20,14 @@ package org.apache.uniffle.test;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import scala.Option;
+
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/TestUtils.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/TestUtils.java
@@ -20,13 +20,14 @@ package org.apache.uniffle.test;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import scala.Tuple2;
+
 import com.google.common.collect.Lists;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-import scala.Tuple2;
 
 public class TestUtils {
   private TestUtils() {

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/WriteAndReadMetricsTest.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import scala.collection.Seq;
+
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -30,7 +32,6 @@ import org.apache.spark.sql.functions;
 import org.apache.spark.status.AppStatusStore;
 import org.apache.spark.status.api.v1.StageData;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq;
 
 public class WriteAndReadMetricsTest extends SimpleTestBase {
 

--- a/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -22,6 +22,8 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import scala.Tuple2;
+
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -37,7 +39,6 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.reader.RssShuffleReader;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.util.Constants;

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQERepartitionTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQERepartitionTest.java
@@ -21,6 +21,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import scala.collection.JavaConverters;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.spark.SparkConf;
@@ -31,7 +33,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.collection.JavaConverters;
 
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -23,6 +23,11 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.Seq;
+import scala.collection.immutable.Map;
+
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -47,10 +52,6 @@ import org.apache.spark.util.AccumulatorV2;
 import org.apache.spark.util.TaskCompletionListener;
 import org.apache.spark.util.TaskFailureListener;
 import org.junit.jupiter.api.Test;
-import scala.Option;
-import scala.Tuple2;
-import scala.collection.Seq;
-import scala.collection.immutable.Map;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.util.Constants;


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. update checkstyle.xml to make scala a separated import group
2. modify java files accordingly

### Why are the changes needed?
Better code style

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need. There's no semantics change.