### PR TITLE
[#937] feat: Add rest api for servernode list of losing connection and unhealthy

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
+++ b/common/src/main/java/org/apache/uniffle/common/ServerStatus.java
@@ -27,6 +27,8 @@ public enum ServerStatus {
   ACTIVE(0),
   DECOMMISSIONING(1),
   DECOMMISSIONED(2),
+  LOST(3),
+  UNHEALTHY(4),
   UNKNOWN(-1);
 
   static final Map<Integer, ServerStatus> VALUE_MAP =

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -41,6 +41,20 @@ public interface ClusterManager extends Closeable, Reconfigurable {
   List<ServerNode> getServerList(Set<String> requiredTags);
 
   /**
+   * Get lost nodes from the cluster
+   *
+   * @return list of lost nodes
+   */
+  List<ServerNode> getLostServerList();
+  
+  /**
+   * Get unhealthy nodes from the cluster
+   *
+   * @return list of unhealthy nodes
+   */
+  List<ServerNode> getUnhealthyServerList();
+
+  /**
    * @return number of server nodes in the cluster
    */
   int getNodesNum();

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -37,8 +37,7 @@ public class ServerNode implements Comparable<ServerNode> {
   private int eventNumInFlush;
   private long timestamp;
   private Set<String> tags;
-  private boolean isHealthy;
-  private final ServerStatus status;
+  private ServerStatus status;
   private Map<String, StorageInfo> storageInfo;
   private int nettyPort = -1;
 
@@ -110,8 +109,7 @@ public class ServerNode implements Comparable<ServerNode> {
     this.eventNumInFlush = eventNumInFlush;
     this.timestamp = System.currentTimeMillis();
     this.tags = tags;
-    this.isHealthy = isHealthy;
-    this.status = status;
+    this.status = isHealthy ? status : ServerStatus.UNHEALTHY;
     this.storageInfo = storageInfoMap;
     if (nettyPort > 0) {
       this.nettyPort = nettyPort;
@@ -160,12 +158,17 @@ public class ServerNode implements Comparable<ServerNode> {
   }
 
   public boolean isHealthy() {
-    return isHealthy;
+    return this.status != ServerStatus.UNHEALTHY;
   }
-
+  
   public ServerStatus getStatus() {
     return status;
   }
+  
+  public void setStatus(ServerStatus serverStatus) {
+    this.status = serverStatus;
+  }
+  
 
   public Map<String, StorageInfo> getStorageInfo() {
     return storageInfo;
@@ -183,7 +186,6 @@ public class ServerNode implements Comparable<ServerNode> {
         + "], eventNumInFlush[" + eventNumInFlush
         + "], timestamp[" + timestamp
         + "], tags" + tags.toString() + ""
-        + ", healthy[" + isHealthy
         + ", status[" + status
         + "], storages[num=" + storageInfo.size() + "]";
 
@@ -192,7 +194,7 @@ public class ServerNode implements Comparable<ServerNode> {
   /**
    * Only for test case
    */
-  void setTimestamp(long timestamp) {
+  public void setTimestamp(long timestamp) {
     this.timestamp = timestamp;
   }
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/servlet/NodesServlet.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/servlet/NodesServlet.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.coordinator.CoordinatorServer;
 import org.apache.uniffle.coordinator.ServerNode;
 import org.apache.uniffle.coordinator.web.Response;
@@ -37,10 +38,17 @@ public class NodesServlet extends BaseServlet<List<ServerNode>> {
   }
 
   @Override
-  protected Response<List<ServerNode>> handleGet(HttpServletRequest req, HttpServletResponse resp) {
-    List<ServerNode> serverList = coordinator.getClusterManager().getServerList(Collections.EMPTY_SET);
+  protected Response handleGet(HttpServletRequest req, HttpServletResponse resp) {
+    List<ServerNode> serverList;
     String id = req.getParameter("id");
     String status = req.getParameter("status");
+    if (ServerStatus.UNHEALTHY.name().equalsIgnoreCase(status)) {
+      serverList = coordinator.getClusterManager().getUnhealthyServerList();
+    } else if (ServerStatus.LOST.name().equalsIgnoreCase(status)) {
+      serverList = coordinator.getClusterManager().getLostServerList();
+    } else {
+      serverList = coordinator.getClusterManager().getServerList(Collections.EMPTY_SET);
+    }
     serverList = serverList.stream().filter((server) -> {
       if (id != null && !id.equals(server.getId())) {
         return false;

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -239,6 +239,8 @@ enum ServerStatus {
   ACTIVE = 0;
   DECOMMISSIONING = 1;
   DECOMMISSIONED = 2;
+  LOST = 3;
+  UNHEALTHY = 4;
   // todo: more status, such as UPGRADING
 }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -457,6 +457,11 @@ public class ShuffleServer {
     return isHealthy.get();
   }
 
+  @VisibleForTesting
+  public void markUnhealthy() {
+    isHealthy.set(false);
+  }
+
   public GRPCMetrics getGrpcMetrics() {
     return grpcMetrics;
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
  Obtain the list of ServerNodes whose heartbeat is lost from a Coordinator Server
  Obtain the list of ServerNodes whose unhealthy from a Coordinator Server

### Why are the changes needed?
There is no interface for viewing lost and unhealthy lists

Fix: #937

### Does this PR introduce _any_ user-facing change?
  1. Change in user-facing APIs.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  Updated UT: SimpleClusterManagerTest
