### PR TITLE
[#808] feat(spark): ensure thread safe and data consistency when spilling

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -57,11 +57,12 @@ public class RssSparkConfig {
           .defaultValue(true)
           .withDescription("indicates row based shuffle, set false when use in columnar shuffle");
 
-  public static final ConfigOption<Boolean> RSS_MEMORY_SPILL_ENABLED = ConfigOptions
-      .key("rss.client.memory.spill.enabled")
-      .booleanType()
-      .defaultValue(false)
-      .withDescription("The memory spill switch triggered by Spark TaskMemoryManager, default value is false.");
+  public static final ConfigOption<Boolean> RSS_MEMORY_SPILL_ENABLED =
+      ConfigOptions.key("rss.client.memory.spill.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "The memory spill switch triggered by Spark TaskMemoryManager, default value is false.");
 
   public static final String SPARK_RSS_CONFIG_PREFIX = "spark.";
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -57,6 +57,12 @@ public class RssSparkConfig {
           .defaultValue(true)
           .withDescription("indicates row based shuffle, set false when use in columnar shuffle");
 
+  public static final ConfigOption<Boolean> RSS_MEMORY_SPILL_ENABLED = ConfigOptions
+      .key("rss.client.memory.spill.enabled")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("The memory spill switch triggered by Spark TaskMemoryManager, default value is false.");
+
   public static final String SPARK_RSS_CONFIG_PREFIX = "spark.";
 
   public static final ConfigEntry<Integer> RSS_PARTITION_NUM_PER_RANGE =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
@@ -87,8 +89,9 @@ public class WriteBufferManager extends MemoryConsumer {
   private long requireMemoryInterval;
   private int requireMemoryRetryMax;
   private Codec codec;
-  private Function<AddBlockEvent, CompletableFuture<Long>> spillFunc;
+  private Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc;
   private long sendSizeLimit;
+  private boolean memorySpillEnabled;
   private int memorySpillTimeoutSec;
   private boolean isRowBased;
 
@@ -124,7 +127,7 @@ public class WriteBufferManager extends MemoryConsumer {
       TaskMemoryManager taskMemoryManager,
       ShuffleWriteMetrics shuffleWriteMetrics,
       RssConf rssConf,
-      Function<AddBlockEvent, CompletableFuture<Long>> spillFunc) {
+      Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc) {
     super(taskMemoryManager, taskMemoryManager.pageSizeBytes(), MemoryMode.ON_HEAP);
     this.bufferSize = bufferManagerOptions.getBufferSize();
     this.spillSize = bufferManagerOptions.getBufferSpillThreshold();
@@ -155,6 +158,7 @@ public class WriteBufferManager extends MemoryConsumer {
     this.spillFunc = spillFunc;
     this.sendSizeLimit = rssConf.get(RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMITATION);
     this.memorySpillTimeoutSec = rssConf.get(RssSparkConfig.RSS_MEMORY_SPILL_TIMEOUT);
+    this.memorySpillEnabled = rssConf.get(RssSparkConfig.RSS_MEMORY_SPILL_ENABLED);
   }
 
   /** add serialized columnar data directly when integrate with gluten */
@@ -165,41 +169,69 @@ public class WriteBufferManager extends MemoryConsumer {
 
   public List<ShuffleBlockInfo> addPartitionData(
       int partitionId, byte[] serializedData, int serializedDataLength, long start) {
-    List<ShuffleBlockInfo> result = Lists.newArrayList();
+    List<ShuffleBlockInfo> candidateSendingBlocks = insertIntoBuffer(partitionId, serializedData, serializedDataLength);
+
+    // check buffer size > spill threshold
+    if (usedBytes.get() - inSendListBytes.get() > spillSize) {
+      candidateSendingBlocks.addAll(clear());
+    }
+    writeTime += System.currentTimeMillis() - start;
+    return candidateSendingBlocks;
+  }
+
+  /**
+   * Before inserting a record into its corresponding buffer, the system should check if there is
+   * sufficient buffer memory available. If there isn't enough memory, it will request additional
+   * memory from the {@link TaskMemoryManager}. In the event that the JVM is low on memory,
+   * a spill operation will be triggered. If any memory consumer managed by the {@link TaskMemoryManager}
+   * fails to meet its memory requirements, it will also be triggered one by one.
+   *
+   * If the current buffer manager requests memory and triggers a spill operation,
+   * the buffer that is currently being held should be dropped, and then re-inserted.
+   */
+  private List<ShuffleBlockInfo> insertIntoBuffer(int partitionId, byte[] serializedData, int serializedDataLength) {
+    List<ShuffleBlockInfo> sentBlocks = new ArrayList<>();
+    long required = Math.max(bufferSegmentSize, serializedDataLength);
+    // Asking memory from task memory manager for the existing writer buffer,
+    // this may trigger current WriteBufferManager spill method, which will
+    // make the current write buffer discard. So we have to recheck the buffer existence.
+    boolean hasRequested = false;
     if (buffers.containsKey(partitionId)) {
       WriterBuffer wb = buffers.get(partitionId);
       if (wb.askForMemory(serializedDataLength)) {
-        requestMemory(Math.max(bufferSegmentSize, serializedDataLength));
+        requestMemory(required);
+        hasRequested = true;
       }
+    }
+
+    if (buffers.containsKey(partitionId)) {
+      if (hasRequested) {
+        usedBytes.addAndGet(required);
+      }
+      WriterBuffer wb = buffers.get(partitionId);
       wb.addRecord(serializedData, serializedDataLength);
       if (wb.getMemoryUsed() > bufferSize) {
-        result.add(createShuffleBlock(partitionId, wb));
+        sentBlocks.add(createShuffleBlock(partitionId, wb));
         copyTime += wb.getCopyTime();
         buffers.remove(partitionId);
-        LOG.debug(
-            "Single buffer is full for shuffleId["
-                + shuffleId
-                + "] partition["
-                + partitionId
-                + "] with memoryUsed["
-                + wb.getMemoryUsed()
-                + "], dataLength["
-                + wb.getDataLength()
-                + "]");
+        LOG.debug("Single buffer is full for shuffleId[" + shuffleId
+            + "] partition[" + partitionId + "] with memoryUsed[" + wb.getMemoryUsed()
+            + "], dataLength[" + wb.getDataLength() + "]");
       }
     } else {
-      requestMemory(Math.max(bufferSegmentSize, serializedDataLength));
+      // The true of hasRequested means the former partitioned buffer has been flushed, that is
+      // triggered by the spill operation caused by asking for memory. So it needn't to re-request
+      // the memory.
+      if (!hasRequested) {
+        requestMemory(required);
+      }
+      usedBytes.addAndGet(required);
+
       WriterBuffer wb = new WriterBuffer(bufferSegmentSize);
       wb.addRecord(serializedData, serializedDataLength);
       buffers.put(partitionId, wb);
     }
-
-    // check buffer size > spill threshold
-    if (usedBytes.get() - inSendListBytes.get() > spillSize) {
-      result.addAll(clear());
-    }
-    writeTime += System.currentTimeMillis() - start;
-    return result;
+    return sentBlocks;
   }
 
   public List<ShuffleBlockInfo> addRecord(int partitionId, Object key, Object value) {
@@ -304,7 +336,6 @@ public class WriteBufferManager extends MemoryConsumer {
     if (allocatedBytes.get() - usedBytes.get() < requiredMem) {
       requestExecutorMemory(requiredMem);
     }
-    usedBytes.addAndGet(requiredMem);
     requireMemoryTime += System.currentTimeMillis() - start;
   }
 
@@ -395,7 +426,31 @@ public class WriteBufferManager extends MemoryConsumer {
 
   @Override
   public long spill(long size, MemoryConsumer trigger) {
-    return 0L;
+    // Only for the MemoryConsumer of this instance, it will flush buffer
+    if (!memorySpillEnabled || trigger != this) {
+      return 0L;
+    }
+
+    List<CompletableFuture<Long>> futures = spillFunc.apply(clear());
+    CompletableFuture<Void> allOfFutures =
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
+    try {
+      allOfFutures.get(memorySpillTimeoutSec, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // A best effort strategy to wait.
+      // If timeout exception occurs, the underlying tasks won't be cancelled.
+    } finally {
+      long releasedSize = futures.stream().filter(x -> x.isDone()).mapToLong(x -> {
+        try {
+          return x.get();
+        } catch (Exception e) {
+          return 0;
+        }
+      }).sum();
+      LOG.info("[taskId: {}] Spill triggered by own, released memory size: {}",
+          taskId, releasedSize);
+      return releasedSize;
+    }
   }
 
   @VisibleForTesting
@@ -470,7 +525,7 @@ public class WriteBufferManager extends MemoryConsumer {
   }
 
   @VisibleForTesting
-  public void setSpillFunc(Function<AddBlockEvent, CompletableFuture<Long>> spillFunc) {
+  public void setSpillFunc(Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc) {
     this.spillFunc = spillFunc;
   }
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -279,10 +279,18 @@ public class WriteBufferManagerTest {
     TaskMemoryManager mockTaskMemoryManager = mock(TaskMemoryManager.class);
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
 
-    WriteBufferManager wbm = new WriteBufferManager(
-        0, "taskId_spillByOthersTest", 0, bufferOptions, new KryoSerializer(conf),
-        Maps.newHashMap(), mockTaskMemoryManager, new ShuffleWriteMetrics(),
-        RssSparkConfig.toRssConf(conf), null);
+    WriteBufferManager wbm =
+        new WriteBufferManager(
+            0,
+            "taskId_spillByOthersTest",
+            0,
+            bufferOptions,
+            new KryoSerializer(conf),
+            Maps.newHashMap(),
+            mockTaskMemoryManager,
+            new ShuffleWriteMetrics(),
+            RssSparkConfig.toRssConf(conf),
+            null);
 
     WriteBufferManager spyManager = spy(wbm);
     doReturn(512L).when(spyManager).acquireMemory(anyLong());
@@ -304,20 +312,29 @@ public class WriteBufferManagerTest {
     TaskMemoryManager mockTaskMemoryManager = mock(TaskMemoryManager.class);
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
 
-    WriteBufferManager wbm = new WriteBufferManager(
-        0, "taskId_spillTest", 0, bufferOptions, new KryoSerializer(conf),
-        Maps.newHashMap(), mockTaskMemoryManager, new ShuffleWriteMetrics(),
-        RssSparkConfig.toRssConf(conf), null);
+    WriteBufferManager wbm =
+        new WriteBufferManager(
+            0,
+            "taskId_spillTest",
+            0,
+            bufferOptions,
+            new KryoSerializer(conf),
+            Maps.newHashMap(),
+            mockTaskMemoryManager,
+            new ShuffleWriteMetrics(),
+            RssSparkConfig.toRssConf(conf),
+            null);
 
-    Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc = blocks -> {
-      long sum = 0L;
-      List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
-      for (AddBlockEvent event : events) {
-        event.getProcessedCallbackChain().stream().forEach(x -> x.run());
-        sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
-      }
-      return Arrays.asList(CompletableFuture.completedFuture(sum));
-    };
+    Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc =
+        blocks -> {
+          long sum = 0L;
+          List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
+          for (AddBlockEvent event : events) {
+            event.getProcessedCallbackChain().stream().forEach(x -> x.run());
+            sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
+          }
+          return Arrays.asList(CompletableFuture.completedFuture(sum));
+        };
     wbm.setSpillFunc(spillFunc);
 
     WriteBufferManager spyManager = spy(wbm);
@@ -339,23 +356,30 @@ public class WriteBufferManagerTest {
     spyManager.setSendSizeLimit(30);
     spyManager.addRecord(0, testKey, testValue);
     spyManager.addRecord(1, testKey, testValue);
-    spillFunc = shuffleBlockInfos -> Arrays.asList(CompletableFuture.supplyAsync(() -> {
-      List<AddBlockEvent> events = spyManager.buildBlockEvents(shuffleBlockInfos);
-      long sum = 0L;
-      for (AddBlockEvent event : events) {
-        int partitionId = event.getShuffleDataInfoList().get(0).getPartitionId();
-        if (partitionId == 1) {
-          try {
-            Thread.sleep(2000);
-          } catch (InterruptedException interruptedException) {
-            // ignore.
-          }
-        }
-        event.getProcessedCallbackChain().stream().forEach(x -> x.run());
-        sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
-      }
-      return sum;
-    }));
+    spillFunc =
+        shuffleBlockInfos ->
+            Arrays.asList(
+                CompletableFuture.supplyAsync(
+                    () -> {
+                      List<AddBlockEvent> events = spyManager.buildBlockEvents(shuffleBlockInfos);
+                      long sum = 0L;
+                      for (AddBlockEvent event : events) {
+                        int partitionId = event.getShuffleDataInfoList().get(0).getPartitionId();
+                        if (partitionId == 1) {
+                          try {
+                            Thread.sleep(2000);
+                          } catch (InterruptedException interruptedException) {
+                            // ignore.
+                          }
+                        }
+                        event.getProcessedCallbackChain().stream().forEach(x -> x.run());
+                        sum +=
+                            event.getShuffleDataInfoList().stream()
+                                .mapToLong(x -> x.getFreeMemory())
+                                .sum();
+                      }
+                      return sum;
+                    }));
     spyManager.setSpillFunc(spillFunc);
     releasedSize = spyManager.spill(1000, spyManager);
     assertEquals(0, releasedSize);
@@ -410,23 +434,32 @@ public class WriteBufferManagerTest {
     FakedTaskMemoryManager fakedTaskMemoryManager = new FakedTaskMemoryManager();
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
 
-    WriteBufferManager wbm = new WriteBufferManager(
-        0, "taskId_spillTest", 0, bufferOptions, new KryoSerializer(conf),
-        Maps.newHashMap(), fakedTaskMemoryManager, new ShuffleWriteMetrics(),
-        RssSparkConfig.toRssConf(conf), null);
+    WriteBufferManager wbm =
+        new WriteBufferManager(
+            0,
+            "taskId_spillTest",
+            0,
+            bufferOptions,
+            new KryoSerializer(conf),
+            Maps.newHashMap(),
+            fakedTaskMemoryManager,
+            new ShuffleWriteMetrics(),
+            RssSparkConfig.toRssConf(conf),
+            null);
 
     List<ShuffleBlockInfo> blockList = new ArrayList<>();
 
-    Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc = blocks -> {
-      blockList.addAll(blocks);
-      long sum = 0L;
-      List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
-      for (AddBlockEvent event : events) {
-        event.getProcessedCallbackChain().stream().forEach(x -> x.run());
-        sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
-      }
-      return Arrays.asList(CompletableFuture.completedFuture(sum));
-    };
+    Function<List<ShuffleBlockInfo>, List<CompletableFuture<Long>>> spillFunc =
+        blocks -> {
+          blockList.addAll(blocks);
+          long sum = 0L;
+          List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
+          for (AddBlockEvent event : events) {
+            event.getProcessedCallbackChain().stream().forEach(x -> x.run());
+            sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
+          }
+          return Arrays.asList(CompletableFuture.completedFuture(sum));
+        };
     wbm.setSpillFunc(spillFunc);
 
     WriteBufferManager spyManager = spy(wbm);
@@ -438,7 +471,8 @@ public class WriteBufferManagerTest {
     spyManager.addRecord(0, testKey, testValue);
     assertEquals(0, blockList.size());
 
-    // Second time, the memory manager trigger the spill, so it will flush buffer and then insert the record
+    // Second time, the memory manager trigger the spill, so it will flush buffer and then insert
+    // the record
     spyManager.addRecord(1, testKey, testValue);
     assertEquals(1, blockList.size());
     assertEquals(32, blockList.stream().mapToLong(x -> x.getFreeMemory()).sum());

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -44,10 +44,8 @@ import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.shuffle.reader.RssShuffleReader;
 import org.apache.spark.shuffle.writer.AddBlockEvent;
-import org.apache.spark.shuffle.writer.BufferManagerOptions;
 import org.apache.spark.shuffle.writer.DataPusher;
 import org.apache.spark.shuffle.writer.RssShuffleWriter;
-import org.apache.spark.shuffle.writer.WriteBufferManager;
 import org.apache.spark.storage.BlockId;
 import org.apache.spark.storage.BlockManagerId;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
@@ -418,33 +416,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
       int shuffleId = rssHandle.getShuffleId();
       String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
-      BufferManagerOptions bufferOptions = new BufferManagerOptions(sparkConf);
       ShuffleWriteMetrics writeMetrics = context.taskMetrics().shuffleWriteMetrics();
-      WriteBufferManager bufferManager =
-          new WriteBufferManager(
-              shuffleId,
-              taskId,
-              context.taskAttemptId(),
-              bufferOptions,
-              rssHandle.getDependency().serializer(),
-              rssHandle.getPartitionToServers(),
-              context.taskMemoryManager(),
-              writeMetrics,
-              RssSparkConfig.toRssConf(sparkConf),
-              this::sendData);
-
       return new RssShuffleWriter<>(
-          rssHandle.getAppId(),
-          shuffleId,
-          taskId,
-          context.taskAttemptId(),
-          bufferManager,
-          writeMetrics,
-          this,
-          sparkConf,
-          shuffleWriteClient,
-          rssHandle,
-          (Function<String, Boolean>) this::markFailedTask);
+          rssHandle.getAppId(), shuffleId, taskId, context.taskAttemptId(),
+          writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle,
+          this::markFailedTask, context);
     } else {
       throw new RssException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import scala.Option;
 import scala.Tuple2;
@@ -418,9 +417,17 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
       ShuffleWriteMetrics writeMetrics = context.taskMetrics().shuffleWriteMetrics();
       return new RssShuffleWriter<>(
-          rssHandle.getAppId(), shuffleId, taskId, context.taskAttemptId(),
-          writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle,
-          this::markFailedTask, context);
+          rssHandle.getAppId(),
+          shuffleId,
+          taskId,
+          context.taskAttemptId(),
+          writeMetrics,
+          this,
+          sparkConf,
+          shuffleWriteClient,
+          rssHandle,
+          this::markFailedTask,
+          context);
     } else {
       throw new RssException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -453,9 +453,18 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       writeMetrics = context.taskMetrics().shuffleWriteMetrics();
     }
     LOG.info("RssHandle appId {} shuffleId {} ", rssHandle.getAppId(), rssHandle.getShuffleId());
-    return new RssShuffleWriter<>(rssHandle.getAppId(), shuffleId, taskId, context.taskAttemptId(),
-        writeMetrics, this, sparkConf, shuffleWriteClient, rssHandle,
-        this::markFailedTask, context);
+    return new RssShuffleWriter<>(
+        rssHandle.getAppId(),
+        shuffleId,
+        taskId,
+        context.taskAttemptId(),
+        writeMetrics,
+        this,
+        sparkConf,
+        shuffleWriteClient,
+        rssHandle,
+        this::markFailedTask,
+        context);
   }
 
   public void setPusherAppId(RssShuffleHandle rssShuffleHandle) {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -18,7 +18,9 @@
 package org.apache.spark.shuffle.writer;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +38,6 @@ import com.google.common.collect.Sets;
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -79,8 +80,6 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
         .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
-    // init SparkContext
-    final SparkContext sc = SparkContext.getOrCreate(conf);
     Map<String, Set<Long>> failBlocks = JavaUtils.newConcurrentMap();
     Map<String, Set<Long>> successBlocks = JavaUtils.newConcurrentMap();
     Serializer kryoSerializer = new KryoSerializer(conf);
@@ -149,8 +148,6 @@ public class RssShuffleWriterTest {
     assertTrue(e3.getMessage().startsWith("Send failed:"));
     successBlocks.clear();
     failBlocks.clear();
-
-    sc.stop();
   }
 
   static class FakedDataPusher extends DataPusher {
@@ -185,6 +182,78 @@ public class RssShuffleWriterTest {
   }
 
   @Test
+  public void dataConsistencyWhenSpillTriggeredTest() throws Exception {
+    SparkConf conf = new SparkConf();
+    conf.set("spark.rss.client.memory.spill.enabled", "true");
+    conf.setAppName("dataConsistencyWhenSpillTriggeredTest_app").setMaster("local[2]")
+        .set(RssSparkConfig.RSS_WRITER_SERIALIZER_BUFFER_SIZE.key(), "32")
+        .set(RssSparkConfig.RSS_WRITER_BUFFER_SIZE.key(), "32")
+        .set(RssSparkConfig.RSS_WRITER_PRE_ALLOCATED_BUFFER_SIZE.key(), "32")
+        .set(RssSparkConfig.RSS_TEST_FLAG.key(), "true")
+        .set(RssSparkConfig.RSS_TEST_MODE_ENABLE.key(), "true")
+        .set(RssSparkConfig.RSS_WRITER_BUFFER_SEGMENT_SIZE.key(), "32")
+        .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
+        .set(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key(), "100000")
+        .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY.name())
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+
+    Map<String, Set<Long>> successBlockIds = Maps.newConcurrentMap();
+
+    List<Long> freeMemoryList = new ArrayList<>();
+    FakedDataPusher dataPusher = new FakedDataPusher(event -> {
+      event.getProcessedCallbackChain().stream().forEach(x -> x.run());
+      long sum = event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
+      freeMemoryList.add(sum);
+      successBlockIds.putIfAbsent(event.getTaskId(), new HashSet<>());
+      successBlockIds.get(event.getTaskId()).add(event.getShuffleDataInfoList().get(0).getBlockId());
+      return CompletableFuture.completedFuture(sum);
+    });
+
+    final RssShuffleManager manager = TestUtils.createShuffleManager(
+        conf,
+        false,
+        dataPusher,
+        successBlockIds,
+        JavaUtils.newConcurrentMap());
+
+    WriteBufferManagerTest.FakedTaskMemoryManager fakedTaskMemoryManager =
+        new WriteBufferManagerTest.FakedTaskMemoryManager();
+    BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
+    WriteBufferManager bufferManager = new WriteBufferManager(
+        0, "taskId", 0, bufferOptions, new KryoSerializer(conf),
+        Maps.newHashMap(), fakedTaskMemoryManager, new ShuffleWriteMetrics(),
+        RssSparkConfig.toRssConf(conf), null);
+
+    Serializer kryoSerializer = new KryoSerializer(conf);
+    Partitioner mockPartitioner = mock(Partitioner.class);
+    final ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
+    RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
+    when(mockHandle.getDependency()).thenReturn(mockDependency);
+    when(mockDependency.serializer()).thenReturn(kryoSerializer);
+    when(mockDependency.partitioner()).thenReturn(mockPartitioner);
+    when(mockPartitioner.numPartitions()).thenReturn(1);
+
+    RssShuffleWriter<String, String, String> rssShuffleWriter = new RssShuffleWriter<>("appId", 0, "taskId", 1L,
+        bufferManager, new ShuffleWriteMetrics(), manager, conf, mockShuffleWriteClient, mockHandle);
+    rssShuffleWriter.getBufferManager().setSpillFunc(rssShuffleWriter::processShuffleBlockInfos);
+
+    MutableList<Product2<String, String>> data = new MutableList<>();
+    // One record is 26 bytes
+    data.appendElem(new Tuple2<>("Key", "Value11111111111111"));
+    data.appendElem(new Tuple2<>("Key", "Value11111111111111"));
+    data.appendElem(new Tuple2<>("Key", "Value11111111111111"));
+    data.appendElem(new Tuple2<>("Key", "Value11111111111111"));
+
+    // case1: all blocks are sent and pass the blocks check when spill is triggered
+    rssShuffleWriter.write(data.iterator());
+    assertEquals(4, successBlockIds.get("taskId").size());
+    for (int i = 0; i < 4; i++) {
+      assertEquals(32, freeMemoryList.get(i));
+    }
+  }
+
+  @Test
   public void writeTest() throws Exception {
     SparkConf conf = new SparkConf();
     conf.setAppName("testApp")
@@ -198,9 +267,7 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key(), "128")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
         .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
-    // init SparkContext
     List<ShuffleBlockInfo> shuffleBlockInfos = Lists.newArrayList();
-    final SparkContext sc = SparkContext.getOrCreate(conf);
     Map<String, Set<Long>> successBlockIds = Maps.newConcurrentMap();
 
     FakedDataPusher dataPusher =
@@ -331,7 +398,7 @@ public class RssShuffleWriterTest {
     assertEquals(2, partitionToBlockIds.get(0).size());
     assertEquals(2, partitionToBlockIds.get(2).size());
     partitionToBlockIds.clear();
-    sc.stop();
+
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Guarantees thread safe by only allowing spills to be triggered by the current thread
2. Using  the same logic of processing blocks in the `RssShuffleWriter` and `WriteBufferManager` to ensure the data consistency

### Why are the changes needed?

Fix: #808 

In this PR, we use the two ways to solve the concurrent problem for `addRecord` and `spill` function
1. For the same thread, the spill will be invoked when adding  records and unsuffcient memory. This case could ensure 
thread safe. So it will do the spill sync.
2. When spill is invoked by other consumers, it will do nothing in this thread and just set a signal to let owner to release when adding record.

After this, we could avoid lock(may cause performance regression, like #811 did) to keep thread safe 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. UTs
