### PR TITLE
[MINOR] fix: Fix LocalStorageManager divide by zero exception

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -189,6 +189,10 @@ public class LocalStorageManager extends SingleStorageManager {
         .stream()
         .filter(x -> x.canWrite() && !x.isCorrupted())
         .collect(Collectors.toList());
+
+    if (candidates.size() == 0) {
+      return null;
+    }
     final LocalStorage selectedStorage = candidates.get(
         ShuffleStorageUtils.getStorageIndex(
             candidates.size(),

--- a/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/LocalStorageManagerTest.java
@@ -47,6 +47,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -159,6 +160,11 @@ public class LocalStorageManagerTest {
     ((LocalStorage)restStorage).markCorrupted();
     Storage storage8 = localStorageManager.selectStorage(dataReadEvent);
     assertEquals(storage7, storage8);
+
+    // make all storage corrupted
+    ((LocalStorage)localStorageManager.selectStorage(dataFlushEvent1)).markCorrupted();
+    ShuffleDataFlushEvent dataFlushEvent3 = toDataFlushEvent(appId, 1, 2);
+    assertNull(localStorageManager.selectStorage(dataFlushEvent3));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix LocalStorageManager divide by zero exception when all local disks corrupted.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.
