### PR TITLE
[MINOR] refactor: Reduce the usage of memory in the `ShuffleWriter`

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -209,10 +209,11 @@ public class WriteBufferManager extends MemoryConsumer {
     long memoryUsed = 0;
     Iterator<Entry<Integer, WriterBuffer>> iterator = buffers.entrySet().iterator();
     while (iterator.hasNext()) {
-      WriterBuffer wb = iterator.next().getValue();
+      Entry<Integer, WriterBuffer>  entry = iterator.next();
+      WriterBuffer wb = entry.getValue();
       dataSize += wb.getDataLength();
       memoryUsed += wb.getMemoryUsed();
-      result.add(createShuffleBlock(iterator.next().getKey(), wb));
+      result.add(createShuffleBlock(entry.getKey(), wb));
       iterator.remove();
       copyTime += wb.getCopyTime();
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle.writer;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -206,16 +207,17 @@ public class WriteBufferManager extends MemoryConsumer {
     List<ShuffleBlockInfo> result = Lists.newArrayList();
     long dataSize = 0;
     long memoryUsed = 0;
-    for (Entry<Integer, WriterBuffer> entry : buffers.entrySet()) {
-      WriterBuffer wb = entry.getValue();
+    Iterator<Entry<Integer, WriterBuffer>> iterator = buffers.entrySet().iterator();
+    while (iterator.hasNext()) {
+      WriterBuffer wb = iterator.next().getValue();
       dataSize += wb.getDataLength();
       memoryUsed += wb.getMemoryUsed();
-      result.add(createShuffleBlock(entry.getKey(), wb));
+      result.add(createShuffleBlock(iterator.next().getKey(), wb));
+      iterator.remove();
       copyTime += wb.getCopyTime();
     }
     LOG.info("Flush total buffer for shuffleId[" + shuffleId + "] with allocated["
         + allocatedBytes + "], dataSize[" + dataSize + "], memoryUsed[" + memoryUsed + "]");
-    buffers.clear();
     return result;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should immediately remove the `WriteBuffer` after  we use the method `createShuffleBlock` to create `ShuffeBlock`. Otherwise we will have the compressed data and uncompressed data at the same time in the memory. JVM's GC can't collect the memory of uncompressed data, because the data have the reference in the map `buffers`.

### Why are the changes needed?
Reduce the usage of memory.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed.
