### PR TITLE
[ISSUE-859][Improvement] Set MALLOC_ARENA_MAX in start-shuffle-server.sh

### DIFF
--- a/bin/rss-env.sh
+++ b/bin/rss-env.sh
@@ -32,3 +32,4 @@ XMX_SIZE="80g" # Shuffle Server JVM XMX size
 # RSS_LOG_DIR, Where log files are stored (Default: ${RSS_HOME}/logs)
 # RSS_IP, IP address Shuffle Server binds to on this node (Default: first non-loopback ipv4)
 # MAX_DIRECT_MEMORY_SIZE Shuffle Server JVM off heap memory size (Default: not set)
+# MALLOC_ARENA_MAX, Set the number of memory arenas for Shuffle Server (Default: 4)

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -41,6 +41,12 @@ if [ -n "${RSS_IP:-}" ]; then
   echo "Shuffle Server RSS_IP: ${RSS_IP}"
 fi
 
+# glibc use an arena memory allocator that causes virtual
+# memory usage to explode. This interacts badly
+# with the many threads that we use in rss. Tune the variable
+# down to prevent vmem explosion. Default value is 8 * CORES.
+export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
+
 MAIN_CLASS="org.apache.uniffle.server.ShuffleServer"
 
 HADOOP_DEPENDENCY="$("$HADOOP_HOME/bin/hadoop" classpath --glob)"


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Reduce memory usage for some versions of glibc. Prevent oom.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/859

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
UT
