### PR TITLE
[MINOR][0.7] Avoid returning null in defaultUserApps when quota file does't config user 

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
@@ -117,7 +117,7 @@ public class QuotaManager {
 
   public boolean checkQuota(String user, String uuid) {
     Map<String, Long> appAndTimes = currentUserAndApp.computeIfAbsent(user, x -> Maps.newConcurrentMap());
-    Integer defaultAppNum = defaultUserApps.getOrDefault(user, quotaAppNum);
+    Integer defaultAppNum = defaultUserApps.computeIfAbsent(user, x -> quotaAppNum);
     synchronized (this) {
       int currentAppNum = appAndTimes.size();
       if (currentAppNum >= defaultAppNum) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
`map.getOrDefault()` => `map.computeIfAbsent()`


### Why are the changes needed?
If do not define the user and app num  in the quota configuration file, it will appear that the `defaultUserApps` does not have the corresponding app number for this user, because we did not include the `quotaAppNum` in the `defaultUserApps`. 

**before** :
The log from coordinator is `[ERROR] 2023-03-28 19:24:11,18 Grpc-260 AccessAppQuotaChecker check - Denied by AccessAppQuotaChecker => User: xxxx, current app num is: 3, default app num is: null.`

**after** :
The log from coordinator is `[ERROR] 2023-03-31 14:32:21,228 Grpc-240 AccessAppQuotaChecker check - Denied by AccessAppQuotaChecker => User: xxxx, current app num is: 3, default app num is: 3.`


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Origin uts.
