### PR TITLE
[#846] feat(cli): Service's start & stop & restart through Cli.

### DIFF
--- a/bin/uniffle
+++ b/bin/uniffle
@@ -23,8 +23,13 @@ function uniffle_usage
   uniffle_add_option "--daemon (start|status|stop)" "operate on a daemon"
   uniffle_add_subcommand "client-cli" client "prints uniffle-cli args information"
   uniffle_add_subcommand "admin-cli" admin "prints uniffle-admin args information"
+  uniffle_add_subcommand "shuffle-server" daemon "run the shuffle-server"
+  uniffle_add_subcommand "coordinator" daemon "run the coordinator"
   uniffle_generate_usage "${UNIFFLE_SHELL_EXECNAME}" true
 }
+
+uniffle_parse_args "$@"
+shift "${UNIFFLE_PARSE_COUNTER}"
 
 function uniffle_cmd_case
 {
@@ -37,6 +42,66 @@ function uniffle_cmd_case
     ;;
     admin-cli)
       UNIFFLE_CLASSNAME=org.apache.uniffle.cli.UniffleAdminCLI
+    ;;
+    shuffle-server)
+      MAX_DIRECT_MEMORY_OPTS=""
+      if [ -n "${MAX_DIRECT_MEMORY_SIZE:-}" ]; then
+        MAX_DIRECT_MEMORY_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY_SIZE"
+      fi
+
+      JVM_ARGS=" -server \
+          -Xmx${XMX_SIZE} \
+          -Xms${XMX_SIZE} \
+          ${MAX_DIRECT_MEMORY_OPTS} \
+          -XX:+UseG1GC \
+          -XX:MaxGCPauseMillis=200 \
+          -XX:ParallelGCThreads=20 \
+          -XX:ConcGCThreads=5 \
+          -XX:InitiatingHeapOccupancyPercent=20 \
+          -XX:G1HeapRegionSize=32m \
+          -XX:+UnlockExperimentalVMOptions \
+          -XX:G1NewSizePercent=10 \
+          -XX:+PrintGC \
+          -XX:+PrintAdaptiveSizePolicy \
+          -XX:+PrintGCDateStamps \
+          -XX:+PrintGCTimeStamps \
+          -XX:+PrintGCDetails \
+          -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
+
+      JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
+          -Xlog:gc:tags,time,uptime,level"
+      UNIFFLE_OPTS=$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS
+
+      UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION="true"
+      RSS_CONF_FILE="${RSS_CONF_DIR}/server.conf"
+      uniffle_add_classpath "${RSS_HOME}/jars/server/*"
+      UNIFFLE_CLASSNAME=org.apache.uniffle.server.ShuffleServer
+    ;;
+    coordinator)
+      JVM_ARGS=" -server \
+          -Xmx${XMX_SIZE:-8g} \
+          -Xms${XMX_SIZE:-8g} \
+          -XX:+UseG1GC \
+          -XX:MaxGCPauseMillis=200 \
+          -XX:ParallelGCThreads=20 \
+          -XX:ConcGCThreads=5 \
+          -XX:InitiatingHeapOccupancyPercent=45 \
+          -XX:+PrintGC \
+          -XX:+PrintAdaptiveSizePolicy \
+          -XX:+PrintGCDateStamps \
+          -XX:+PrintGCTimeStamps \
+          -XX:+PrintGCDetails \
+          -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
+
+      JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
+          -Xlog:gc:tags,time,uptime,level"
+
+      UNIFFLE_OPTS=$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS
+      echo UNIFFLE_OPTS
+      UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION="true"
+      RSS_CONF_FILE="${RSS_CONF_DIR}/coordinator.conf"
+      uniffle_add_classpath "${RSS_HOME}/jars/coordinator/*"
+      UNIFFLE_CLASSNAME=org.apache.uniffle.coordinator.CoordinatorServer
     ;;
     *)
       UNIFFLE_CLASSNAME="${subcmd}"
