### PR TITLE
[#886] fix(mr): MR Client may lost data or throw exception when rss.storage.type without MEMORY.

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -260,12 +260,6 @@ public class SortWriteBufferManager<K, V> {
       sendBuffersToServers();
     }
     long start = System.currentTimeMillis();
-    long commitDuration = 0;
-    if (!isMemoryShuffleEnabled) {
-      long s = System.currentTimeMillis();
-      sendCommit();
-      commitDuration = System.currentTimeMillis() - s;
-    }
     while (true) {
       // if failed when send data to shuffle server, mark task as failed
       if (failedBlockIds.size() > 0) {
@@ -290,6 +284,12 @@ public class SortWriteBufferManager<K, V> {
         LOG.error(errorMsg);
         throw new RssException(errorMsg);
       }
+    }
+    long commitDuration = 0;
+    if (!isMemoryShuffleEnabled) {
+      long s = System.currentTimeMillis();
+      sendCommit();
+      commitDuration = System.currentTimeMillis() - s;
     }
 
     start = System.currentTimeMillis();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make sure finishShuffle after send all shuffle data.

### Why are the changes needed?

If type without MEMORY, some data will never flush.

### How was this patch tested?

I test in two mode:
* Tez local debug mode
* MR on yarn mode

Add new UT