### PR TITLE
[#983] improvement(tez): Optimize tez client delivery configuration

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
@@ -18,7 +18,9 @@
 package org.apache.tez.common;
 
 import java.util.Map;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.Configuration;
 
 import org.apache.uniffle.client.util.RssClientConfig;
@@ -153,8 +155,6 @@ public class RssTezConfig {
   public static final int RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE =
       RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE;
 
-  public static final String RSS_CONF_FILE = "rss_conf.xml";
-
   public static final String RSS_REMOTE_STORAGE_PATH =
       TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_REMOTE_STORAGE_PATH;
 
@@ -168,6 +168,12 @@ public class RssTezConfig {
   public static final Boolean RSS_AM_SLOW_START_ENABLE_DEFAULT = false;
 
   public static final String RSS_REDUCE_INITIAL_MEMORY = TEZ_RSS_CONFIG_PREFIX + "rss.reduce.initial.memory";
+
+  public static final String RSS_ACCESS_TIMEOUT_MS = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ACCESS_TIMEOUT_MS;
+  public static final int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE;
+
+  public static final Set<String> RSS_MANDATORY_CLUSTER_CONF =
+      ImmutableSet.of(RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);
 
   public static RssConf toRssConf(Configuration jobConf) {
     RssConf rssConf = new RssConf();

--- a/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
@@ -393,4 +393,40 @@ public class RssTezUtils {
       return className;
     }
   }
+
+  public static void applyDynamicClientConf(Configuration conf, Map<String, String> confItems) {
+    if (conf == null) {
+      LOG.warn("Tez conf is null");
+      return;
+    }
+
+    if (confItems == null || confItems.isEmpty()) {
+      LOG.warn("Empty conf items");
+      return;
+    }
+
+    for (Map.Entry<String, String> kv : confItems.entrySet()) {
+      String tezConfKey = kv.getKey();
+      if (!tezConfKey.startsWith(RssTezConfig.TEZ_RSS_CONFIG_PREFIX)) {
+        tezConfKey = RssTezConfig.TEZ_RSS_CONFIG_PREFIX + tezConfKey;
+      }
+      String tezConfVal = kv.getValue();
+      if (StringUtils.isEmpty(conf.get(tezConfKey, ""))
+          || RssTezConfig.RSS_MANDATORY_CLUSTER_CONF.contains(tezConfKey)) {
+        LOG.warn("Use conf dynamic conf {} = {}", tezConfKey, tezConfVal);
+        conf.set(tezConfKey, tezConfVal);
+      }
+    }
+  }
+
+  public static Configuration filterRssConf(Configuration extraConf) {
+    Configuration conf = new Configuration();
+    for (Map.Entry<String, String> entry : extraConf) {
+      String key = entry.getKey();
+      if (key.startsWith(RssTezConfig.TEZ_RSS_CONFIG_PREFIX)) {
+        conf.set(entry.getKey(), entry.getValue());
+      }
+    }
+    return conf;
+  }
 }

--- a/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
@@ -420,7 +420,7 @@ public class RssTezUtils {
   }
 
   public static Configuration filterRssConf(Configuration extraConf) {
-    Configuration conf = new Configuration();
+    Configuration conf = new Configuration(false);
     for (Map.Entry<String, String> entry : extraConf) {
       String key = entry.getKey();
       if (key.startsWith(RssTezConfig.TEZ_RSS_CONFIG_PREFIX)) {

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -67,7 +67,7 @@ import static org.apache.uniffle.common.config.RssClientConf.MAX_CONCURRENCY_PER
 public class TezRemoteShuffleManager implements ServicePluginLifecycle {
   private static final Logger LOG = LoggerFactory.getLogger(TezRemoteShuffleManager.class);
 
-  protected InetSocketAddress address;
+  private InetSocketAddress address;
 
   protected volatile Server server;
   private String tokenIdentifier;
@@ -100,6 +100,10 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
   @Override
   public void shutdown() throws Exception {
     server.stop();
+  }
+
+  public InetSocketAddress getAddress() {
+    return address;
   }
 
   private class TezRemoteShuffleUmbilicalProtocolImpl implements TezRemoteShuffleUmbilicalProtocol {

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
@@ -1609,7 +1609,8 @@ class RssShuffleScheduler extends ShuffleScheduler {
           shuffleServerInfoList,
           readerJobConf,
           new TezIdHelper(),
-          expectedTaskIdsBitmapFilterEnable);
+          expectedTaskIdsBitmapFilterEnable,
+          RssTezConfig.toRssConf(conf));
 
       ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
       RssTezShuffleDataFetcher fetcher = new RssTezShuffleDataFetcher(

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
@@ -34,13 +34,11 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.GetShuffleServerRequest;
 import org.apache.tez.common.GetShuffleServerResponse;
-import org.apache.tez.common.RssTezConfig;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRemoteShuffleUmbilicalProtocol;
@@ -65,7 +63,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
 
-
+import static org.apache.tez.common.RssTezConfig.RSS_AM_SHUFFLE_MANAGER_ADDRESS;
+import static org.apache.tez.common.RssTezConfig.RSS_AM_SHUFFLE_MANAGER_PORT;
 
 /**
  * {@link RssOrderedPartitionedKVOutput} is an {@link AbstractLogicalOutput} which
@@ -112,18 +111,6 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
     LOG.info("Initialized RssOrderedPartitionedKVOutput.");
   }
 
-  private void getRssConf() {
-    try {
-      JobConf conf = new JobConf(RssTezConfig.RSS_CONF_FILE);
-      this.host = conf.get(RssTezConfig.RSS_AM_SHUFFLE_MANAGER_ADDRESS, "null host");
-      this.port = conf.getInt(RssTezConfig.RSS_AM_SHUFFLE_MANAGER_PORT, -1);
-
-      LOG.info("Got RssConf am info : host is {}, port is {}", host, port);
-    } catch (Exception e) {
-      LOG.warn("debugRssConf error: ", e);
-    }
-  }
-
   @Override
   public List<Event> initialize() throws Exception {
     this.startTime = System.nanoTime();
@@ -135,12 +122,12 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
     getContext().requestInitialMemory(memRequestSize, memoryUpdateCallbackHandler);
     LOG.info("Got initialMemory.");
 
-    getRssConf();
-
     this.sendEmptyPartitionDetails = conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED,
         TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED_DEFAULT);
 
+    this.host = this.conf.get(RSS_AM_SHUFFLE_MANAGER_ADDRESS);
+    this.port = this.conf.getInt(RSS_AM_SHUFFLE_MANAGER_PORT, -1);
     final InetSocketAddress address = NetUtils.createSocketAddrForHost(host, port);
 
     UserGroupInformation taskOwner = UserGroupInformation.createRemoteUser(this.applicationId.toString());

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
@@ -34,13 +34,11 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.GetShuffleServerRequest;
 import org.apache.tez.common.GetShuffleServerResponse;
-import org.apache.tez.common.RssTezConfig;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRemoteShuffleUmbilicalProtocol;
@@ -65,7 +63,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
 
-
+import static org.apache.tez.common.RssTezConfig.RSS_AM_SHUFFLE_MANAGER_ADDRESS;
+import static org.apache.tez.common.RssTezConfig.RSS_AM_SHUFFLE_MANAGER_PORT;
 
 /**
  * {@link RssUnorderedKVOutput} is an {@link AbstractLogicalOutput} which
@@ -113,19 +112,6 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
     LOG.info("Initialized RssUnorderedKVOutput.");
   }
 
-  private void getRssConf() {
-    try {
-      JobConf conf = new JobConf(RssTezConfig.RSS_CONF_FILE);
-      this.host = conf.get(RssTezConfig.RSS_AM_SHUFFLE_MANAGER_ADDRESS, "null host");
-      this.port = conf.getInt(RssTezConfig.RSS_AM_SHUFFLE_MANAGER_PORT, -1);
-      LOG.info("Got RssConf am info : host is {}, port is {}", host, port);
-
-    } catch (Exception e) {
-      LOG.warn("debugRssConf error: ", e);
-    }
-  }
-
-
   @Override
   public List<Event> initialize() throws Exception {
     this.startTime = System.nanoTime();
@@ -137,12 +123,12 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
     getContext().requestInitialMemory(memRequestSize, memoryUpdateCallbackHandler);
     LOG.info("Got initialMemory.");
 
-    getRssConf();
-
     this.sendEmptyPartitionDetails = conf.getBoolean(
       TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED,
       TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED_DEFAULT);
 
+    this.host = this.conf.get(RSS_AM_SHUFFLE_MANAGER_ADDRESS);
+    this.port = this.conf.getInt(RSS_AM_SHUFFLE_MANAGER_PORT, -1);
     final InetSocketAddress address = NetUtils.createSocketAddrForHost(host, port);
 
     UserGroupInformation taskOwner = UserGroupInformation.createRemoteUser(this.applicationId.toString());

--- a/client-tez/src/test/java/org/apache/tez/dag/app/TezRemoteShuffleManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/dag/app/TezRemoteShuffleManagerTest.java
@@ -102,8 +102,8 @@ public class TezRemoteShuffleManagerTest {
       tezRemoteShuffleManager.initialize();
       tezRemoteShuffleManager.start();
 
-      String host = tezRemoteShuffleManager.address.getHostString();
-      int port = tezRemoteShuffleManager.address.getPort();
+      String host = tezRemoteShuffleManager.getAddress().getHostString();
+      int port = tezRemoteShuffleManager.getAddress().getPort();
       final InetSocketAddress address = NetUtils.createSocketAddrForHost(host, port);
 
       String tokenIdentifier = appId.toString();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three improvement about configuration will be done in this issue.

- 1 For now, tez client use rss_conf.xml to delivery configuration. As https://github.com/apache/incubator-uniffle/pull/966 is applied, we can delivery configuration by edge conf.
- 2 delivery dynamic configuration from coordinator, then override the tez client configuration.
- 3 delivery configuration from client side.

### Why are the changes needed?

- 1. rss_conf.xml is unnecessary.
- 2. dynamic configuration from coordinator are not applied.
- 3. config in client side can not delivery to input/ouput.

### How was this patch tested?

integration test, unit test, test in yarn cluster, test in tez local mode.