@@ -67,6 +132,8 @@ source "$(dirname "$0")/utils.sh"
 UNIFFLE_SHELL_SCRIPT_DEBUG=false
 load_rss_env
 uniffle_java_setup
+uniffle_basic_init
+uniffle_finalize_uniffle_opts
 
 CLASSPATH=""
 
@@ -74,6 +141,9 @@ JAR_DIR="${RSS_HOME}/jars"
 for file in $(ls ${JAR_DIR}/cli/*.jar 2>/dev/null); do
   CLASSPATH=$CLASSPATH:$file
 done
+
+HADOOP_DEPENDENCY="$("$HADOOP_HOME/bin/hadoop" classpath --glob)"
+CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR:$HADOOP_DEPENDENCY
 
 set +u
 uniffle_cmd_case "${UNIFFLE_SUBCMD}" "${UNIFFLE_SUBCMD_ARGS[@]}"

--- a/bin/uniffle
+++ b/bin/uniffle
@@ -70,7 +70,7 @@ function uniffle_cmd_case
 
       JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
           -Xlog:gc:tags,time,uptime,level"
-      UNIFFLE_OPTS=$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS
+      UNIFFLE_OPTS="$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS"
 
       UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION="true"
       RSS_CONF_FILE="${RSS_CONF_DIR}/server.conf"
@@ -95,9 +95,8 @@ function uniffle_cmd_case
 
       JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
           -Xlog:gc:tags,time,uptime,level"
+      UNIFFLE_OPTS="$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS"
 
-      UNIFFLE_OPTS=$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS
-      echo UNIFFLE_OPTS
       UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION="true"
       RSS_CONF_FILE="${RSS_CONF_DIR}/coordinator.conf"
       uniffle_add_classpath "${RSS_HOME}/jars/coordinator/*"

--- a/bin/uniffle-function.sh
+++ b/bin/uniffle-function.sh
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set +x
 declare -a UNIFFLE_SUBCMD_USAGE
 declare -a UNIFFLE_OPTION_USAGE
 declare -a UNIFFLE_SUBCMD_USAGE_TYPES
@@ -79,7 +80,7 @@ function uniffle_error
 #---
 function uniffle_debug
 {
-  if [[ -n "${UNIFFLE_SHELL_SCRIPT_DEBUG}" ]]; then
+  if [[ "${UNIFFLE_SHELL_SCRIPT_DEBUG}" = true ]]; then
     echo "DEBUG: $*" 1>&2
   fi
 }
@@ -303,7 +304,7 @@ function uniffle_add_option
   local option=$1
   local text=$2
 
-  UNIFFLE_OPTION_USAGE[${UNIFFLE_OPTION_USAGE}]="${option}@${text}"
+  UNIFFLE_OPTION_USAGE[${UNIFFLE_OPTION_USAGE_COUNTER}]="${option}@${text}"
   ((UNIFFLE_OPTION_USAGE_COUNTER=UNIFFLE_OPTION_USAGE_COUNTER+1))
 }
 
@@ -369,7 +370,422 @@ function uniffle_validate_classname
   return 0
 }
 
+function uniffle_basic_init
+{
+  CLASSPATH=""
+  uniffle_debug "Initialize CLASSPATH"
+
+  USER=${USER:-$(id -nu)}
+  UNIFFLE_IDENT_STRING=${UNIFFLE_IDENT_STRING:-$USER}
+  UNIFFLE_LOG_DIR=${RSS_LOG_DIR:-"${RSS_HOME}/logs"}
+  UNIFFLE_LOGFILE=${UNIFFLE_LOGFILE:-uniffle.log}
+  UNIFFLE_STOP_TIMEOUT=${UNIFFLE_STOP_TIMEOUT:-60}
+  UNIFFLE_PID_DIR=${RSS_PID_DIR:-"${RSS_HOME}"}
+  UNIFFLE_LOG_CONF_FILE=${LOG_CONF_FILE:-"${RSS_CONF_DIR}/log4j.properties"}
+
+  uniffle_debug "USER: "$USER
+  uniffle_debug "UNIFFLE_IDENT_STRING: "$UNIFFLE_IDENT_STRING
+  uniffle_debug "UNIFFLE_LOG_DIR: "$UNIFFLE_LOG_DIR
+  uniffle_debug "UNIFFLE_LOGFILE: "$UNIFFLE_LOGFILE
+  uniffle_debug "UNIFFLE_STOP_TIMEOUT: "$UNIFFLE_STOP_TIMEOUT
+}
+
+function uniffle_parse_args
+{
+  UNIFFLE_DAEMON_MODE="default"
+  UNIFFLE_PARSE_COUNTER=0
+  while true; do
+    uniffle_debug "uniffle_parse_args: processing $1"
+    case $1 in
+      --daemon)
+        shift
+        UNIFFLE_DAEMON_MODE=$1
+        uniffle_debug "UNIFFLE_DAEMON_MODE:"$UNIFFLE_DAEMON_MODE
+        shift
+        ((UNIFFLE_PARSE_COUNTER=UNIFFLE_PARSE_COUNTER+2))
+        if [[ -z "${UNIFFLE_DAEMON_MODE}" || \
+          ! "${UNIFFLE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]]; then
+          uniffle_error "ERROR: --daemon must be followed by either \"start\", \"stop\", or \"status\"."
+          uniffle_exit_with_usage 1
+        fi
+      ;;
+      *)
+        break
+      ;;
+    esac
+  done
+
+  uniffle_debug "uniffle_parse: asking caller to skip ${UNIFFLE_PARSE_COUNTER}"
+}
+
+function uniffle_add_classpath
+{
+  if [[ $1 =~ ^.*\*$ ]]; then
+    local mp
+    mp=$(dirname "$1")
+    if [[ ! -d "${mp}" ]]; then
+      uniffle_debug "Rejected CLASSPATH: $1 (not a dir)"
+      return 1
+    fi
+
+    # no wildcard in the middle, so check existence
+    # (doesn't matter *what* it is)
+  elif [[ ! $1 =~ ^.*\*.*$ ]] && [[ ! -e "$1" ]]; then
+    uniffle_debug "Rejected CLASSPATH: $1 (does not exist)"
+    return 1
+  fi
+  if [[ -z "${CLASSPATH}" ]]; then
+    CLASSPATH=$1
+    uniffle_debug "Initial CLASSPATH=$1"
+  elif [[ ":${CLASSPATH}:" != *":$1:"* ]]; then
+    if [[ "$2" = "before" ]]; then
+      CLASSPATH="$1:${CLASSPATH}"
+      uniffle_debug "Prepend CLASSPATH: $1"
+    else
+      CLASSPATH+=:$1
+      uniffle_debug "Append CLASSPATH: $1"
+    fi
+  else
+    uniffle_debug "Dupe CLASSPATH: $1"
+  fi
+  return 0
+}
+
+function uniffle_start_daemon
+{
+  local command=$1
+  local class=$2
+  local pidfile=$3
+  shift 3
+
+  uniffle_debug "Final CLASSPATH: ${CLASSPATH}"
+  uniffle_debug "Final UNIFFLE_OPTS: ${UNIFFLE_OPTS}"
+  uniffle_debug "Final JAVA_HOME: ${JAVA_HOME}"
+  uniffle_debug "java: ${JAVA}"
+  uniffle_debug "Class name: ${class}"
+  uniffle_debug "Command line options: $*"
+
+  echo $$ > "${pidfile}" 2>/dev/null
+  if [[ $? -gt 0 ]]; then
+    uniffle_error "ERROR:  Cannot write ${command} pid ${pidfile}."
+  fi
+
+  export CLASSPATH
+  exec "${JAVA}" "-Dproc_${command}" ${UNIFFLE_OPTS} "${class}" "$@"
+}
+
+function uniffle_rotate_log
+{
+  local log=$1;
+  local num=${2:-5};
+
+  if [[ -f "${log}" ]]; then
+    while [[ ${num} -gt 1 ]]; do
+      let prev=${num}-1
+      if [[ -f "${log}.${prev}" ]]; then
+        mv "${log}.${prev}" "${log}.${num}"
+      fi
+      num=${prev}
+    done
+    mv "${log}" "${log}.${num}"
+  fi
+}
+
+function uniffle_start_daemon_wrapper
+{
+  local daemonname=$1
+  local class=$2
+  local pidfile=$3
+  local outfile=$4
+
+  shift 4
+
+  local counter
+
+  uniffle_rotate_log "${outfile}"
+
+  uniffle_start_daemon "${daemonname}" \
+    "$class" \
+    "${pidfile}" \
+    "$@" >> "${outfile}" 2>&1 < /dev/null &
+
+  (( counter=0 ))
+  while [[ ! -f ${pidfile} && ${counter} -le 5 ]]; do
+    sleep 1
+    (( counter++ ))
+  done
+
+  echo $! > "${pidfile}" 2>/dev/null
+  if [[ $? -gt 0 ]]; then
+    uniffle_error "ERROR:  Cannot write ${daemonname} pid ${pidfile}."
+  fi
+
+  ulimit -a >> "${outfile}" 2>&1
+
+  if ! ps -p $! >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+
+function uniffle_status_daemon
+{
+  local pidfile=$1
+  shift
+
+  local pid
+  local pspid
+
+  if [[ -f "${pidfile}" ]]; then
+    pid=$(cat "${pidfile}")
+    if pspid=$(ps -o args= -p"${pid}" 2>/dev/null); then
+      if [[ ${pspid} =~ -Dproc_${daemonname} ]]; then
+        return 0
+      fi
+    fi
+    return 1
+  fi
+  return 3
+}
+
+function uniffle_daemon_handler
+{
+  set +e
+
+  local daemonmode=$1
+  local daemonname=$2
+  local class=$3
+  local daemon_pidfile=$4
+  local daemon_outfile=$5
+  shift 5
+
+  case ${daemonmode} in
+    status)
+      uniffle_status_daemon "${daemon_pidfile}"
+
+      if [[ $? == 0 ]]; then
+        echo "${daemonname} is running as process $(cat "${daemon_pidfile}")."
+      elif [[ $? == 1 ]]; then
+        echo "${daemonname} is stopped."
+      else
+        uniffle_error "uniffle_status_daemon error"
+      fi
+
+      exit $?
+    ;;
+
+    stop)
+      uniffle_stop_daemon "${daemonname}" "${daemon_pidfile}"
+      if [[ $? == 0 ]]; then
+        echo "${daemonname} stop success."
+      fi
+      exit $?
+    ;;
+
+    start|default)
+
+      uniffle_verify_piddir
+      uniffle_verify_logdir
+      uniffle_status_daemon "${daemon_pidfile}"
+
+      if [[ $? == 0 ]]; then
+        uniffle_error "${daemonname} is running as process $(cat "${daemon_pidfile}").  Stop it first and ensure ${daemon_pidfile} file is empty before retry."
+        exit 1
+      else
+        rm -f "${daemon_pidfile}" >/dev/null 2>&1
+      fi
+
+      if [[ "$daemonmode" = "default" ]]; then
+        uniffle_start_daemon "${daemonname}" "${class}" "${daemon_pidfile}" "$@"
+      else
+        uniffle_start_daemon_wrapper "${daemonname}" "${class}" "${daemon_pidfile}" "${daemon_outfile}" "$@"
+      fi
+
+      if [[ $? == 0 ]]; then
+        echo "${daemonname} start success, is running as process $(cat "${daemon_pidfile}")."
+      fi
+    ;;
+  esac
+
+  set -e
+}
+
+function uniffle_start_daemon
+{
+  local command=$1
+  local class=$2
+  local pidfile=$3
+  shift 3
+
+  uniffle_debug "Final CLASSPATH: ${CLASSPATH}"
+  uniffle_debug "Final UNIFFLE_OPTS: ${UNIFFLE_OPTS}"
+  uniffle_debug "Final JAVA_HOME: ${JAVA_HOME}"
+  uniffle_debug "java: ${JAVA}"
+  uniffle_debug "Class name: ${class}"
+  uniffle_debug "Command line options: $*"
+
+  echo $$ > "${pidfile}" 2>/dev/null
+  if [[ $? -gt 0 ]]; then
+    uniffle_error "ERROR:  Cannot write ${command} pid ${pidfile}."
+  fi
+
+  export CLASSPATH
+  exec "${JAVA}" "-Dproc_${command}" ${UNIFFLE_OPTS} "${class}" --conf "$RSS_CONF_FILE" "$@"
+}
+
+function uniffle_stop_daemon
+{
+  local cmd=$1
+  local pidfile=$2
+  shift 2
+
+  local pid
+  local cur_pid
+
+  if [[ -f "${pidfile}" ]]; then
+    pid=$(cat "$pidfile")
+
+    kill "${pid}" >/dev/null 2>&1
+
+    wait_process_to_die_or_timeout "${pid}" "${UNIFFLE_STOP_TIMEOUT}"
+
+    if kill -0 "${pid}" > /dev/null 2>&1; then
+      uniffle_error "WARNING: ${cmd} did not stop gracefully after ${UNIFFLE_STOP_TIMEOUT} seconds: Trying to kill with kill -9"
+      kill -9 "${pid}" >/dev/null 2>&1
+    fi
+    wait_process_to_die_or_timeout "${pid}" "${UNIFFLE_STOP_TIMEOUT}"
+    if ps -p "${pid}" > /dev/null 2>&1; then
+      uniffle_error "ERROR: Unable to kill ${pid}"
+    else
+      cur_pid=$(cat "$pidfile")
+      if [[ "${pid}" = "${cur_pid}" ]]; then
+        rm -f "${pidfile}" >/dev/null 2>&1
+      else
+        uniffle_error "WARNING: pid has changed for ${cmd}, skip deleting pid file"
+      fi
+    fi
+  fi
+}
+
+function wait_process_to_die_or_timeout
+{
+  local pid=$1
+  local timeout=$2
+
+  timeout=$(printf "%.0f\n" "${timeout}")
+  if [[ ${timeout} -lt 1  ]]; then
+    timeout=1
+  fi
+
+  for (( i=0; i < "${timeout}"; i++ ))
+  do
+    if kill -0 "${pid}" > /dev/null 2>&1; then
+      sleep 1
+    else
+      break
+    fi
+  done
+}
+
+function uniffle_verify_piddir
+{
+  uniffle_debug "uniffle_verify_piddir: "${UNIFFLE_PID_DIR}
+  if [[ -z "${UNIFFLE_PID_DIR}" ]]; then
+    uniffle_error "No pid directory defined."
+    exit 1
+  fi
+  uniffle_mkdir "${UNIFFLE_PID_DIR}"
+  touch "${UNIFFLE_PID_DIR}/$$" >/dev/null 2>&1
+  if [[ $? -gt 0 ]]; then
+    uniffle_error "ERROR: Unable to write in ${UNIFFLE_PID_DIR}. Aborting."
+    exit 1
+  fi
+  rm "${UNIFFLE_PID_DIR}/$$" >/dev/null 2>&1
+}
+
+function uniffle_verify_logdir
+{
+  uniffle_debug "uniffle_verify_logdir: "${UNIFFLE_LOG_DIR}
+  if [[ -z "${UNIFFLE_LOG_DIR}" ]]; then
+    uniffle_error "No Uniffle log directory defined."
+    exit 1
+  fi
+  uniffle_mkdir "${UNIFFLE_LOG_DIR}"
+  touch "${UNIFFLE_LOG_DIR}/$$" >/dev/null 2>&1
+  if [[ $? -gt 0 ]]; then
+    uniffle_error "ERROR: Unable to write in ${UNIFFLE_LOG_DIR}. Aborting."
+    exit 1
+  fi
+  rm "${UNIFFLE_LOG_DIR}/$$" >/dev/null 2>&1
+}
+
+function uniffle_mkdir
+{
+  local dir=$1
+
+  if [[ ! -w "${dir}" ]] && [[ ! -d "${dir}" ]]; then
+    uniffle_error "WARNING: ${dir} does not exist. Creating."
+    if ! mkdir -p "${dir}"; then
+      uniffle_error "ERROR: Unable to create ${dir}. Aborting."
+      exit 1
+    fi
+  fi
+}
+
+function uniffle_finalize_uniffle_opts
+{
+  set +u
+  uniffle_add_param UNIFFLE_OPTS log4j.configuration "-Dlog4j.configuration=file:${UNIFFLE_LOG_CONF_FILE}"
+  uniffle_add_param UNIFFLE_OPTS uniffle.log.dir "-Duniffle.log.dir=${UNIFFLE_LOG_DIR}"
+  uniffle_add_param UNIFFLE_OPTS uniffle.home.dir "-Duniffle.home.dir=${RSS_HOME}"
+  uniffle_add_param UNIFFLE_OPTS uniffle.id.str "-Duniffle.id.str=${UNIFFLE_IDENT_STRING}"
+  set -u
+}
+
+function uniffle_add_param
+{
+  if [[ ! ${!1} =~ $2 ]] ; then
+    eval "$1"="'${!1} $3'"
+    if [[ ${!1:0:1} = ' ' ]]; then
+      eval "$1"="'${!1# }'"
+    fi
+    uniffle_debug "$1 accepted $3"
+  else
+    uniffle_debug "$1 declined $3"
+  fi
+}
+
 function uniffle_generic_java_subcmd_handler
 {
-  uniffle_java_exec "${UNIFFLE_SUBCMD}" "${UNIFFLE_CLASSNAME}" "${UNIFFLE_SUBCMD_ARGS[@]}"
+  declare priv_outfile
+  declare priv_errfile
+  declare priv_pidfile
+  declare daemon_outfile
+  declare daemon_pidfile
+
+  if [[ "${UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION}" = true ]]; then
+
+    daemon_outfile="${UNIFFLE_LOG_DIR}/uniffle-${UNIFFLE_IDENT_STRING}-${UNIFFLE_SUBCMD}-${HOSTNAME}.out"
+    daemon_pidfile="${UNIFFLE_PID_DIR}/uniffle-${UNIFFLE_IDENT_STRING}-${UNIFFLE_SUBCMD}.pid"
+    UNIFFLE_LOGFILE="uniffle-${UNIFFLE_IDENT_STRING}-${UNIFFLE_SUBCMD}-${HOSTNAME}.log"
+    uniffle_add_param UNIFFLE_OPTS log.path "-Dlog.path=${UNIFFLE_LOG_DIR}/${UNIFFLE_LOGFILE}"
+
+    uniffle_debug "Daemon Outfile: ${daemon_outfile}"
+    uniffle_debug "Daemon Pidfile: ${daemon_pidfile}"
+    uniffle_debug "UNIFFLE_DAEMON_MODE: "$UNIFFLE_DAEMON_MODE
+    uniffle_debug "UNIFFLE_SUBCMD: "$UNIFFLE_SUBCMD
+    uniffle_debug "UNIFFLE_CLASSNAME: "$UNIFFLE_CLASSNAME
+    uniffle_debug "UNIFFLE_SUBCMD_ARGS: "$UNIFFLE_SUBCMD_ARGS
+
+    uniffle_daemon_handler \
+        "${UNIFFLE_DAEMON_MODE}" \
+        "${UNIFFLE_SUBCMD}" \
+        "${UNIFFLE_CLASSNAME}" \
+        "${daemon_pidfile}" \
+        "${daemon_outfile}" \
+        "${UNIFFLE_SUBCMD_ARGS[@]}"
+    exit $?
+  else
+    uniffle_java_exec "${UNIFFLE_SUBCMD}" "${UNIFFLE_CLASSNAME}" "${UNIFFLE_SUBCMD_ARGS[@]}"
+  fi
 }

--- a/bin/uniffle-function.sh
+++ b/bin/uniffle-function.sh
@@ -370,6 +370,9 @@ function uniffle_validate_classname
   return 0
 }
 
+#---
+# uniffle_basic_init: Initialize some basic environment variables for Uniffle.
+#---
 function uniffle_basic_init
 {
   CLASSPATH=""
@@ -390,6 +393,9 @@ function uniffle_basic_init
   uniffle_debug "UNIFFLE_STOP_TIMEOUT: "$UNIFFLE_STOP_TIMEOUT
 }
 
+#---
+# uniffle_parse_args: Initialize some basic environment variables for Uniffle.
+#---
 function uniffle_parse_args
 {
   UNIFFLE_DAEMON_MODE="default"
@@ -415,9 +421,12 @@ function uniffle_parse_args
     esac
   done
 
-  uniffle_debug "uniffle_parse: asking caller to skip ${UNIFFLE_PARSE_COUNTER}"
+  uniffle_debug "uniffle_parse: requesting the caller to skip ${UNIFFLE_PARSE_COUNTER}"
 }
 
+#---
+# uniffle_add_classpath: add jars or path to the classpath.
+#---
 function uniffle_add_classpath
 {
   if [[ $1 =~ ^.*\*$ ]]; then
@@ -427,9 +436,6 @@ function uniffle_add_classpath
       uniffle_debug "Rejected CLASSPATH: $1 (not a dir)"
       return 1
     fi
-
-    # no wildcard in the middle, so check existence
-    # (doesn't matter *what* it is)
   elif [[ ! $1 =~ ^.*\*.*$ ]] && [[ ! -e "$1" ]]; then
     uniffle_debug "Rejected CLASSPATH: $1 (does not exist)"
     return 1
@@ -451,6 +457,9 @@ function uniffle_add_classpath
   return 0
 }
 
+#---
+# uniffle_start_daemon: Start the daemon process.
+#---
 function uniffle_start_daemon
 {
   local command=$1
@@ -474,6 +483,9 @@ function uniffle_start_daemon
   exec "${JAVA}" "-Dproc_${command}" ${UNIFFLE_OPTS} "${class}" "$@"
 }
 
+#---
+# uniffle_rotate_log: rotate uniffle log.
+#---
 function uniffle_rotate_log
 {
   local log=$1;
@@ -491,6 +503,9 @@ function uniffle_rotate_log
   fi
 }
 
+#---
+# uniffle_start_daemon_wrapper: start uniffle daemon wrapper.
+#---
 function uniffle_start_daemon_wrapper
 {
   local daemonname=$1
@@ -528,6 +543,13 @@ function uniffle_start_daemon_wrapper
   return 0
 }
 
+#---
+# uniffle_start_daemon: check daemon status.
+# @param        pidfile
+# @return  0, The uniffle process has started and running
+#          1, The uniffle process has started but dead
+#          3, The uniffle process not running
+#---
 function uniffle_status_daemon
 {
   local pidfile=$1
@@ -548,6 +570,14 @@ function uniffle_status_daemon
   return 3
 }
 
+#---
+# uniffle_daemon_handler: handling daemon requests for uniffle.
+# @param daemonmode [start|stop|status|default]
+# @param daemonname [coordinator|shuffle-server]
+# @param class The main function that needs to be started.
+# @param daemonpidfile
+# @param daemonoutfile
+#---
 function uniffle_daemon_handler
 {
   set +e
@@ -610,6 +640,12 @@ function uniffle_daemon_handler
   set -e
 }
 
+#---
+# uniffle_start_daemon: Start the Uniffle service.
+# @param command [coordinator|shuffle-server]
+# @param class The main function that needs to be started.
+# @param pidfile pid file.
+#---
 function uniffle_start_daemon
 {
   local command=$1
@@ -633,6 +669,11 @@ function uniffle_start_daemon
   exec "${JAVA}" "-Dproc_${command}" ${UNIFFLE_OPTS} "${class}" --conf "$RSS_CONF_FILE" "$@"
 }
 
+#---
+# uniffle_stop_daemon: Stop the Uniffle service.
+# @param command [coordinator|shuffle-server]
+# @param pidfile pid file.
+#---
 function uniffle_stop_daemon
 {
   local cmd=$1
@@ -667,6 +708,11 @@ function uniffle_stop_daemon
   fi
 }
 
+#---
+# wait_process_to_die_or_timeout: Wait for the program to terminate or timeout.
+# @param pid process pid.
+# @param timeout timeout duration.
+#---
 function wait_process_to_die_or_timeout
 {
   local pid=$1
@@ -687,6 +733,9 @@ function wait_process_to_die_or_timeout
   done
 }
 
+#---
+# uniffle_verify_piddir: verify pid folder.
+#---
 function uniffle_verify_piddir
 {
   uniffle_debug "uniffle_verify_piddir: "${UNIFFLE_PID_DIR}
@@ -703,6 +752,9 @@ function uniffle_verify_piddir
   rm "${UNIFFLE_PID_DIR}/$$" >/dev/null 2>&1
 }
 
+#---
+# uniffle_verify_piddir: verify log folder.
+#---
 function uniffle_verify_logdir
 {
   uniffle_debug "uniffle_verify_logdir: "${UNIFFLE_LOG_DIR}
@@ -719,6 +771,9 @@ function uniffle_verify_logdir
   rm "${UNIFFLE_LOG_DIR}/$$" >/dev/null 2>&1
 }
 
+#---
+# uniffle_mkdir: uniffle mkdir.
+#---
 function uniffle_mkdir
 {
   local dir=$1
@@ -732,6 +787,9 @@ function uniffle_mkdir
   fi
 }
 
+#---
+# uniffle_finalize_uniffle_opts: Finish configuring Uniffle specific system properties.
+#---
 function uniffle_finalize_uniffle_opts
 {
   set +u
@@ -742,6 +800,9 @@ function uniffle_finalize_uniffle_opts
   set -u
 }
 
+#---
+# uniffle_add_param: Append command line arguments.
+#---
 function uniffle_add_param
 {
   if [[ ! ${!1} =~ $2 ]] ; then
@@ -755,6 +816,9 @@ function uniffle_add_param
   fi
 }
 
+#---
+# uniffle_generic_java_subcmd_handler: Execute java common commands.
+#---
 function uniffle_generic_java_subcmd_handler
 {
   declare priv_outfile


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

We support starting and stopping services using CLI commands.

- Command 1: uniffle --daemon start coordinator

```
coordinator start success, is running as process 61743.
```

- Command 2: uniffle --daemon stop coordinator

```
coordinator stop success.
```

- Command 3: uniffle --daemon status coordinator

> If the service is started

```
coordinator is running as process 62087.
```

> If the service is stoped
```
coordinator is stopped.
```


### Why are the changes needed?

Supporting service start and stop functionality using CLI commands is part of this PR.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Testing environment verification.
