### PR TITLE
[#590][part-1] ManagedBuffer instead ByteBuf to hold ShuffleData 

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -67,11 +67,11 @@ public class ShuffleDataResult {
     if (buffer.nioByteBuffer().hasArray()) {
       return buffer.nioByteBuffer().array();
     }
-    return ByteBufUtils.readBytes(Unpooled.wrappedBuffer(buffer.nioByteBuffer()));
+    return ByteBufUtils.readBytes(buffer.byteBuf());
   }
 
   public ByteBuf getDataBuf() {
-    return Unpooled.wrappedBuffer(buffer.nioByteBuffer());
+    return buffer.byteBuf();
   }
 
   public ByteBuffer getDataBuffer() {

--- a/common/src/main/java/org/apache/uniffle/common/netty/MessageEncoder.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/MessageEncoder.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.netty.protocol.Message;
+import org.apache.uniffle.common.netty.protocol.Transferable;
 
 /**
  * Encoder used by the server side to encode server-to-client responses.
@@ -46,7 +47,6 @@ public class MessageEncoder extends ChannelOutboundHandlerAdapter {
 
   @Override
   public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-    // todo: support zero copy
     Message message = (Message) msg;
     int encodeLength = message.encodedLength();
     ByteBuf byteBuf = ctx.alloc().buffer(FrameDecoder.HEADER_SIZE + encodeLength);
@@ -59,5 +59,9 @@ public class MessageEncoder extends ChannelOutboundHandlerAdapter {
       byteBuf.release();
     }
     ctx.writeAndFlush(byteBuf);
+    // do transferTo send data after encode buffer send.
+    if (message instanceof Transferable) {
+      ((Transferable) message).transferTo(ctx.channel());
+    }
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common.netty.buffer;
 
 import java.io.File;

--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/ManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/ManagedBuffer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common.netty.buffer;
 
 import java.nio.ByteBuffer;

--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/ManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/ManagedBuffer.java
@@ -1,0 +1,22 @@
+package org.apache.uniffle.common.netty.buffer;
+
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+
+public abstract class ManagedBuffer {
+
+  public abstract int size();
+
+  public abstract ByteBuf byteBuf();
+
+  public abstract ByteBuffer nioByteBuffer();
+
+  public abstract ManagedBuffer release();
+
+  /**
+   * Convert the buffer into an Netty object, used to write the data out. The return value is either
+   * a {@link io.netty.buffer.ByteBuf} or a {@link io.netty.channel.FileRegion}.
+   */
+  public abstract Object convertToNetty();
+}

--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/NettyManagedBuffer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common.netty.buffer;
 
 import java.nio.ByteBuffer;

--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/NettyManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/NettyManagedBuffer.java
@@ -1,0 +1,41 @@
+package org.apache.uniffle.common.netty.buffer;
+
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class NettyManagedBuffer extends ManagedBuffer {
+
+  private ByteBuf buf;
+
+  public NettyManagedBuffer(ByteBuf byteBuf) {
+    this.buf = byteBuf;
+  }
+
+  @Override
+  public int size() {
+    return buf.readableBytes();
+  }
+
+  @Override
+  public ByteBuf byteBuf() {
+    return Unpooled.wrappedBuffer(this.nioByteBuffer());
+  }
+
+  @Override
+  public ByteBuffer nioByteBuffer() {
+    return buf.nioBuffer();
+  }
+
+  @Override
+  public ManagedBuffer release() {
+    buf.release();
+    return this;
+  }
+
+  @Override
+  public Object convertToNetty() {
+    return buf.duplicate().retain();
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Transferable.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Transferable.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.uniffle.common.netty.protocol;
 
 import io.netty.channel.Channel;

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Transferable.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Transferable.java
@@ -1,0 +1,8 @@
+package org.apache.uniffle.common.netty.protocol;
+
+import io.netty.channel.Channel;
+
+public interface Transferable {
+
+  void transferTo(Channel channel);
+}

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
@@ -31,6 +31,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.rpc.StatusCode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -116,7 +117,8 @@ public class NettyProtocolTest {
   public void testGetLocalShuffleDataResponse() {
     byte[] data = new byte[]{1, 2, 3};
     GetLocalShuffleDataResponse getLocalShuffleDataResponse =
-        new GetLocalShuffleDataResponse(1, StatusCode.SUCCESS, "", Unpooled.wrappedBuffer(data).retain());
+        new GetLocalShuffleDataResponse(1, StatusCode.SUCCESS, "",
+            new NettyManagedBuffer(Unpooled.wrappedBuffer(data).retain()));
     int encodeLength = getLocalShuffleDataResponse.encodedLength();
     ByteBuf byteBuf = Unpooled.buffer(encodeLength, encodeLength);
     getLocalShuffleDataResponse.encode(byteBuf);

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -225,7 +225,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
       case SUCCESS:
         return new RssGetShuffleDataResponse(
             StatusCode.SUCCESS,
-            getLocalShuffleDataResponse.getData().nioBuffer());
+            getLocalShuffleDataResponse.getBuffer().nioByteBuffer());
       default:
         String msg = "Can't get shuffle data from " + host + ":" + port
                          + " for " + requestInfo + ", errorMsg:" + getLocalShuffleDataResponse.getRetMessage();


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

part-1: 
1. add a ManagedBuffer instead ByteBuf to hold ShuffleData.
2. ShuffleResultData & GetLocalShuffleDataResponse use ManagedBuffer instead of ByteBuf
3. MessageEncoder write support sendfile


### Why are the changes needed?
Fix: #590 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
No.

### How was this patch tested?
Integration Testing
