### PR TITLE
[#999] improvement: apply REST principles in the urls of the http interfaces

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/metrics/TestUtils.java
+++ b/common/src/test/java/org/apache/uniffle/common/metrics/TestUtils.java
@@ -44,6 +44,10 @@ public class TestUtils {
     return content.toString();
   }
 
+  public static String httpPost(String urlString) throws IOException {
+    return httpPost(urlString, null);
+  }
+
   public static String httpPost(String urlString, String postData) throws IOException {
     URL url = new URL(urlString);
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
@@ -51,8 +55,10 @@ public class TestUtils {
     con.setRequestMethod("POST");
     con.setRequestProperty("Content-type", "application/json");
     StringBuilder content = new StringBuilder();
-    try (OutputStream outputStream = con.getOutputStream();) {
-      outputStream.write(postData.getBytes());
+    try (OutputStream outputStream = con.getOutputStream()) {
+      if (postData != null) {
+        outputStream.write(postData.getBytes());
+      }
       try (BufferedReader in = new BufferedReader(
           new InputStreamReader(con.getInputStream()));) {
         String inputLine;

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/AdminResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/AdminResource.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.coordinator.web.resource;
 
 import java.util.List;
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.Path;
@@ -35,22 +34,22 @@ import org.apache.uniffle.coordinator.access.checker.AccessChecker;
 import org.apache.uniffle.coordinator.web.Response;
 
 @Produces({MediaType.APPLICATION_JSON})
-public class AdminResource {
+public class AdminResource extends BaseResource {
   private static final Logger LOG = LoggerFactory.getLogger(AdminResource.class);
-  @Context
-  private HttpServletRequest httpRequest;
   @Context
   protected ServletContext servletContext;
 
   @GET
   @Path("/refreshChecker")
   public Response<List<ServerNode>> refreshChecker() {
-    List<AccessChecker> accessCheckers = getAccessManager().getAccessCheckers();
-    LOG.info(
-        "The access checker {} has been refreshed, you can add the checker via rss.coordinator.access.checkers.",
-        accessCheckers);
-    accessCheckers.forEach(AccessChecker::refreshAccessChecker);
-    return Response.success(null);
+    return execute(() -> {
+      List<AccessChecker> accessCheckers = getAccessManager().getAccessCheckers();
+      LOG.info(
+          "The access checker {} has been refreshed, you can add the checker via rss.coordinator.access.checkers.",
+          accessCheckers);
+      accessCheckers.forEach(AccessChecker::refreshAccessChecker);
+      return null;
+    });
   }
 
   private AccessManager getAccessManager() {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/BaseResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/BaseResource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.coordinator.web.resource;
+
+import java.util.concurrent.Callable;
+
+import org.apache.uniffle.coordinator.web.Response;
+
+public abstract class BaseResource {
+  protected <T> Response<T> execute(Callable<T> callable) {
+    try {
+      return Response.success(callable.call());
+    } catch (Throwable e) {
+      return Response.fail(e.getMessage());
+    }
+  }
+}

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -27,6 +27,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.POST;
 import org.apache.hbase.thirdparty.javax.ws.rs.Path;
+import org.apache.hbase.thirdparty.javax.ws.rs.PathParam;
 import org.apache.hbase.thirdparty.javax.ws.rs.Produces;
 import org.apache.hbase.thirdparty.javax.ws.rs.QueryParam;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
@@ -40,13 +41,27 @@ import org.apache.uniffle.coordinator.web.request.CancelDecommissionRequest;
 import org.apache.uniffle.coordinator.web.request.DecommissionRequest;
 
 @Produces({ MediaType.APPLICATION_JSON })
-public class ServerResource {
+public class ServerResource extends BaseResource {
   @Context
   protected ServletContext servletContext;
 
   @GET
+  @Path("/{id}")
+  public Response<ServerNode> node(@PathParam("id") String id) {
+    return execute(() -> getClusterManager().getServerNodeById(id));
+  }
+
+  @GET
   @Path("/nodes")
-  public Response<List<ServerNode>> nodes(@QueryParam("id") String id, @QueryParam("status") String status) {
+  public Response<List<ServerNode>> nodes(@QueryParam("id") String id) {
+    return nodes(id, null);
+  }
+
+  @GET
+  @Path("/nodes/{status}")
+  public Response<List<ServerNode>> nodes(
+      @QueryParam("id") String id,
+      @PathParam("status") String status) {
     ClusterManager clusterManager = getClusterManager();
     List<ServerNode> serverList;
     if (ServerStatus.UNHEALTHY.name().equalsIgnoreCase(status)) {
@@ -71,34 +86,43 @@ public class ServerResource {
 
   @POST
   @Path("/cancelDecommission")
-  @Produces({ MediaType.APPLICATION_JSON })
   public Response<Object> cancelDecommission(CancelDecommissionRequest params) {
-    if (CollectionUtils.isEmpty(params.getServerIds())) {
-      return Response.fail("Parameter[serverIds] should not be null!");
-    }
-    ClusterManager clusterManager = getClusterManager();
-    try {
-      params.getServerIds().forEach(clusterManager::cancelDecommission);
-    } catch (Exception e) {
-      return Response.fail(e.getMessage());
-    }
-    return Response.success(null);
+    return execute(() -> {
+      assert CollectionUtils.isNotEmpty(params.getServerIds())
+          : "Parameter[serverIds] should not be null!";
+      params.getServerIds().forEach(getClusterManager()::cancelDecommission);
+      return null;
+    });
+  }
+
+  @POST
+  @Path("/{id}/cancelDecommission")
+  public Response<Object> cancelDecommission(@PathParam("id") String serverId) {
+    return execute(() -> {
+      getClusterManager().cancelDecommission(serverId);
+      return null;
+    });
   }
 
   @POST
   @Path("/decommission")
-  @Produces({ MediaType.APPLICATION_JSON })
   public Response<Object> decommission(DecommissionRequest params) {
-    if (CollectionUtils.isEmpty(params.getServerIds())) {
-      return Response.fail("Parameter[serverIds] should not be null!");
-    }
-    ClusterManager clusterManager = getClusterManager();
-    try {
-      params.getServerIds().forEach(clusterManager::decommission);
-    } catch (Exception e) {
-      return Response.fail(e.getMessage());
-    }
-    return Response.success(null);
+    return execute(() -> {
+      assert CollectionUtils.isNotEmpty(params.getServerIds())
+          : "Parameter[serverIds] should not be null!";
+      params.getServerIds().forEach(getClusterManager()::decommission);
+      return null;
+    });
+  }
+
+  @POST
+  @Path("/{id}/decommission")
+  @Produces({ MediaType.APPLICATION_JSON })
+  public Response<Object> decommission(@PathParam("id") String serverId) {
+    return execute(() -> {
+      getClusterManager().decommission(serverId);
+      return null;
+    });
   }
 
   private ClusterManager getClusterManager() {

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -138,24 +138,43 @@ PrometheusPushGatewayMetricReporter is one of the built-in metrics reporter, whi
 |rss.metrics.prometheus.pushgateway.jobname|-| The job name under which metrics will be pushed.                                                                                                                                                                                                                                                                                      |
 |rss.metrics.prometheus.pushgateway.report.interval.seconds|10| The interval in seconds for the reporter to report metrics.                                                                                                                                                                                                                                                                                     |
 
-## RESTful API(beta)
+## RESTful API
 
-### Fetch Shuffle servers
+### Fetch single shuffle server
 
 <details>
- <summary><code>GET</code> <code><b>/api/server/nodes</b></code> </summary>
+ <summary><code>GET</code> <code><b>/api/server/{id}</b></code> </summary>
 
 ##### Parameters
 
 > |name|type|data type|description|
 > |----|----|---------|-----------|
-> |id|required|string|shuffle server id, eg:127.0.0.1:19999|
+> |id|required|string|shuffle server id, eg:127.0.0.1-19999|
+##### Example cURL
+
+> ```bash
+>  curl -X GET http://localhost:19998/api/server/127.0.0.1-19999
+> ```
+</details>
+
+
+### Fetch shuffle servers
+
+<details>
+ <summary><code>GET</code> <code><b>/api/server/nodes/{status}</b></code> </summary>
+
+##### Parameters
+
+> |name|type|data type|description|
+> |----|----|---------|-----------|
+> |id|required|string|shuffle server id, eg:127.0.0.1-19999|
 > |status|optional|string|Shuffle server status, eg:ACTIVE, DECOMMISSIONING, DECOMMISSIONED|
 
 ##### Example cURL
 
 > ```bash
 >  curl -X GET http://localhost:19998/api/server/nodes
+>  curl -X GET http://localhost:19998/api/server/nodes/ACTIVE
 > ```
 </details>
 
@@ -168,12 +187,31 @@ PrometheusPushGatewayMetricReporter is one of the built-in metrics reporter, whi
 
 > |name|type| data type         |description|
 > |----|-------------------|---------|-----------|
-> |serverIds|required| array |Shuffle server array, eg:["127.0.0.1:19999"]|
+> |serverIds|required| array |Shuffle server array, eg:["127.0.0.1-19999"]|
 > 
 ##### Example cURL
 
 > ```bash
 >  curl -X POST -H "Content-Type: application/json" http://localhost:19998/api/server/decommission  -d '{"serverIds:": ["127.0.0.1:19999"]}'
+> ```
+</details>
+
+
+### Decommission single shuffle server
+
+<details>
+ <summary><code>POST</code> <code><b>/api/server/{id}/decommission</b></code> </summary>
+
+##### Parameters
+
+> | name |type| data type | description                          |
+> |------|-------------------|-----------|--------------------------------------|
+> | id   |required| string    | Shuffle server id, eg:127.0.0.1-19999 |
+>
+##### Example cURL
+
+> ```bash
+>  curl -X POST -H "Content-Type: application/json" http://localhost:19998/api/server/127.0.0.1-19999/decommission
 > ```
 </details>
 
@@ -193,5 +231,24 @@ PrometheusPushGatewayMetricReporter is one of the built-in metrics reporter, whi
 
 > ```bash
 >  curl -X POST -H "Content-Type: application/json" http://localhost:19998/api/server/cancelDecommission  -d '{"serverIds:": ["127.0.0.1:19999"]}'
+> ```
+</details>
+
+
+### Cancel decommission single shuffle server
+
+<details>
+ <summary><code>POST</code> <code><b>/api/server/{id}/cancelDecommission</b></code> </summary>
+
+##### Parameters
+
+> |name|type| data type | description                             |
+> |----|-------------------|--------|-----------------------------------------|
+> |serverIds|required| string | Shuffle server id, eg:"127.0.0.1-19999" |
+>
+##### Example cURL
+
+> ```bash
+>  curl -X POST -H "Content-Type: application/json" http://localhost:19998/api/server/127.0.0.1-19999/cancelDecommission
 > ```
 </details>

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -59,11 +59,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServletTest extends IntegrationTestBase {
   private static final String URL_PREFIX = "http://127.0.0.1:12345/api/";
+  private static final String SINGLE_NODE_URL = URL_PREFIX + "server/%s";
   private static final String NODES_URL = URL_PREFIX + "server/nodes";
-  private static final String LOSTNODES_URL = URL_PREFIX + "server/nodes?status=LOST";
-  private static final String UNHEALTHYNODES_URL = URL_PREFIX + "server/nodes?status=UNHEALTHY";
+  private static final String LOSTNODES_URL = URL_PREFIX + "server/nodes/LOST";
+  private static final String UNHEALTHYNODES_URL = URL_PREFIX + "server/nodes/UNHEALTHY";
   private static final String DECOMMISSION_URL = URL_PREFIX + "server/decommission";
   private static final String CANCEL_DECOMMISSION_URL = URL_PREFIX + "server/cancelDecommission";
+  private static final String DECOMMISSION_SINGLENODE_URL = URL_PREFIX + "server/%s/decommission";
+  private static final String CANCEL_DECOMMISSION_SINGLENODE_URL = URL_PREFIX + "server/%s/cancelDecommission";
   private static CoordinatorServer coordinatorServer;
   private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -108,6 +111,18 @@ public class ServletTest extends IntegrationTestBase {
     coordinatorServer = coordinators.get(0);
     Awaitility.await().timeout(30, TimeUnit.SECONDS).until(() ->
         coordinatorServer.getClusterManager().list().size() == 4);
+  }
+
+  @Test
+  public void testGetSingleNode() throws Exception {
+    ShuffleServer shuffleServer = shuffleServers.get(0);
+    String content = TestUtils.httpGet(String.format(SINGLE_NODE_URL, shuffleServer.getId()));
+    Response<HashMap<String, Object>> response = objectMapper.readValue(content,
+        new TypeReference<Response<HashMap<String, Object>>>() {});
+    HashMap<String, Object> server = response.getData();
+    assertEquals(0, response.getCode());
+    assertEquals(SHUFFLE_SERVER_PORT, Integer.parseInt(server.get("grpcPort").toString()));
+    assertEquals(ServerStatus.ACTIVE.toString(), server.get("status"));
   }
 
   @Test
@@ -182,7 +197,7 @@ public class ServletTest extends IntegrationTestBase {
     DecommissionRequest decommissionRequest = new DecommissionRequest();
     decommissionRequest.setServerIds(Sets.newHashSet("not_exist_serverId"));
     String content = TestUtils.httpPost(CANCEL_DECOMMISSION_URL, objectMapper.writeValueAsString(decommissionRequest));
-    Response<Object> response = objectMapper.readValue(content, Response.class);
+    Response<?> response = objectMapper.readValue(content, Response.class);
     assertEquals(-1, response.getCode());
     assertNotNull(response.getErrMsg());
     CancelDecommissionRequest cancelDecommissionRequest = new CancelDecommissionRequest();
@@ -207,6 +222,38 @@ public class ServletTest extends IntegrationTestBase {
             coordinatorServer.getClusterManager().getServerNodeById(shuffleServer.getId()).getStatus()));
     // Cancel decommission.
     content = TestUtils.httpPost(CANCEL_DECOMMISSION_URL, objectMapper.writeValueAsString(cancelDecommissionRequest));
+    response = objectMapper.readValue(content, Response.class);
+    assertEquals(0, response.getCode());
+    assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
+  }
+
+  @Test
+  public void testDecommissionSingleNode() throws Exception {
+    ShuffleServer shuffleServer = shuffleServers.get(0);
+    assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
+    String content = TestUtils.httpPost(String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, "not_exist_serverId"));
+    Response<?> response = objectMapper.readValue(content, Response.class);
+    assertEquals(-1, response.getCode());
+    assertNotNull(response.getErrMsg());
+    content = TestUtils.httpPost(String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()));
+    response = objectMapper.readValue(content, Response.class);
+    assertEquals(0, response.getCode());
+
+    // Register shuffle, avoid server exiting immediately.
+    ShuffleServerGrpcClient shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    shuffleServerClient.registerShuffle(new RssRegisterShuffleRequest("testDecommissionServlet_appId", 0,
+        Lists.newArrayList(new PartitionRange(0, 1)), ""));
+    content = TestUtils.httpPost(String.format(DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()));
+    response = objectMapper.readValue(content, Response.class);
+    assertEquals(0, response.getCode());
+    assertEquals(ServerStatus.DECOMMISSIONING, shuffleServer.getServerStatus());
+
+    // Wait until shuffle server send heartbeat to coordinator.
+    Awaitility.await().timeout(10, TimeUnit.SECONDS).until(() ->
+        ServerStatus.DECOMMISSIONING.equals(
+            coordinatorServer.getClusterManager().getServerNodeById(shuffleServer.getId()).getStatus()));
+    // Cancel decommission.
+    content = TestUtils.httpPost(String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()));
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Apply REST principles in the urls of the http interfaces

### Why are the changes needed?
Fix: #999

### Does this PR introduce _any_ user-facing change?

Env:
Server IP: 127.0.0.1
HTTP port: 19998
RPC port: 19999
#### Decommission single shuffle server example:
```
curl -XPOST -H "Content-type:application/json" "http://127.0.0.1:19998/api/server/127.0.0.1-19999/decommission" 
```
####  Cancel decommission single shuffle server example:
```
curl -XPOST -H "Content-type:application/json" "http://127.0.0.1:19998/api/server/127.0.0.1-19999/cancelDecommission" 
```
####  Fetch single shuffle server:
```
curl -X GET http://127.0.0.1:19998/api/server/127.0.0.1-19999
```
#### Fetch server list:
```
#path: /api/server/nodes/[{status}][?id={serverId}]
curl  "http://127.0.0.1:19998/api/server/nodes"
curl  "http://127.0.0.1:19998/api/server/nodes?id=127.0.0.1-19999"
curl  "http://127.0.0.1:19998/api/server/nodes/DECOMMISSIONING"
curl  "http://127.0.0.1:19998/api/server/nodes/ACTIVE?id=127.0.0.1-19999"
```
### How was this patch tested?

UT
