### PR TITLE
[MINOR] fix: Error logs upload fail

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -50,6 +50,7 @@ jobs:
     strategy:
       matrix:
         profile:
+          # Pay attention! Don't use profile with character '-'!
           - spark2
           - spark2.3
           - spark3.0
@@ -57,8 +58,8 @@ jobs:
           - spark3.2
           - spark3.2.0
           - spark3.3
-          - mr:hadoop2.8
-          - mr:hadoop3.2
+          - mr-hadoop2.8
+          - mr-hadoop3.2
           - tez
       fail-fast: false
     name: -P${{ matrix.profile }}
@@ -83,7 +84,7 @@ jobs:
     - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
       run: |
         PROFILES="${{ matrix.profile }}"
-        PROFILES=${PROFILES/:/,}
+        PROFILES=${PROFILES/-/,}
         mvn -B -fae ${{ inputs.maven-args }} -P${PROFILES} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         profile:
-          # Pay attention! Don't use profile with character '-'!
+          # Pay attention! Don't use profile with character ':'!
           - spark2
           - spark2.3
           - spark3.0


### PR DESCRIPTION

### What changes were proposed in this pull request?

https://github.com/apache/incubator-uniffle/actions/runs/5141497645/jobs/9254329542?pr=916 fail, but error logs upload fail, so we can't analyze the cause.

Upload logs are below: 

```
Run actions/upload-artifact@v3
With the provided path, there will be 53 files uploaded
Starting artifact upload
For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
Error: Artifact name is not valid: test-reports-mr:hadoop3.2. Contains the following character:  Colon :
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n, Backslash \, Forward slash /
          
These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```

### Why are the changes needed?

reproduce error describe in https://github.com/apache/incubator-uniffle/actions/runs/5141497645/jobs/9254329542?pr=916