### PR TITLE
[#774] docs: Fix the metadata.annotations: Too long in `install.md`

### DIFF
--- a/docs/operator/install.md
+++ b/docs/operator/install.md
@@ -42,7 +42,11 @@ to [crd yaml file](../../deploy/kubernetes/operator/config/crd/bases/uniffle.apa
 Run the following command:
 
 ```
+# create, cannot use apply here, see https://github.com/apache/incubator-uniffle/issues/774
 kubectl create -f ${crd-yaml-file}
+
+# update, make sure the crd-yaml-file is a complete CRD file.
+kubectl replace -f ${crd-yaml-file}
 ```
 
 ## Setup or Update Uniffle Webhook

--- a/docs/operator/install.md
+++ b/docs/operator/install.md
@@ -42,7 +42,7 @@ to [crd yaml file](../../deploy/kubernetes/operator/config/crd/bases/uniffle.apa
 Run the following command:
 
 ```
-kubectl apply -f ${crd-yaml-file}
+kubectl create -f ${crd-yaml-file}
 ```
 
 ## Setup or Update Uniffle Webhook


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the metadata.annotations: Too long in `install.md`

### Why are the changes needed?

Solve the error message encountered below when using `kubectl apply -f`

`The CustomResourceDefinition "remoteshuffleservices.uniffle.apache.org" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
`

Fix: #774 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.