### PR TITLE
[#854][FOLLOWUP] feat(tez): Add Simple Fetched Allocator to allocation memory or disk for shuffle data

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocator.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocator.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.library.common.shuffle.impl;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.LocalDirAllocator;
+import org.apache.tez.common.TezRuntimeFrameworkConfigs;
+import org.apache.tez.dag.api.TezUncheckedException;
+import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.Constants;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.DiskFetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput.Type;
+import org.apache.tez.runtime.library.common.shuffle.MemoryFetchedInput;
+import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFiles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Usage: Create instance, setInitialMemoryAvailable(long), configureAndStart()
+ *
+ */
+@Private
+public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RssSimpleFetchedInputAllocator.class);
+  
+  private final Configuration conf;
+
+  private final TezTaskOutputFiles fileNameAllocator;
+  private final LocalDirAllocator localDirAllocator;
+
+  // Configuration parameters
+  private final long memoryLimit;
+  private final long maxSingleShuffleLimit;
+
+  private final long maxAvailableTaskMemory;
+  private final long initialMemoryAvailable;
+
+  private final String srcNameTrimmed;
+  
+  private volatile long usedMemory = 0;
+
+  public RssSimpleFetchedInputAllocator(String srcNameTrimmed,
+                                     String uniqueIdentifier, int dagID,
+                                     Configuration conf,
+                                     long maxTaskAvailableMemory,
+                                     long memoryAvailable) {
+    super(srcNameTrimmed, uniqueIdentifier, dagID, conf, maxTaskAvailableMemory, memoryAvailable);
+    this.srcNameTrimmed = srcNameTrimmed;
+    this.conf = conf;    
+    this.maxAvailableTaskMemory = maxTaskAvailableMemory;
+    this.initialMemoryAvailable = memoryAvailable;
+    
+    this.fileNameAllocator = new TezTaskOutputFiles(conf, uniqueIdentifier, dagID);
+    this.localDirAllocator = new LocalDirAllocator(TezRuntimeFrameworkConfigs.LOCAL_DIRS);
+    
+    // Setup configuration
+    final float maxInMemCopyUse = conf.getFloat(
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT,
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT_DEFAULT);
+    if (maxInMemCopyUse > 1.0 || maxInMemCopyUse < 0.0) {
+      throw new IllegalArgumentException("Invalid value for "
+          + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT + ": " + maxInMemCopyUse);
+    }
+    
+    long memReq = (long) (conf.getLong(Constants.TEZ_RUNTIME_TASK_MEMORY,
+        Math.min(maxAvailableTaskMemory, Integer.MAX_VALUE)) * maxInMemCopyUse);
+
+    if (memReq <= this.initialMemoryAvailable) {
+      this.memoryLimit = memReq;
+    } else {
+      this.memoryLimit = initialMemoryAvailable;
+    }
+
+    final float singleShuffleMemoryLimitPercent = conf.getFloat(
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT,
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT_DEFAULT);
+    if (singleShuffleMemoryLimitPercent <= 0.0f
+        || singleShuffleMemoryLimitPercent > 1.0f) {
+      throw new IllegalArgumentException("Invalid value for "
+          + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT + ": " + singleShuffleMemoryLimitPercent);
+    }
+    this.maxSingleShuffleLimit = (long) Math.min((memoryLimit * singleShuffleMemoryLimitPercent), Integer.MAX_VALUE);
+
+    LOG.info(srcNameTrimmed + ": "
+        + "RequestedMemory=" + memReq
+        + ", AssignedMemory=" + this.memoryLimit
+        + ", maxSingleShuffleLimit=" + this.maxSingleShuffleLimit
+    );
+
+  }
+
+  @Private
+  public static long getInitialMemoryReq(Configuration conf, long maxAvailableTaskMemory) {
+    final float maxInMemCopyUse = conf.getFloat(
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT,
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT_DEFAULT);
+    if (maxInMemCopyUse > 1.0 || maxInMemCopyUse < 0.0) {
+      throw new IllegalArgumentException("Invalid value for "
+          + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT + ": " + maxInMemCopyUse);
+    }
+    return (long) (conf.getLong(Constants.TEZ_RUNTIME_TASK_MEMORY,
+        Math.min(maxAvailableTaskMemory, Integer.MAX_VALUE)) * maxInMemCopyUse);
+  }
+
+  @Override
+  public synchronized FetchedInput allocate(long actualSize, long compressedSize,
+            InputAttemptIdentifier inputAttemptIdentifier) throws IOException {
+    if (actualSize > maxSingleShuffleLimit
+        || this.usedMemory + actualSize > this.memoryLimit) {
+      LOG.info("Allocate DiskFetchedInput, length:{}", actualSize);
+      return new DiskFetchedInput(actualSize + 8, inputAttemptIdentifier, this, conf,
+          localDirAllocator, fileNameAllocator);
+    } else {
+      this.usedMemory += actualSize;
+      if (LOG.isDebugEnabled()) {
+        LOG.info(srcNameTrimmed + ": " + "Used memory after allocating " + actualSize + " : " + usedMemory);
+      }
+      return new MemoryFetchedInput(actualSize, inputAttemptIdentifier, this);
+    }
+  }
+
+  @Override
+  public synchronized FetchedInput allocateType(Type type, long actualSize,
+      long compressedSize, InputAttemptIdentifier inputAttemptIdentifier)
+      throws IOException {
+
+    switch (type) {
+      case DISK:
+        LOG.info("AllocateType DiskFetchedInput, compressedSize:{}", compressedSize);
+        return new DiskFetchedInput(compressedSize + 8, inputAttemptIdentifier, this,
+            conf, localDirAllocator, fileNameAllocator);
+      default:
+        return allocate(actualSize, compressedSize, inputAttemptIdentifier);
+    }
+  }
+
+  @Override
+  public synchronized void fetchComplete(FetchedInput fetchedInput) {
+    switch (fetchedInput.getType()) {
+      // Not tracking anything here.
+      case DISK:
+      case DISK_DIRECT:
+      case MEMORY:
+        break;
+      default:
+        throw new TezUncheckedException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
+    }
+  }
+
+  @Override
+  public synchronized void fetchFailed(FetchedInput fetchedInput) {
+    cleanup(fetchedInput);
+  }
+
+  @Override
+  public synchronized void freeResources(FetchedInput fetchedInput) {
+    cleanup(fetchedInput);
+  }
+
+  private void cleanup(FetchedInput fetchedInput) {
+    switch (fetchedInput.getType()) {
+      case DISK:
+        break;
+      case MEMORY:
+        unreserve(((MemoryFetchedInput) fetchedInput).getSize());
+        break;
+      default:
+        throw new TezUncheckedException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
+    }
+  }
+
+  private synchronized void unreserve(long size) {
+    this.usedMemory -= size;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(srcNameTrimmed + ": " + "Used memory after freeing " + size  + " : " + usedMemory);
+    }
+  }
+}

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocator.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocator.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
-import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.Constants;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -36,6 +35,7 @@ import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFile
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.exception.RssException;
 
 /**
  * Usage: Create instance, setInitialMemoryAvailable(long), configureAndStart()
@@ -81,7 +81,7 @@ public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator 
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT_DEFAULT);
     if (maxInMemCopyUse > 1.0 || maxInMemCopyUse < 0.0) {
-      throw new IllegalArgumentException("Invalid value for "
+      throw new RssException("Invalid value for "
           + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT + ": " + maxInMemCopyUse);
     }
     
@@ -99,7 +99,7 @@ public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator 
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT_DEFAULT);
     if (singleShuffleMemoryLimitPercent <= 0.0f
         || singleShuffleMemoryLimitPercent > 1.0f) {
-      throw new IllegalArgumentException("Invalid value for "
+      throw new RssException("Invalid value for "
           + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT + ": " + singleShuffleMemoryLimitPercent);
     }
     this.maxSingleShuffleLimit = (long) Math.min((memoryLimit * singleShuffleMemoryLimitPercent), Integer.MAX_VALUE);
@@ -118,7 +118,7 @@ public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator 
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT_DEFAULT);
     if (maxInMemCopyUse > 1.0 || maxInMemCopyUse < 0.0) {
-      throw new IllegalArgumentException("Invalid value for "
+      throw new RssException("Invalid value for "
           + TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT + ": " + maxInMemCopyUse);
     }
     return (long) (conf.getLong(Constants.TEZ_RUNTIME_TASK_MEMORY,
@@ -166,7 +166,7 @@ public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator 
       case MEMORY:
         break;
       default:
-        throw new TezUncheckedException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
+        throw new RssException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
     }
   }
 
@@ -188,7 +188,7 @@ public class RssSimpleFetchedInputAllocator extends SimpleFetchedInputAllocator 
         unreserve(((MemoryFetchedInput) fetchedInput).getSize());
         break;
       default:
-        throw new TezUncheckedException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
+        throw new RssException("InputType: " + fetchedInput.getType() + " not expected for Broadcast fetch");
     }
   }
 

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -10,7 +10,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY RssSimpleFetchedInputAllocatorTest.javaKIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -10,7 +10,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY RssSimpleFetchedInputAllocatorTest.javaKIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -67,21 +67,21 @@ public class RssSimpleFetchedInputAllocatorTest {
 
     MockedConstruction<DiskFetchedInput> mockedConstruction =
           Mockito.mockConstruction(DiskFetchedInput.class, ((mockedInput, context) -> {
-      // Over limit by this point. Next reserve should give back a DISK allocation
-      FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
-      assertEquals(FetchedInput.Type.DISK, fi3.getType());
+            // Over limit by this point. Next reserve should give back a DISK allocation
+            FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
+            assertEquals(FetchedInput.Type.DISK, fi3.getType());
 
-      // Freed one memory allocation. Next should be mem again.
-      fi1.abort();
-      fi1.free();
-      FetchedInput fi4 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
-      assertEquals(FetchedInput.Type.MEMORY, fi4.getType());
+            // Freed one memory allocation. Next should be mem again.
+            fi1.abort();
+            fi1.free();
+            FetchedInput fi4 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+            assertEquals(FetchedInput.Type.MEMORY, fi4.getType());
 
-      // Freed one disk allocation. Next sould be disk again (no mem freed)
-      fi3.abort();
-      fi3.free();
-      FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
-      assertEquals(FetchedInput.Type.DISK, fi5.getType());
+            // Freed one disk allocation. Next sould be disk again (no mem freed)
+            fi3.abort();
+            fi3.free();
+            FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+            assertEquals(FetchedInput.Type.DISK, fi5.getType());
     }));
   }
 }

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -1,13 +1,12 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,11 +21,13 @@ import java.io.IOException;
 import java.util.UUID;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.DiskFetchedInput;
 import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class RssSimpleFetchedInputAllocatorTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssSimpleFetchedInputAllocatorTest.class);
-  
+
   @Test
   public void testAllocate() throws IOException {
     Configuration conf = new Configuration();
@@ -46,8 +47,6 @@ public class RssSimpleFetchedInputAllocatorTest {
     float bufferPercent = 0.1f;
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, bufferPercent);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 1.0f);
-    String localDirs = "/tmp/" + this.getClass().getName();
-    conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, localDirs);
 
     long inMemThreshold = (long) (bufferPercent * jvmMax);
     LOG.info("InMemThreshold: " + inMemThreshold);
@@ -66,22 +65,23 @@ public class RssSimpleFetchedInputAllocatorTest {
     FetchedInput fi2 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(2, 1));
     assertEquals(FetchedInput.Type.MEMORY, fi2.getType());
 
-    // Over limit by this point. Next reserve should give back a DISK allocation
-    FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
-    assertEquals(FetchedInput.Type.DISK, fi3.getType());
+    MockedConstruction<DiskFetchedInput> mockedConstruction =
+          Mockito.mockConstruction(DiskFetchedInput.class, ((mockedInput, context) -> {
+      // Over limit by this point. Next reserve should give back a DISK allocation
+      FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
+      assertEquals(FetchedInput.Type.DISK, fi3.getType());
 
+      // Freed one memory allocation. Next should be mem again.
+      fi1.abort();
+      fi1.free();
+      FetchedInput fi4 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+      assertEquals(FetchedInput.Type.MEMORY, fi4.getType());
 
-    // Freed one memory allocation. Next should be mem again.
-    fi1.abort();
-    fi1.free();
-    FetchedInput fi4 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
-    assertEquals(FetchedInput.Type.MEMORY, fi4.getType());
-
-    // Freed one disk allocation. Next sould be disk again (no mem freed)
-    fi3.abort();
-    fi3.free();
-    FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
-    assertEquals(FetchedInput.Type.DISK, fi5.getType());
+      // Freed one disk allocation. Next sould be disk again (no mem freed)
+      fi3.abort();
+      fi3.free();
+      FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+      assertEquals(FetchedInput.Type.DISK, fi5.getType());
+    }));
   }
 }
-

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -38,7 +38,6 @@ public class RssSimpleFetchedInputAllocatorTest {
   
   @Test
   public void testAllocate() throws IOException {
-    String localDirs = "/tmp/" + this.getClass().getName();
     Configuration conf = new Configuration();
     
     long jvmMax = 954728448;
@@ -47,6 +46,7 @@ public class RssSimpleFetchedInputAllocatorTest {
     float bufferPercent = 0.1f;
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, bufferPercent);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 1.0f);
+    String localDirs = "/tmp/" + this.getClass().getName();
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, localDirs);
     
     long inMemThreshold = (long) (bufferPercent * jvmMax);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -63,11 +63,6 @@ public class RssSimpleFetchedInputAllocatorTest {
     FetchedInput fi1 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(1, 1));
     assertEquals(FetchedInput.Type.MEMORY, fi1.getType());
     
-    
-    FetchedInput fi2 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(2, 1));
-    assertEquals(FetchedInput.Type.MEMORY, fi2.getType());
-    
-    
     // Over limit by this point. Next reserve should give back a DISK allocation
     FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
     assertEquals(FetchedInput.Type.DISK, fi3.getType());
@@ -82,8 +77,6 @@ public class RssSimpleFetchedInputAllocatorTest {
     // Freed one disk allocation. Next sould be disk again (no mem freed)
     fi3.abort();
     fi3.free();
-    FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
-    assertEquals(FetchedInput.Type.DISK, fi5.getType());
   }
 }
 

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -82,6 +82,6 @@ public class RssSimpleFetchedInputAllocatorTest {
             fi3.free();
             FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
             assertEquals(FetchedInput.Type.DISK, fi5.getType());
-    }));
+          }));
   }
 }

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -38,7 +38,6 @@ public class RssSimpleFetchedInputAllocatorTest {
   
   @Test
   public void testAllocate() throws IOException {
-    String localDirs = "/tmp/" + this.getClass().getName();
     Configuration conf = new Configuration();
 
     long jvmMax = 954728448L;
@@ -47,6 +46,7 @@ public class RssSimpleFetchedInputAllocatorTest {
     float bufferPercent = 0.1f;
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, bufferPercent);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 1.0f);
+    String localDirs = "/tmp/" + this.getClass().getName();
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, localDirs);
 
     long inMemThreshold = (long) (bufferPercent * jvmMax);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssSimpleFetchedInputAllocatorTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.library.common.shuffle.impl;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tez.common.TezRuntimeFrameworkConfigs;
+import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RssSimpleFetchedInputAllocatorTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RssSimpleFetchedInputAllocatorTest.class);
+  
+  @Test
+  public void testAllocate() throws IOException {
+    String localDirs = "/tmp/" + this.getClass().getName();
+    Configuration conf = new Configuration();
+    
+    long jvmMax = 954728448;
+    LOG.info("jvmMax: " + jvmMax);
+    
+    float bufferPercent = 0.1f;
+    conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, bufferPercent);
+    conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 1.0f);
+    conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, localDirs);
+    
+    long inMemThreshold = (long) (bufferPercent * jvmMax);
+    LOG.info("InMemThreshold: " + inMemThreshold);
+
+    RssSimpleFetchedInputAllocator inputManager = new RssSimpleFetchedInputAllocator(
+        "srcName", UUID.randomUUID().toString(), 123, conf,
+        Runtime.getRuntime().maxMemory(), inMemThreshold);
+
+    long requestSize = (long) (0.4f * inMemThreshold);
+    long compressedSize = 1L;
+    LOG.info("RequestSize: " + requestSize);
+    
+    FetchedInput fi1 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(1, 1));
+    assertEquals(FetchedInput.Type.MEMORY, fi1.getType());
+    
+    
+    FetchedInput fi2 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(2, 1));
+    assertEquals(FetchedInput.Type.MEMORY, fi2.getType());
+    
+    
+    // Over limit by this point. Next reserve should give back a DISK allocation
+    FetchedInput fi3 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(3, 1));
+    assertEquals(FetchedInput.Type.DISK, fi3.getType());
+    
+    
+    // Freed one memory allocation. Next should be mem again.
+    fi1.abort();
+    fi1.free();
+    FetchedInput fi4 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+    assertEquals(FetchedInput.Type.MEMORY, fi4.getType());
+    
+    // Freed one disk allocation. Next sould be disk again (no mem freed)
+    fi3.abort();
+    fi3.free();
+    FetchedInput fi5 = inputManager.allocate(requestSize, compressedSize, new InputAttemptIdentifier(4, 1));
+    assertEquals(FetchedInput.Type.DISK, fi5.getType());
+  }
+}
+


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add Simple Fetched Allocator to allcation memory or disk for shuffle data

### Why are the changes needed?


Fix: https://github.com/apache/incubator-uniffle/issues/854

### Does this PR introduce _any_ user-facing change?


No.

### How was this patch tested?

unit test case