### PR TITLE
[#381]imporvement(server): Check JAVA_HOME and HADOOP_HOME in start-shuffle-server.sh

### DIFF
--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -97,7 +97,7 @@ cd $RSS_HOME
 
 if [ -z "$JAVA_HOME" ]; then
   echo "Error: JAVA_HOME is not set, cannot proceed."
-  exit 1
+  exit -1
 fi
 
 if [ $(command -v git) ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Comment the variable `JAVA_HOME` and `HADOOP_HOME` assignment in `bin/rss-env.sh`
- Keep the variable `JAVA_HOME` and `HADOOP_HOME` be checked in `bin/utils.sh`

### Why are the changes needed?

Fix: #381 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

current UT