### PR TITLE
[#363] refactor: Make the coordinator client managed by CoordinatorClientFactory singleton

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -108,9 +108,9 @@ public class RssSparkShuffleUtils {
   public static List<CoordinatorClient> createCoordinatorClients(SparkConf sparkConf) {
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
-    CoordinatorClientFactory coordinatorClientFactory =
-        new CoordinatorClientFactory(ClientType.valueOf(clientType));
-    return coordinatorClientFactory.createCoordinatorClient(coordinators);
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
+    factory.setCoordinatorClientType(ClientType.valueOf(clientType));
+    return factory.createCoordinatorClient(coordinators);
   }
 
   public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -46,8 +46,6 @@ import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.util.ClientUtils;
-import org.apache.uniffle.client.util.RssClientConfig;
-import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
@@ -59,7 +57,6 @@ import org.apache.uniffle.common.util.Constants;
 import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
 
 public class RssSparkShuffleUtils {
-
   private static final Logger LOG = LoggerFactory.getLogger(RssSparkShuffleUtils.class);
 
   public static final ClassTag<ShuffleHandleInfo> SHUFFLE_HANDLER_INFO_CLASS_TAG =
@@ -109,8 +106,7 @@ public class RssSparkShuffleUtils {
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    factory.setCoordinatorClientType(ClientType.valueOf(clientType));
-    return factory.createCoordinatorClient(coordinators);
+    return factory.getOrCreateCoordinatorClient(clientType, coordinators);
   }
 
   public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -57,6 +57,7 @@ import org.apache.uniffle.common.util.Constants;
 import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
 
 public class RssSparkShuffleUtils {
+
   private static final Logger LOG = LoggerFactory.getLogger(RssSparkShuffleUtils.class);
 
   public static final ClassTag<ShuffleHandleInfo> SHUFFLE_HANDLER_INFO_CLASS_TAG =
@@ -103,6 +104,11 @@ public class RssSparkShuffleUtils {
   }
 
   public static List<CoordinatorClient> createCoordinatorClients(SparkConf sparkConf) {
+    if (sparkConf == null) {
+      LOG.warn("Spark conf is null");
+      return null;
+    }
+
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -112,7 +112,7 @@ public class RssSparkShuffleUtils {
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    return factory.getOrCreateCoordinatorClient(clientType, coordinators);
+    return factory.getOrCreateCoordinatorClients(clientType, coordinators);
   }
 
   public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -161,7 +161,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    this.heartBeatExecutorService = ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
+    this.heartBeatExecutorService =
+        ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
     this.replica = replica;
     this.replicaWrite = replicaWrite;
     this.replicaRead = replicaRead;
@@ -563,7 +564,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
   @Override
   public void registerCoordinators(String coordinators) {
-    List<CoordinatorClient> clients = coordinatorClientFactory.getOrCreateCoordinatorClients(clientType, coordinators);
+    List<CoordinatorClient> clients =
+        coordinatorClientFactory.getOrCreateCoordinatorClients(clientType, coordinators);
     coordinatorClients.addAll(clients);
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -77,7 +77,6 @@ import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.client.util.ClientUtils;
-import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -162,7 +161,6 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    this.coordinatorClientFactory.setCoordinatorClientType(ClientType.valueOf(clientType));
     this.heartBeatExecutorService = ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
     this.replica = replica;
     this.replicaWrite = replicaWrite;
@@ -565,8 +563,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
   @Override
   public void registerCoordinators(String coordinators) {
-    List<CoordinatorClient> clients =
-        coordinatorClientFactory.createCoordinatorClient(coordinators);
+    List<CoordinatorClient> clients = coordinatorClientFactory.getOrCreateCoordinatorClients(clientType, coordinators);
     coordinatorClients.addAll(clients);
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -162,7 +162,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
     this.coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    coordinatorClientFactory.setCoordinatorClientType(ClientType.valueOf(clientType));
+    this.coordinatorClientFactory.setCoordinatorClientType(ClientType.valueOf(clientType));
     this.heartBeatExecutorService = ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
     this.replica = replica;
     this.replicaWrite = replicaWrite;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -161,9 +161,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.clientType = clientType;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
-    this.coordinatorClientFactory = new CoordinatorClientFactory(ClientType.valueOf(clientType));
-    this.heartBeatExecutorService =
-        ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
+    this.coordinatorClientFactory = CoordinatorClientFactory.getInstance();
+    coordinatorClientFactory.setCoordinatorClientType(ClientType.valueOf(clientType));
+    this.heartBeatExecutorService = ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
     this.replica = replica;
     this.replicaWrite = replicaWrite;
     this.replicaRead = replicaRead;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -172,12 +172,12 @@ public class AccessClusterTest extends CoordinatorTestBase {
     shuffleServer.start();
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 
-    CoordinatorClient client =
-        new CoordinatorClientFactory(ClientType.GRPC)
-            .createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
-    request =
-        new RssAccessClusterRequest(
-            accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");
+    CoordinatorClientFactory coordinatorClientFactory = CoordinatorClientFactory.getInstance();
+    coordinatorClientFactory.setCoordinatorClientType(ClientType.GRPC);
+    CoordinatorClient client = coordinatorClientFactory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
+
+    request = new RssAccessClusterRequest(accessId,
+        Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");
     response = client.accessCluster(request);
     assertEquals(StatusCode.INTERNAL_ERROR, response.getStatusCode());
     assertTrue(response.getMessage().startsWith("UNAVAILABLE: io exception"));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -173,8 +173,8 @@ public class AccessClusterTest extends CoordinatorTestBase {
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    factory.setCoordinatorClientType(ClientType.GRPC);
-    CoordinatorClient client = factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
+    CoordinatorClient client = factory.getOrCreateCoordinatorClient(ClientType.GRPC.name(),
+            LOCALHOST, COORDINATOR_PORT_1 + 13);
 
     request = new RssAccessClusterRequest(accessId,
         Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -172,9 +172,9 @@ public class AccessClusterTest extends CoordinatorTestBase {
     shuffleServer.start();
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 
-    CoordinatorClientFactory coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    coordinatorClientFactory.setCoordinatorClientType(ClientType.GRPC);
-    CoordinatorClient client = coordinatorClientFactory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
+    factory.setCoordinatorClientType(ClientType.GRPC);
+    CoordinatorClient client = factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
 
     request = new RssAccessClusterRequest(accessId,
         Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -173,11 +173,13 @@ public class AccessClusterTest extends CoordinatorTestBase {
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    CoordinatorClient client = factory.getOrCreateCoordinatorClient(ClientType.GRPC.name(),
-            LOCALHOST, COORDINATOR_PORT_1 + 13);
+    CoordinatorClient client =
+        factory.getOrCreateCoordinatorClient(
+            ClientType.GRPC.name(), LOCALHOST, COORDINATOR_PORT_1 + 13);
 
-    request = new RssAccessClusterRequest(accessId,
-        Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");
+    request =
+        new RssAccessClusterRequest(
+            accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");
     response = client.accessCluster(request);
     assertEquals(StatusCode.INTERNAL_ERROR, response.getStatusCode());
     assertTrue(response.getMessage().startsWith("UNAVAILABLE: io exception"));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
@@ -26,11 +26,12 @@ import org.apache.uniffle.common.ClientType;
 
 public class CoordinatorTestBase extends IntegrationTestBase {
 
-  protected CoordinatorClientFactory factory = new CoordinatorClientFactory(ClientType.GRPC);
+  protected CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
   protected CoordinatorGrpcClient coordinatorClient;
 
   @BeforeEach
   public void createClient() {
+    factory.setCoordinatorClientType(ClientType.GRPC);
     coordinatorClient =
         (CoordinatorGrpcClient) factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1);
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
@@ -32,8 +32,9 @@ public class CoordinatorTestBase extends IntegrationTestBase {
   @BeforeEach
   public void createClient() {
     coordinatorClient =
-        (CoordinatorGrpcClient) factory.getOrCreateCoordinatorClient(ClientType.GRPC.name(),
-                LOCALHOST, COORDINATOR_PORT_1);
+        (CoordinatorGrpcClient)
+            factory.getOrCreateCoordinatorClient(
+                ClientType.GRPC.name(), LOCALHOST, COORDINATOR_PORT_1);
   }
 
   @AfterEach

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
@@ -31,9 +31,9 @@ public class CoordinatorTestBase extends IntegrationTestBase {
 
   @BeforeEach
   public void createClient() {
-    factory.setCoordinatorClientType(ClientType.GRPC);
     coordinatorClient =
-        (CoordinatorGrpcClient) factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1);
+        (CoordinatorGrpcClient) factory.getOrCreateCoordinatorClient(ClientType.GRPC.name(),
+                LOCALHOST, COORDINATOR_PORT_1);
   }
 
   @AfterEach

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -35,7 +35,15 @@ public class CoordinatorClientFactory {
 
   private ClientType clientType;
 
-  public CoordinatorClientFactory(ClientType clientType) {
+  private static class LazyHolder {
+    static final CoordinatorClientFactory INSTANCE = new CoordinatorClientFactory();
+  }
+
+  public static CoordinatorClientFactory getInstance() {
+    return LazyHolder.INSTANCE;
+  }
+
+  public void setCoordinatorClientType(ClientType clientType) {
     this.clientType = clientType;
   }
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -59,7 +59,7 @@ public class CoordinatorClientFactory {
         typeToClients.put(coordinator, grpcClient);
         clients.put(type, typeToClients);
         return grpcClient;
-      default :
+      default:
         throw new UnsupportedOperationException("Unsupported client type " + type);
     }
   }

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -58,8 +58,7 @@ public class RegisterHeartBeat {
     this.heartBeatInterval = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL);
     this.coordinatorQuorum = conf.getString(ShuffleServerConf.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    factory.setCoordinatorClientType(conf.get(ShuffleServerConf.RSS_CLIENT_TYPE));
-    this.coordinatorClients = factory.getOrCreateCoordinatorClient(
+    this.coordinatorClients = factory.getOrCreateCoordinatorClients(
             conf.get(ShuffleServerConf.RSS_CLIENT_TYPE).name(), this.coordinatorQuorum);
     this.shuffleServer = shuffleServer;
     this.heartBeatExecutorService =

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -58,7 +58,8 @@ public class RegisterHeartBeat {
     this.heartBeatInterval = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL);
     this.coordinatorQuorum = conf.getString(ShuffleServerConf.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
-    this.coordinatorClients = factory.getOrCreateCoordinatorClients(
+    this.coordinatorClients =
+        factory.getOrCreateCoordinatorClients(
             conf.get(ShuffleServerConf.RSS_CLIENT_TYPE).name(), this.coordinatorQuorum);
     this.shuffleServer = shuffleServer;
     this.heartBeatExecutorService =

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -57,8 +57,8 @@ public class RegisterHeartBeat {
     this.heartBeatInitialDelay = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_DELAY);
     this.heartBeatInterval = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL);
     this.coordinatorQuorum = conf.getString(ShuffleServerConf.RSS_COORDINATOR_QUORUM);
-    CoordinatorClientFactory factory =
-        new CoordinatorClientFactory(conf.get(ShuffleServerConf.RSS_CLIENT_TYPE));
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
+    factory.setCoordinatorClientType(conf.get(ShuffleServerConf.RSS_CLIENT_TYPE));
     this.coordinatorClients = factory.createCoordinatorClient(this.coordinatorQuorum);
     this.shuffleServer = shuffleServer;
     this.heartBeatExecutorService =

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -59,7 +59,8 @@ public class RegisterHeartBeat {
     this.coordinatorQuorum = conf.getString(ShuffleServerConf.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
     factory.setCoordinatorClientType(conf.get(ShuffleServerConf.RSS_CLIENT_TYPE));
-    this.coordinatorClients = factory.createCoordinatorClient(this.coordinatorQuorum);
+    this.coordinatorClients = factory.getOrCreateCoordinatorClient(
+            conf.get(ShuffleServerConf.RSS_CLIENT_TYPE).name(), this.coordinatorQuorum);
     this.shuffleServer = shuffleServer;
     this.heartBeatExecutorService =
         ThreadUtils.getDaemonFixedThreadPool(


### PR DESCRIPTION
Hi @zuston 

Any comments and suggestions would be appreciated if you are available, thank you.

### What changes were proposed in this pull request?

Make the coordinator client managed by CoordinatorClientFactory singleton

### Why are the changes needed?

Fix: #363

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

current UT