### PR TITLE
[#989] fix(tez): parition class is not set for RssUnorderedKVOutput.

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
@@ -118,6 +118,8 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
   public List<Event> initialize() throws Exception {
     this.startTime = System.nanoTime();
     this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS,
+        UnorderedKVOutput.CustomPartitioner.class.getName());
     this.memoryUpdateCallbackHandler = new MemoryUpdateCallbackHandler();
 
     long memRequestSize = RssTezUtils.getInitialMemoryRequirement(conf, getContext().getTotalMemoryAvailableToTask());

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.runtime.api.MemoryUpdateCallback;
@@ -38,6 +40,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 public class OutputTestHelpers {
+
+  public static final ApplicationId APP_ID = ApplicationId.newInstance(1681717153064L, 3601637);
+  public static final ApplicationAttemptId APP_ATTEMPT_ID = ApplicationAttemptId.newInstance(APP_ID, 1);
+
   /**
    * help to create output context
    */
@@ -64,6 +70,7 @@ public class OutputTestHelpers {
     OutputStatisticsReporter statsReporter = mock(OutputStatisticsReporter.class);
     doReturn(statsReporter).when(ctx).getStatisticsReporter();
     doReturn(new ExecutionContextImpl("localhost")).when(ctx).getExecutionContext();
+    doReturn(APP_ID).when(ctx).getApplicationId();
     return ctx;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

set the partition class for RssUnorderedKVOutput.

### Why are the changes needed?

If the partition class is not set for RssUnorderedKVOutput, will throw error:

```
at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:348)
  at org.apache.hadoop.conf.Configuration.getClassByNameOrNull(Configuration.java:2534)
  at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2499)
  at org.apache.tez.runtime.library.common.TezRuntimeUtils.instantiatePartitioner(TezRuntimeUtils.java:117)
  at org.apache.tez.runtime.library.common.sort.impl.ExternalSorter.(ExternalSorter.java:271)
  at org.apache.tez.runtime.library.common.sort.impl.RssUnSorter.(RssUnSorter.java:68)
  at org.apache.tez.runtime.library.output.RssUnorderedKVOutput.start(RssUnorderedKVOutput.java:204)
  at org.apache.hadoop.hive.ql.exec.tez.MapRecordProcessor.init(MapRecordProcessor.java:193)
  at org.apache.hadoop.hive.ql.exec.tez.TezProcessor.initializeAndRunProcessor(TezProcessor.java:266)
```

Fix: #989

### How was this patch tested?

unit test, integration test, tez local, tez on yarn.
