### PR TITLE
[#593][FOLLOWUP] Fix zstd compress dest ByteBuffer position

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/compression/ZstdCodec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/ZstdCodec.java
@@ -76,9 +76,11 @@ public class ZstdCodec extends Codec {
         return Zstd.compress(dest, src.duplicate(), compressionLevel);
       }
       if (!src.isDirect() && !dest.isDirect()) {
-        long compressedSize = Zstd.compressByteArray(dest.array(), dest.position(), dest.remaining(), src.array(),
+        int destOff = dest.position();
+        int compressedSize = (int) Zstd.compressByteArray(dest.array(), dest.position(), dest.remaining(), src.array(),
             src.position(), src.remaining(), compressionLevel);
-        return (int) compressedSize;
+        dest.position(destOff + compressedSize);
+        return compressedSize;
       }
     } catch (Exception e) {
       throw new RssException("Failed to compress by Zstd", e);

--- a/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
@@ -123,7 +123,8 @@ public class CompressionTest {
         assertTrue(e instanceof IllegalStateException);
       }
     } else {
-      codec.compress(srcBuffer, destBuffer);
+      int compressedLength = codec.compress(srcBuffer, destBuffer);
+      assertEquals(destBuffer.position(), destOffset + compressedLength);
       assertEquals(srcBuffer.position(), destOffset);
       destBuffer.flip();
       destBuffer.position(destOffset);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix Zstd compress dest ByteBuffer position

### Why are the changes needed?
ZstdCodec compress method called with src&dest on Heap ByteBuffer, the dest ByteBuffer position will not update. should keep consistent with others Codec.

Fix: #593

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT
