### PR TITLE
[MINOR] Remove unused code of shuffle upload

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/common/HdfsStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/HdfsStorage.java
@@ -68,16 +68,6 @@ public class HdfsStorage extends AbstractStorage {
   }
 
   @Override
-  public boolean lockShuffleShared(String shuffleKey) {
-    return true;
-  }
-
-  @Override
-  public boolean unlockShuffleShared(String shuffleKey) {
-    return true;
-  }
-
-  @Override
   public void updateReadMetrics(StorageReadMetrics metrics) {
     // do nothing
   }

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
-import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storage/src/main/java/org/apache/uniffle/storage/common/Storage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/Storage.java
@@ -29,10 +29,6 @@ public interface Storage {
 
   boolean canWrite();
 
-  boolean lockShuffleShared(String shuffleKey);
-
-  boolean unlockShuffleShared(String shuffleKey);
-
   void updateWriteMetrics(StorageWriteMetrics metrics);
 
   void updateReadMetrics(StorageReadMetrics metrics);

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -21,19 +21,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.roaringbitmap.RoaringBitmap;
 
 import org.apache.uniffle.common.storage.StorageMedia;
-import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.storage.request.CreateShuffleWriteHandlerRequest;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -128,84 +124,6 @@ public class LocalStorageTest {
     // not existed base dir should work
     File notExisted = new File(newBaseDir, "not_existed");
     createTestStorage(notExisted);
-  }
-
-  @Test
-  public void removeResourcesTest() throws Exception {
-    LocalStorage item = prepareDiskItem();
-    final String key1 = RssUtils.generateShuffleKey("1", 1);
-    final String key2 = RssUtils.generateShuffleKey("1", 2);
-    item.removeResources(key1);
-    assertEquals(50L, item.getMetaData().getDiskSize().get());
-    assertEquals(0L, item.getMetaData().getShuffleSize(key1));
-    assertEquals(50L, item.getMetaData().getShuffleSize(key2));
-    assertTrue(item.getMetaData().getNotUploadedPartitions(key1).isEmpty());
-  }
-
-  private LocalStorage prepareDiskItem() {
-    final LocalStorage item = createTestStorage(testBaseDir);
-    RoaringBitmap partitionBitMap = RoaringBitmap.bitmapOf();
-    partitionBitMap.add(1);
-    partitionBitMap.add(2);
-    partitionBitMap.add(1);
-    List<Integer> partitionList = Lists.newArrayList(1, 2);
-    item.createMetadataIfNotExist("1/1");
-    item.createMetadataIfNotExist("1/2");
-    item.updateWrite("1/1", 100, partitionList);
-    item.updateWrite("1/2", 50, Lists.newArrayList());
-    assertEquals(150L, item.getMetaData().getDiskSize().get());
-    assertEquals(2, item.getMetaData().getNotUploadedPartitions("1/1").getCardinality());
-    assertTrue(partitionBitMap.contains(item.getMetaData().getNotUploadedPartitions("1/1")));
-    return item;
-  }
-
-  @Test
-  public void concurrentRemoveResourcesTest() throws Exception {
-    LocalStorage item = prepareDiskItem();
-    Runnable runnable = () -> item.removeResources("1/1");
-    List<Thread> testThreads = Lists.newArrayList(new Thread(runnable), new Thread(runnable), new Thread(runnable));
-    testThreads.forEach(Thread::start);
-    testThreads.forEach(t -> {
-      try {
-        t.join();
-      } catch (InterruptedException e) {
-        // ignore
-      }
-    });
-
-    assertEquals(50L, item.getMetaData().getDiskSize().get());
-    assertEquals(0L, item.getMetaData().getShuffleSize("1/1"));
-    assertEquals(50L, item.getMetaData().getShuffleSize("1/2"));
-    assertTrue(item.getMetaData().getNotUploadedPartitions("1/1").isEmpty());
-  }
-
-  @Test
-  public void diskMetaTest() {
-    LocalStorage item = createTestStorage(testBaseDir);
-    List<Integer> partitionList1 = Lists.newArrayList(1, 2, 3, 4, 5);
-    List<Integer> partitionList2 = Lists.newArrayList(6, 7, 8, 9, 10);
-    List<Integer> partitionList3 = Lists.newArrayList(1, 2, 3);
-    item.createMetadataIfNotExist("key1");
-    item.createMetadataIfNotExist("key2");
-    item.updateWrite("key1", 10, partitionList1);
-    item.updateWrite("key2", 30, partitionList2);
-    item.updateUploadedShuffle("key1", 5, partitionList3);
-
-    assertTrue(item.getNotUploadedPartitions("notKey").isEmpty());
-    assertEquals(2, item.getNotUploadedPartitions("key1").getCardinality());
-    assertEquals(5, item.getNotUploadedPartitions("key2").getCardinality());
-    assertEquals(0, item.getNotUploadedSize("notKey"));
-    assertEquals(5, item.getNotUploadedSize("key1"));
-    assertEquals(30, item.getNotUploadedSize("key2"));
-
-    assertTrue(item.getSortedShuffleKeys(true, 1).isEmpty());
-    assertTrue(item.getSortedShuffleKeys(true, 2).isEmpty());
-    item.prepareStartRead("key1");
-    assertEquals(1, item.getSortedShuffleKeys(true, 3).size());
-    assertEquals(1, item.getSortedShuffleKeys(false, 1).size());
-    assertEquals("key2", item.getSortedShuffleKeys(false, 1).get(0));
-    assertEquals(2, item.getSortedShuffleKeys(false, 2).size());
-    assertEquals(2, item.getSortedShuffleKeys(false, 3).size());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Remove the meta lock, this lock is used for upload shuffle function.
2. Remove the meta of upload shuffle function.

### Why are the changes needed?
Simplify our logic

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA passed.
