### PR TITLE
[#972 ] fix(tez): Add output mapOutputByteCounter metrics

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
@@ -167,7 +167,8 @@ public class RssSorter extends ExternalSorter {
             sendCheckTimeout,
             bitmapSplitNum,
             shuffleId,
-            true);
+            true,
+            mapOutputByteCounter);
     LOG.info("Initialized WriteBufferManager.");
   }
 

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
@@ -165,7 +165,8 @@ public class RssUnSorter extends ExternalSorter {
             sendCheckTimeout,
             bitmapSplitNum,
             shuffleId,
-            false);
+            false,
+            mapOutputByteCounter);
     LOG.info("Initialized WriteBufferManager.");
   }
 

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -102,17 +102,20 @@ public class WriteBufferManagerTest {
 
     Configuration conf = new Configuration();
     FileSystem localFs = FileSystem.getLocal(conf);
-    Path workingDir = new Path(System.getProperty("test.build.data",
-        System.getProperty("java.io.tmpdir", tmpDir.toString())),
-        RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
-        localFs.getUri(), localFs.getWorkingDirectory());
+    Path workingDir =
+        new Path(
+                System.getProperty(
+                    "test.build.data", System.getProperty("java.io.tmpdir", tmpDir.toString())),
+                RssOrderedPartitionedKVOutputTest.class.getName())
+            .makeQualified(localFs.getUri(), localFs.getWorkingDirectory());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, Text.class.getName());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, Text.class.getName());
-    conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS,
-        HashPartitioner.class.getName());
+    conf.set(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, HashPartitioner.class.getName());
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, workingDir.toString());
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
-    TezCounter mapOutputByteCounter = outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
+    TezCounter mapOutputByteCounter =
+        outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
 
     WriteBufferManager<BytesWritable, BytesWritable> bufferManager =
         new WriteBufferManager(
@@ -195,17 +198,20 @@ public class WriteBufferManagerTest {
 
     Configuration conf = new Configuration();
     FileSystem localFs = FileSystem.getLocal(conf);
-    Path workingDir = new Path(System.getProperty("test.build.data",
-        System.getProperty("java.io.tmpdir", tmpDir.toString())),
-        RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
-        localFs.getUri(), localFs.getWorkingDirectory());
+    Path workingDir =
+        new Path(
+                System.getProperty(
+                    "test.build.data", System.getProperty("java.io.tmpdir", tmpDir.toString())),
+                RssOrderedPartitionedKVOutputTest.class.getName())
+            .makeQualified(localFs.getUri(), localFs.getWorkingDirectory());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, Text.class.getName());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, Text.class.getName());
-    conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS,
-        HashPartitioner.class.getName());
+    conf.set(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, HashPartitioner.class.getName());
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, workingDir.toString());
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
-    TezCounter mapOutputByteCounter = outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
+    TezCounter mapOutputByteCounter =
+        outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
 
     WriteBufferManager<BytesWritable, BytesWritable> bufferManager =
         new WriteBufferManager(
@@ -266,7 +272,8 @@ public class WriteBufferManagerTest {
   }
 
   @Test
-  public void testCommitBlocksWhenMemoryShuffleDisabled(@TempDir File tmpDir) throws IOException, InterruptedException {
+  public void testCommitBlocksWhenMemoryShuffleDisabled(@TempDir File tmpDir)
+      throws IOException, InterruptedException {
     TezTaskAttemptID tezTaskAttemptID =
         TezTaskAttemptID.fromString("attempt_1681717153064_3770270_1_00_000000_0");
     final long maxMemSize = 10240;
@@ -297,17 +304,20 @@ public class WriteBufferManagerTest {
 
     Configuration conf = new Configuration();
     FileSystem localFs = FileSystem.getLocal(conf);
-    Path workingDir = new Path(System.getProperty("test.build.data",
-        System.getProperty("java.io.tmpdir", tmpDir.toString())),
-        RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
-        localFs.getUri(), localFs.getWorkingDirectory());
+    Path workingDir =
+        new Path(
+                System.getProperty(
+                    "test.build.data", System.getProperty("java.io.tmpdir", tmpDir.toString())),
+                RssOrderedPartitionedKVOutputTest.class.getName())
+            .makeQualified(localFs.getUri(), localFs.getWorkingDirectory());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, Text.class.getName());
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, Text.class.getName());
-    conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS,
-        HashPartitioner.class.getName());
+    conf.set(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, HashPartitioner.class.getName());
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, workingDir.toString());
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
-    TezCounter mapOutputByteCounter = outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
+    TezCounter mapOutputByteCounter =
+        outputContext.getCounters().findCounter(TaskCounter.OUTPUT_BYTES);
 
     WriteBufferManager<BytesWritable, BytesWritable> bufferManager =
         new WriteBufferManager(

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -102,10 +102,6 @@ public class WriteBufferManagerTest {
 
     Configuration conf = new Configuration();
     FileSystem localFs = FileSystem.getLocal(conf);
-//    Path workingDir = new Path(System.getProperty("test.build.data",
-//        System.getProperty("java.io.tmpdir", "/tmp")),
-//        RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
-//        localFs.getUri(), localFs.getWorkingDirectory());
     Path workingDir = new Path(System.getProperty("test.build.data",
         System.getProperty("java.io.tmpdir", tmpDir.toString())),
         RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
@@ -301,10 +297,6 @@ public class WriteBufferManagerTest {
 
     Configuration conf = new Configuration();
     FileSystem localFs = FileSystem.getLocal(conf);
-//    Path workingDir = new Path(System.getProperty("test.build.data",
-//        System.getProperty("java.io.tmpdir", "/tmp")),
-//        RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(
-//        localFs.getUri(), localFs.getWorkingDirectory());
     Path workingDir = new Path(System.getProperty("test.build.data",
         System.getProperty("java.io.tmpdir", tmpDir.toString())),
         RssOrderedPartitionedKVOutputTest.class.getName()).makeQualified(


### PR DESCRIPTION
<!--
1. Title: [#972 ] Fix(tez) add output mapOutputByteCounter metrics
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add output mapOutputByteCounter metrics

### Why are the changes needed?
add this metrics to fix reducing the number of tasks

Fix: #972 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
ut
