### PR TITLE
[#841] feat(config): Support deprecated and fallback keys for ConfigOptions

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/FallbackKey.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/FallbackKey.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.config;
+
+/** A key with FallbackKeys will fall back to the FallbackKeys if it itself is not configured. */
+public class FallbackKey {
+
+  // -------------------------
+  //  Factory methods
+  // -------------------------
+
+  static FallbackKey createFallbackKey(String key) {
+    return new FallbackKey(key, false);
+  }
+
+  static FallbackKey createDeprecatedKey(String key) {
+    return new FallbackKey(key, true);
+  }
+
+  // ------------------------------------------------------------------------
+
+  private final String key;
+
+  private final boolean isDeprecated;
+
+  public String getKey() {
+    return key;
+  }
+
+  public boolean isDeprecated() {
+    return isDeprecated;
+  }
+
+  private FallbackKey(String key, boolean isDeprecated) {
+    this.key = key;
+    this.isDeprecated = isDeprecated;
+  }
+
+  // ------------------------------------------------------------------------
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (o != null && o.getClass() == FallbackKey.class) {
+      FallbackKey that = (FallbackKey) o;
+      return this.key.equals(that.key) && (this.isDeprecated == that.isDeprecated);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * key.hashCode() + (isDeprecated ? 1 : 0);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("{key=%s, isDeprecated=%s}", key, isDeprecated);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/config/FallbackKey.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/FallbackKey.java
@@ -52,25 +52,6 @@ public class FallbackKey {
     this.isDeprecated = isDeprecated;
   }
 
-  // ------------------------------------------------------------------------
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    } else if (o != null && o.getClass() == FallbackKey.class) {
-      FallbackKey that = (FallbackKey) o;
-      return this.key.equals(that.key) && (this.isDeprecated == that.isDeprecated);
-    } else {
-      return false;
-    }
-  }
-
-  @Override
-  public int hashCode() {
-    return 31 * key.hashCode() + (isDeprecated ? 1 : 0);
-  }
-
   @Override
   public String toString() {
     return String.format("{key=%s, isDeprecated=%s}", key, isDeprecated);

--- a/common/src/main/java/org/apache/uniffle/common/config/RssConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssConf.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.common.config;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -569,8 +570,23 @@ public class RssConf implements Cloneable {
         .orElseGet(option::defaultValue);
   }
 
+  private Optional<Object> geRawValFromFallbackKeys(Iterator<FallbackKey> iter) {
+    if (iter.hasNext()) {
+      FallbackKey key = iter.next();
+      Optional<Object> rawVal = getRawValue(key.getKey());
+      if (!rawVal.isPresent()) {
+        return geRawValFromFallbackKeys(iter);
+      }
+      return rawVal;
+    }
+    return Optional.empty();
+  }
+
   public <T> Optional<T> getOptional(ConfigOption<T> option) {
     Optional<Object> rawValue = getRawValueFromOption(option);
+    if (!rawValue.isPresent()) {
+      rawValue = geRawValFromFallbackKeys(option.fallbackKeys().iterator());
+    }
     Class<?> clazz = option.getClazz();
     Optional<T> value = rawValue.map(v -> option.convertValue(v, clazz));
     return value;

--- a/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
@@ -33,7 +33,75 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ConfigOptionTest {
 
   @Test
+  public void testDeprecatedAndFallbackKeys() {
+    final ConfigOption<Integer> intConfig = ConfigOptions
+        .key("rss.main.key")
+        .intType().defaultValue(100)
+        .withFallbackKeys("rss.fallback.key1")
+        .withDeprecatedKeys("rss.deprecated.key1");
+
+    // case1
+    RssConf conf = new RssBaseConf();
+    assertEquals(100, conf.get(intConfig));
+
+    // case2
+    conf = new RssBaseConf();
+    conf.setString("rss.fallback.key1", "12");
+    conf.setString("rss.deprecated.key1", "13");
+    assertEquals(12, conf.get(intConfig));
+
+    // case3
+    conf = new RssBaseConf();
+    conf.setString("rss.deprecated.key1", "13");
+    assertEquals(13, conf.get(intConfig));
+
+    // case4
+    conf = new RssBaseConf();
+    conf.setString("rss.fallback.key1", "12");
+    assertEquals(12, conf.get(intConfig));
+
+    // case5
+    conf = new RssBaseConf();
+    conf.setString(intConfig.key(), "999");
+    conf.setString("rss.fallback.key1", "12");
+    conf.setString("rss.deprecated.key1", "13");
+    assertEquals(999, conf.get(intConfig));
+  }
+
+  @Test
   public void testFallbackKeys() {
+    final ConfigOption<Integer> config1 = ConfigOptions
+        .key("rss.key.1")
+        .intType()
+        .defaultValue(1);
+
+    final ConfigOption<Integer> config2 = ConfigOptions
+        .key("rss.key.2")
+        .intType()
+        .defaultValue(2);
+
+    final ConfigOption<Integer> config3 = ConfigOptions
+        .key("rss.key.3")
+        .intType()
+        .defaultValue(9999)
+        .withFallbackKeys(config1.key(), config2.key());
+
+    // case1
+    RssConf conf = new RssBaseConf();
+    conf.setString(config1.key(), "10");
+    assertEquals(10, conf.get(config3));
+
+    // case2
+    conf.setString(config3.key(), "1111");
+    assertEquals(1111, conf.get(config3));
+
+    // case3
+    conf = new RssBaseConf();
+    assertEquals(9999, conf.get(config3));
+  }
+
+  @Test
+  public void testDeprecatedKeys() {
     final ConfigOption<Integer> intConfig = ConfigOptions
         .key("rss.key")
         .intType()
@@ -64,6 +132,10 @@ public class ConfigOptionTest {
     conf.setString(intConfig.key(), "25");
     conf.setString("rss.s3", "3");
     assertEquals(25, conf.get(intConfig));
+
+    // case 5
+    conf = new RssBaseConf();
+    assertEquals(100, conf.get(intConfig));
   }
 
   @Test

--- a/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/config/ConfigOptionTest.java
@@ -33,6 +33,40 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ConfigOptionTest {
 
   @Test
+  public void testFallbackKeys() {
+    final ConfigOption<Integer> intConfig = ConfigOptions
+        .key("rss.key")
+        .intType()
+        .defaultValue(100)
+        .withDeprecatedKeys("rss.s1", "rss.s2", "rss.s3");
+
+    // case 1
+    RssConf conf = new RssBaseConf();
+    conf.setString("rss.s1", "10");
+    int val = conf.get(intConfig);
+    assertEquals(10, val);
+
+    // case 2
+    conf = new RssBaseConf();
+    conf.setString("rss.s1", "1");
+    conf.setString("rss.s2", "2");
+    conf.setString("rss.s3", "3");
+    assertEquals(1, conf.get(intConfig));
+
+    // case 3
+    conf = new RssBaseConf();
+    conf.setString("rss.s3", "3");
+    conf.setString("rss.s2", "2");
+    assertEquals(2, conf.get(intConfig));
+
+    // case 4
+    conf = new RssBaseConf();
+    conf.setString(intConfig.key(), "25");
+    conf.setString("rss.s3", "3");
+    assertEquals(25, conf.get(intConfig));
+  }
+
+  @Test
   public void testSetKVWithStringTypeDirectly() {
     final ConfigOption<Integer> intConfig = ConfigOptions
             .key("rss.key1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support deprecated and fallback keys for ConfigOptions

### Why are the changes needed?

#841 . To achieve better compatibility, it's time to support deprecated keys for ConfigOptions .

After this PR, the configOption will have the fallback and deprecated keys. Like this

```java
    final ConfigOption<Integer> intConfig = ConfigOptions
        .key("rss.main.key")
        .intType()
        .defaultValue(100)
        .withFallbackKeys("rss.fallback.key1")
        .withDeprecatedKeys("rss.deprecated.key1");
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Existing UTs
2. Newly UTs