### PR TITLE
[MINOR] Add new collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,9 @@ github:
   collaborators:
     - leixm
     - wangao1236
+    - lifeSo
+    - zhengchenyu
+    - xumanbu
   enabled_merge_buttons:
     squash: true
     merge: false


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new collaborators:
lifeSo
zhengchenyu
xumanbu

### Why are the changes needed?
Collaborators can run the workflow without committer's approval and manage issues.
1. lifeSo is responsible for Apache Tez framework. 
2. zhengchenyu is responsible for the support of Hadoop 3.2.
3. xumanbu is responsible for the support of Netty.

They have contributed some features and improvements.  It will be more convenient for them to become collaborators.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need.
