### PR TITLE
[#908] feat(tez): Write byte array shuffle data to MapoutPut 

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezBypassWriter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezBypassWriter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.DataChecksum;
+import org.apache.tez.runtime.library.common.shuffle.DiskFetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.MemoryFetchedInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+// In Tez shuffle, MapOutput encapsulates the logic to fetch map task's output data via http.
+// So, in RSS, we should bypass this logic, and directly write data to MapOutput.
+public class RssTezBypassWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(RssTezBypassWriter.class);
+  private static final byte[] HEADER = new byte[] { (byte) 'T', (byte) 'I', (byte) 'F', (byte) 0};
+
+  public static void write(MapOutput mapOutput, byte[] buffer) {
+    // Write and commit uncompressed data to MapOutput.
+    // In the majority of cases, merger allocates memory to accept data,
+    // but when data size exceeds the threshold, merger can also allocate disk.
+    // So, we should consider the two situations, respectively.
+    if (mapOutput.getType() == MapOutput.Type.MEMORY) {
+      byte[] memory = mapOutput.getMemory();
+      System.arraycopy(buffer, 0, memory, 0, buffer.length);
+    } else if (mapOutput.getType() == MapOutput.Type.DISK) {
+      // RSS leverages its own compression, it is incompatible with hadoop's disk file compression.
+      // So we should disable this situation.
+      throw new IllegalStateException("RSS does not support OnDiskMapOutput as shuffle ouput,"
+              + " try to reduce mapreduce.reduce.shuffle.memory.limit.percent");
+    } else {
+      throw new IllegalStateException("Merger reserve unknown type of MapOutput: "
+              + mapOutput.getClass().getCanonicalName());
+    }
+  }
+
+
+  public static void write(final FetchedInput mapOutput, byte[] buffer) throws IOException {
+    // Write and commit uncompressed data to MapOutput.
+    // In the majority of cases, merger allocates memory to accept data,
+    // but when data size exceeds the threshold, merger can also allocate disk.
+    // So, we should consider the two situations, respectively.
+    if (mapOutput.getType() == FetchedInput.Type.MEMORY) {
+      byte[] memory = ((MemoryFetchedInput) mapOutput).getBytes();
+      System.arraycopy(buffer, 0, memory, 0, buffer.length);
+    } else if (mapOutput.getType() == FetchedInput.Type.DISK) {
+      OutputStream output = ((DiskFetchedInput) mapOutput).getOutputStream();
+      output.write(HEADER);
+      output.write(buffer);
+      output.write(calcChecksum(buffer));
+      output.flush();
+      output.close();
+    } else {
+      throw new IllegalStateException("Merger reserve unknown type of MapOutput: "
+          + mapOutput.getClass().getCanonicalName());
+    }
+  }
+
+  @VisibleForTesting
+  protected static byte[] calcChecksum(final byte[] buffer) throws IOException {
+    DataChecksum sum = DataChecksum.newDataChecksum(DataChecksum.Type.CRC32, Integer.MAX_VALUE);
+    int size = 4096;
+    int bufferSize = buffer.length;
+    int cur = 0;
+    while (cur < bufferSize) {
+      int l = Math.min(size, bufferSize - cur);
+      sum.update(buffer, cur, l);
+      cur += l;
+    }
+    byte[] checksum = new byte[sum.getChecksumSize()];
+    sum.writeValue(checksum, 0, false);
+    return checksum;
+  }
+}

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezBypassWriterTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezBypassWriterTest.java
@@ -1,0 +1,18 @@
+package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RssTezBypassWriterTest {
+
+  @Test
+  public void testCalcChecksum() throws IOException {
+    byte[] data = new byte[]{1, 2, -1, 1, 2, -1, -1};
+    byte[] checksum = RssTezBypassWriter.calcChecksum(data);
+    assertTrue(Arrays.equals(new byte[]{-71, -87, 19, -71}, checksum));
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?

Write byte array shuffle data to MapoutPut 

### Why are the changes needed?


Fix: # ([908](https://github.com/apache/incubator-uniffle/issues/908))

### Does this PR introduce _any_ user-facing change?


No.

### How was this patch tested?
test unit
