### PR TITLE
[MINOR] Remove unused config `SHUFFLE_EXPIRED_TIMEOUT_MS`

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageHdfsFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageHdfsFallbackTest.java
@@ -40,7 +40,6 @@ public class MultiStorageHdfsFallbackTest extends MultiStorageFaultToleranceBase
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
     shuffleServerConf.setLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC, 30L);
-    shuffleServerConf.setLong(ShuffleServerConf.SHUFFLE_EXPIRED_TIMEOUT_MS, 5000L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 60L * 1000L * 60L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
     shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE_HDFS.name());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageLocalFileFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/MultiStorageLocalFileFallbackTest.java
@@ -43,7 +43,6 @@ public class MultiStorageLocalFileFallbackTest extends MultiStorageFaultToleranc
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
     shuffleServerConf.setLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC, 30L);
-    shuffleServerConf.setLong(ShuffleServerConf.SHUFFLE_EXPIRED_TIMEOUT_MS, 5000L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 60L * 1000L * 60L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
     shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE_HDFS.name());

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -201,14 +201,6 @@ public class ShuffleServerConf extends RssBaseConf {
           .withDescription("The maximum ratio of disk that could be used as shuffle server. This is only effective "
               + "when `rss.server.disk.capacity` is not explicitly set");
 
-  public static final ConfigOption<Long> SHUFFLE_EXPIRED_TIMEOUT_MS = ConfigOptions
-      .key("rss.server.shuffle.expired.timeout.ms")
-      .longType()
-      .checkValue(ConfigUtils.POSITIVE_LONG_VALIDATOR, "shuffle expired timeout must be positive")
-      .defaultValue(60L * 1000 * 2)
-      .withDescription("If the shuffle is not read for the long time, and shuffle is uploaded totally,"
-          + " , we can delete the shuffle");
-
   public static final ConfigOption<Long> SERVER_SHUFFLE_INDEX_SIZE_HINT = ConfigOptions
       .key("rss.server.index.size.hint")
       .longType()


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Remove unused config `SHUFFLE_EXPIRED_TIMEOUT_MS`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need.
