### PR TITLE
[#133] feat(netty): Fix IllegalReferenceCountException.

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -107,7 +107,10 @@ public class ShuffleBuffer {
         spBlocks,
         isValid,
         this);
-    event.addCleanupCallback(() -> this.clearInFlushBuffer(event.getEventId()));
+    event.addCleanupCallback(() -> {
+      this.clearInFlushBuffer(event.getEventId());
+      spBlocks.forEach(spb -> spb.getData().release());
+    });
     inFlushBlockMap.put(eventId, inFlushedQueueBlocks);
     blocks.clear();
     size = 0;

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -563,6 +563,7 @@ public class ShuffleBufferManager {
       Collection<ShuffleBuffer> buffers = bufferRangeMap.asMapOfRanges().values();
       if (buffers != null) {
         for (ShuffleBuffer buffer : buffers) {
+          buffer.getBlocks().forEach(spb -> spb.getData().release());
           ShuffleServerMetrics.gaugeTotalPartitionNum.dec();
           size += buffer.getSize();
         }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -108,7 +108,6 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
         long crc = block.getCrc();
         long startOffset = dataWriter.nextOffset();
         dataWriter.writeData(ByteBufUtils.readBytes(block.getData()));
-        block.getData().release();
 
         FileBasedShuffleSegment segment = new FileBasedShuffleSegment(
             blockId, startOffset, block.getLength(), block.getUncompressLength(), crc, block.getTaskAttemptId());


### PR DESCRIPTION
### What changes were proposed in this pull request?

The ByteBuf.release() of the block should be called after clearInFlushBuffer is called, otherwise there will be a certain probability of IllegalReferenceCountException at `ShuffleBuffer#updateShuffleData -> data.addComponent(true, block.getData().retain());`
1.Fix IllegalReferenceCountException, 
2.Added ByteBuf.release() when remove resources.

### Why are the changes needed?

Fix: #133 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

existing UTs.
