### PR TITLE
[#593][part-2]feat:WriteBuffer use ByteBuf

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -224,21 +225,24 @@ public class WriteBufferManager extends MemoryConsumer {
 
   // transform records to shuffleBlock
   protected ShuffleBlockInfo createShuffleBlock(int partitionId, WriterBuffer wb) {
-    byte[] data = wb.getData();
-    final int uncompressLength = data.length;
-    byte[] compressed = data;
+    ByteBuffer data = wb.getData();
+    final int uncompressLength = data.limit();
+    ByteBuffer compressed = data;
+    int compressedLength = uncompressLength;
     if (codec != null) {
-      long start = System.currentTimeMillis();
-      compressed = codec.compress(data);
+      final long start = System.currentTimeMillis();
+      compressed = ByteBuffer.allocate(codec.maxCompressedLength(uncompressLength));
+      compressedLength = codec.compress(data, compressed);
+      compressed.flip();
       compressTime += System.currentTimeMillis() - start;
     }
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     final long blockId = ClientUtils.getBlockId(partitionId, taskAttemptId, getNextSeqNo(partitionId));
-    uncompressedDataLen += data.length;
-    shuffleWriteMetrics.incBytesWritten(compressed.length);
+    uncompressedDataLen += uncompressLength;
+    shuffleWriteMetrics.incBytesWritten(compressedLength);
     // add memory to indicate bytes which will be sent to shuffle server
     inSendListBytes.addAndGet(wb.getMemoryUsed());
-    return new ShuffleBlockInfo(shuffleId, partitionId, blockId, compressed.length, crc32,
+    return new ShuffleBlockInfo(shuffleId, partitionId, blockId, compressedLength, crc32,
         compressed, partitionToServers.get(partitionId), uncompressLength, wb.getMemoryUsed(), taskAttemptId);
   }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
@@ -17,9 +17,11 @@
 
 package org.apache.spark.shuffle.writer;
 
-import java.util.List;
+import java.nio.ByteBuffer;
 
-import com.google.common.collect.Lists;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,56 +29,44 @@ public class WriterBuffer {
 
   private static final Logger LOG = LoggerFactory.getLogger(WriterBuffer.class);
   private long copyTime = 0;
-  private byte[] buffer;
+  private ByteBuf buffer;
   private int bufferSize;
-  private int nextOffset = 0;
-  private List<WrappedBuffer> buffers = Lists.newArrayList();
+  private int bufferUsedSize = 0;
+  private CompositeByteBuf compositeByteBuf;
   private int dataLength = 0;
   private int memoryUsed = 0;
 
   public WriterBuffer(int bufferSize) {
     this.bufferSize = bufferSize;
+    compositeByteBuf = Unpooled.compositeBuffer();
   }
 
   public void addRecord(byte[] recordBuffer, int length) {
     if (askForMemory(length)) {
       // buffer has data already, add buffer to list
-      if (nextOffset > 0) {
-        buffers.add(new WrappedBuffer(buffer, nextOffset));
-        nextOffset = 0;
+      if (bufferUsedSize > 0) {
+        compositeByteBuf.addComponent(true, buffer);
+        bufferUsedSize = 0;
       }
       int newBufferSize = Math.max(length, bufferSize);
-      buffer = new byte[newBufferSize];
+      buffer = Unpooled.buffer(newBufferSize);
       memoryUsed += newBufferSize;
     }
-
-    try {
-      System.arraycopy(recordBuffer, 0, buffer, nextOffset, length);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception for System.arraycopy, length[" + length + "], nextOffset["
-          + nextOffset + "], bufferSize[" + bufferSize + "]");
-      throw e;
-    }
-
-    nextOffset += length;
+    buffer.writeBytes(Unpooled.wrappedBuffer(recordBuffer, 0, length));
+    bufferUsedSize += length;
     dataLength += length;
   }
 
   public boolean askForMemory(long length) {
-    return buffer == null || nextOffset + length > bufferSize;
+    return buffer == null || bufferUsedSize + length > bufferSize;
   }
 
-  public byte[] getData() {
-    byte[] data = new byte[dataLength];
-    int offset = 0;
-    long start = System.currentTimeMillis();
-    for (WrappedBuffer wrappedBuffer : buffers) {
-      System.arraycopy(wrappedBuffer.getBuffer(), 0, data, offset, wrappedBuffer.getSize());
-      offset += wrappedBuffer.getSize();
-    }
-    // nextOffset is the length of current buffer used
-    System.arraycopy(buffer, 0, data, offset, nextOffset);
+  public ByteBuffer getData() {
+    final long start = System.currentTimeMillis();
+    compositeByteBuf.addComponent(true, buffer);
+    final ByteBuffer data = compositeByteBuf.nioBuffer();
     copyTime += System.currentTimeMillis() - start;
+    buffer.clear();
     return data;
   }
 
@@ -90,24 +80,5 @@ public class WriterBuffer {
 
   public int getMemoryUsed() {
     return memoryUsed;
-  }
-
-  private static final class WrappedBuffer {
-
-    byte[] buffer;
-    int size;
-
-    WrappedBuffer(byte[] buffer, int size) {
-      this.buffer = buffer;
-      this.size = size;
-    }
-
-    public byte[] getBuffer() {
-      return buffer;
-    }
-
-    public int getSize() {
-      return size;
-    }
   }
 }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -182,7 +183,7 @@ public class WriteBufferManagerTest {
     SparkConf conf = getConf();
     WriteBufferManager wbm = createManager(conf);
     WriterBuffer mockWriterBuffer = mock(WriterBuffer.class);
-    when(mockWriterBuffer.getData()).thenReturn(new byte[]{});
+    when(mockWriterBuffer.getData()).thenReturn(ByteBuffer.wrap(new byte[]{}));
     when(mockWriterBuffer.getMemoryUsed()).thenReturn(0);
     ShuffleBlockInfo sbi = wbm.createShuffleBlock(0, mockWriterBuffer);
     // seqNo = 0, partitionId = 0, taskId = 0

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
@@ -50,15 +50,15 @@ public class WriteBufferTest {
     wb.addRecord(serializedData, serializedDataLength);
     assertEquals(32, wb.getMemoryUsed());
     // case: data size < output buffer size, when getData(), [] + buffer with 24b = 24b
-    assertEquals(24, wb.getData().length);
+    assertEquals(24, wb.getData().limit());
     wb.addRecord(serializedData, serializedDataLength);
     // case: data size > output buffer size, when getData(), [1 buffer] + buffer with 12 = 36b
-    assertEquals(36, wb.getData().length);
+    assertEquals(36, wb.getData().limit());
     assertEquals(64, wb.getMemoryUsed());
     wb.addRecord(serializedData, serializedDataLength);
     wb.addRecord(serializedData, serializedDataLength);
     // case: data size > output buffer size, when getData(), 2 buffer + output with 12b = 60b
-    assertEquals(60, wb.getData().length);
+    assertEquals(60, wb.getData().array().length);
     assertEquals(96, wb.getMemoryUsed());
 
     wb = new WriterBuffer(32);
@@ -74,12 +74,12 @@ public class WriteBufferTest {
     assertEquals(99, wb.getMemoryUsed());
     // 67 + 12
     assertEquals(79, wb.getDataLength());
-    assertEquals(79, wb.getData().length);
+    assertEquals(79, wb.getData().array().length);
 
     wb.addRecord(serializedData, serializedDataLength);
     assertEquals(99, wb.getMemoryUsed());
     assertEquals(91, wb.getDataLength());
-    assertEquals(91, wb.getData().length);
+    assertEquals(91, wb.getData().array().length);
   }
 
   private void serializeData(Object key, Object value) {

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.common;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
@@ -34,6 +35,13 @@ public class ShuffleBlockInfo {
   private List<ShuffleServerInfo> shuffleServerInfos;
   private int uncompressLength;
   private long freeMemory;
+
+  public ShuffleBlockInfo(int shuffleId, int partitionId, long blockId, int length, long crc,
+      ByteBuffer data, List<ShuffleServerInfo> shuffleServerInfos,
+      int uncompressLength, long freeMemory, long taskAttemptId) {
+    this(shuffleId, partitionId, blockId, length, crc, Unpooled.wrappedBuffer(data),
+        shuffleServerInfos, uncompressLength, freeMemory, taskAttemptId);
+  }
 
   public ShuffleBlockInfo(int shuffleId, int partitionId, long blockId, int length, long crc,
       byte[] data, List<ShuffleServerInfo> shuffleServerInfos,


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1. WriteBuffer use ByteBuf instead byte array.

### Why are the changes needed?

Fix: #593 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

UT
