### PR TITLE
[#477] feat(spark): support getShuffleResult throws FetchFailedException.

### DIFF
--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -473,7 +473,8 @@ public class SortWriteBufferManagerTest {
         String clientType,
         Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
         String appId,
-        int shuffleId) {
+        int shuffleId,
+        Set<Integer> failedPartitions) {
       return null;
     }
 

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -550,7 +550,8 @@ public class FetcherTest {
         String clientType,
         Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
         String appId,
-        int shuffleId) {
+        int shuffleId,
+        Set<Integer> failedPartitions) {
       return null;
     }
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -690,14 +690,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return shuffleIdToNumMapTasks.getOrDefault(shuffleId, 0);
   }
 
-  private Roaring64NavigableMap getShuffleResult(String clientType, Set<ShuffleServerInfo> shuffleServerInfoSet,
-      String appId, int shuffleId, int partitionId, int stageAttemptId) {
+  private Roaring64NavigableMap getShuffleResult(
+      String clientType,
+      Set<ShuffleServerInfo> shuffleServerInfoSet,
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int stageAttemptId) {
     try {
       return shuffleWriteClient.getShuffleResult(
           clientType, shuffleServerInfoSet, appId, shuffleId, partitionId);
     } catch (RssFetchFailedException e) {
-      throw RssSparkShuffleUtils.reportRssFetchFailedException(e, sparkConf, appId, shuffleId,
-          stageAttemptId, Sets.newHashSet(partitionId));
+      throw RssSparkShuffleUtils.reportRssFetchFailedException(
+          e, sparkConf, appId, shuffleId, stageAttemptId, Sets.newHashSet(partitionId));
     }
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -985,15 +985,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return !failedTaskIds.contains(taskId);
   }
 
-  private Roaring64NavigableMap getShuffleResultForMultiPart(String clientType,
-      Map<ShuffleServerInfo, Set<Integer>> serverToPartitions, String appId, int shuffleId, int stageAttemptId) {
+  private Roaring64NavigableMap getShuffleResultForMultiPart(
+      String clientType,
+      Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
+      String appId,
+      int shuffleId,
+      int stageAttemptId) {
     Set<Integer> failedPartitions = Sets.newHashSet();
     try {
       return shuffleWriteClient.getShuffleResultForMultiPart(
           clientType, serverToPartitions, appId, shuffleId, failedPartitions);
     } catch (RssFetchFailedException e) {
-      throw RssSparkShuffleUtils.reportRssFetchFailedException(e, sparkConf, appId, shuffleId,
-          stageAttemptId, failedPartitions);
+      throw RssSparkShuffleUtils.reportRssFetchFailedException(
+          e, sparkConf, appId, shuffleId, stageAttemptId, failedPartitions);
     }
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -73,6 +73,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.exception.RssFetchFailedException;
 import org.apache.uniffle.common.rpc.GrpcServer;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -597,8 +598,12 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         RssUtils.generateServerToPartitions(requirePartitionToServers);
     long start = System.currentTimeMillis();
     Roaring64NavigableMap blockIdBitmap =
-        shuffleWriteClient.getShuffleResultForMultiPart(
-            clientType, serverToPartitions, rssShuffleHandle.getAppId(), shuffleId);
+        getShuffleResultForMultiPart(
+            clientType,
+            serverToPartitions,
+            rssShuffleHandle.getAppId(),
+            shuffleId,
+            context.stageAttemptNumber());
     LOG.info(
         "Get shuffle blockId cost "
             + (System.currentTimeMillis() - start)
@@ -978,5 +983,17 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
   public boolean isValidTask(String taskId) {
     return !failedTaskIds.contains(taskId);
+  }
+
+  private Roaring64NavigableMap getShuffleResultForMultiPart(String clientType,
+      Map<ShuffleServerInfo, Set<Integer>> serverToPartitions, String appId, int shuffleId, int stageAttemptId) {
+    Set<Integer> failedPartitions = Sets.newHashSet();
+    try {
+      return shuffleWriteClient.getShuffleResultForMultiPart(
+          clientType, serverToPartitions, appId, shuffleId, failedPartitions);
+    } catch (RssFetchFailedException e) {
+      throw RssSparkShuffleUtils.reportRssFetchFailedException(e, sparkConf, appId, shuffleId,
+          stageAttemptId, failedPartitions);
+    }
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -56,6 +56,8 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 
+import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
+
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleReader.class);
   private final Map<Integer, List<ShuffleServerInfo>> partitionToShuffleServers;
@@ -184,7 +186,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     // resubmit stage and shuffle manager server port are both set
     if (rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
         && rssConf.getInteger(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT, 0) > 0) {
-      String driver = rssConf.getString("driver.host", "");
+      String driver = rssConf.getString(DRIVER_HOST, "");
       int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);
       resultIter =
           RssFetchFailedIterator.newBuilder()

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -524,7 +524,8 @@ public class WriteBufferManagerTest {
         String clientType,
         Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
         String appId,
-        int shuffleId) {
+        int shuffleId,
+        Set<Integer> failedPartitions) {
       return null;
     }
 

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -89,7 +89,8 @@ public interface ShuffleWriteClient {
       String clientType,
       Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
       String appId,
-      int shuffleId);
+      int shuffleId,
+      Set<Integer> failedPartitions);
 
   void close();
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -792,7 +792,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       String clientType,
       Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,
       String appId,
-      int shuffleId) {
+      int shuffleId,
+      Set<Integer> failedPartitions) {
     Map<Integer, Integer> partitionReadSuccess = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     for (Map.Entry<ShuffleServerInfo, Set<Integer>> entry : serverToPartitions.entrySet()) {
@@ -819,6 +820,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           }
         }
       } catch (Exception e) {
+        failedPartitions.addAll(requestPartitions);
         LOG.warn(
             "Get shuffle result is failed from "
                 + shuffleServerInfo

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -79,4 +79,8 @@ public final class Constants {
   public static final String GRPC_SERVICE_NAME = "grpc.server";
 
   public static final int COMPOSITE_BYTE_BUF_MAX_COMPONENTS = 1024;
+
+  // The `driver.host` is matching spark's `DRIVER_HOST_ADDRESS` configuration, which is `spark.driver.host`.
+  // We are accessing this configuration through RssConf, the spark prefix is stripped, hence, this field.
+  public static final String DRIVER_HOST = "driver.host";
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -80,7 +80,9 @@ public final class Constants {
 
   public static final int COMPOSITE_BYTE_BUF_MAX_COMPONENTS = 1024;
 
-  // The `driver.host` is matching spark's `DRIVER_HOST_ADDRESS` configuration, which is `spark.driver.host`.
-  // We are accessing this configuration through RssConf, the spark prefix is stripped, hence, this field.
+  // The `driver.host` is matching spark's `DRIVER_HOST_ADDRESS` configuration, which is
+  // `spark.driver.host`.
+  // We are accessing this configuration through RssConf, the spark prefix is stripped, hence, this
+  // field.
   public static final String DRIVER_HOST = "driver.host";
 }

--- a/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerGrpcService.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerGrpcService.java
@@ -100,6 +100,14 @@ public class MockedShuffleServerGrpcService extends ShuffleServerGrpcService {
       LOG.info("Add a mocked timeout on getShuffleResult");
       Uninterruptibles.sleepUninterruptibly(mockedTimeout, TimeUnit.MILLISECONDS);
     }
+    if (numOfFailedReadRequest > 0) {
+      int currentFailedReadRequest = failedReadRequest.getAndIncrement();
+      if (currentFailedReadRequest < numOfFailedReadRequest) {
+        LOG.info("This request is failed as mocked failure, current/firstN: {}/{}",
+            currentFailedReadRequest, numOfFailedReadRequest);
+        throw new RuntimeException("This request is failed as mocked failure");
+      }
+    }
     super.getShuffleResult(request, responseObserver);
   }
 
@@ -110,6 +118,16 @@ public class MockedShuffleServerGrpcService extends ShuffleServerGrpcService {
     if (mockedTimeout > 0) {
       LOG.info("Add a mocked timeout on getShuffleResult");
       Uninterruptibles.sleepUninterruptibly(mockedTimeout, TimeUnit.MILLISECONDS);
+    }
+    if (numOfFailedReadRequest > 0) {
+      int currentFailedReadRequest = failedReadRequest.getAndIncrement();
+      if (currentFailedReadRequest < numOfFailedReadRequest) {
+        LOG.info(
+                "This request is failed as mocked failure, current/firstN: {}/{}",
+                currentFailedReadRequest,
+                numOfFailedReadRequest);
+        throw new RuntimeException("This request is failed as mocked failure");
+      }
     }
     if (recordGetShuffleResult) {
       List<Integer> requestPartitions = request.getPartitionsList();

--- a/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerGrpcService.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerGrpcService.java
@@ -103,8 +103,10 @@ public class MockedShuffleServerGrpcService extends ShuffleServerGrpcService {
     if (numOfFailedReadRequest > 0) {
       int currentFailedReadRequest = failedReadRequest.getAndIncrement();
       if (currentFailedReadRequest < numOfFailedReadRequest) {
-        LOG.info("This request is failed as mocked failure, current/firstN: {}/{}",
-            currentFailedReadRequest, numOfFailedReadRequest);
+        LOG.info(
+            "This request is failed as mocked failure, current/firstN: {}/{}",
+            currentFailedReadRequest,
+            numOfFailedReadRequest);
         throw new RuntimeException("This request is failed as mocked failure");
       }
     }
@@ -123,9 +125,9 @@ public class MockedShuffleServerGrpcService extends ShuffleServerGrpcService {
       int currentFailedReadRequest = failedReadRequest.getAndIncrement();
       if (currentFailedReadRequest < numOfFailedReadRequest) {
         LOG.info(
-                "This request is failed as mocked failure, current/firstN: {}/{}",
-                currentFailedReadRequest,
-                numOfFailedReadRequest);
+            "This request is failed as mocked failure, current/firstN: {}/{}",
+            currentFailedReadRequest,
+            numOfFailedReadRequest);
         throw new RuntimeException("This request is failed as mocked failure");
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

feat #477 

### Why are the changes needed?

support getShuffleResult throws FetchFailedException.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Exiting UTs, Already added getShuffleResult failed, see `MockedShuffleServerGrpcService`.