### PR TITLE
[#973] improvement: Make shuffle manager client RPC timeout configurable

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -129,9 +129,10 @@ public class RssBaseConf extends RssConf {
           .defaultValue(ClientType.GRPC)
           .withDescription("client type for rss");
 
-  public static final ConfigOption<Long> RSS_CLIENT_TYPE_GRPC_TIMEOUT =
+  public static final ConfigOption<Long> RSS_CLIENT_TYPE_GRPC_TIMEOUT_MS =
       ConfigOptions.key("rss.rpc.client.type.grpc.timeout")
           .longType()
+          .checkValue(ConfigUtils.POSITIVE_INTEGER_VALIDATOR, "The value must be positive integer")
           .defaultValue(60 * 1000L)
           .withDescription("Remote shuffle service client type grpc timeout (ms)");
 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -129,11 +129,11 @@ public class RssBaseConf extends RssConf {
           .defaultValue(ClientType.GRPC)
           .withDescription("client type for rss");
 
-  public static final ConfigOption<Long> RSS_CLIENT_GRPC_TIME_OUT =
-      ConfigOptions.key("rss.rpc.client.grpc.timeout")
+  public static final ConfigOption<Long> RSS_CLIENT_TYPE_GRPC_TIMEOUT =
+      ConfigOptions.key("rss.rpc.client.type.grpc.timeout")
           .longType()
           .defaultValue(60 * 1000L)
-          .withDescription("timeout value of grpc client");
+          .withDescription("Remote shuffle service client type grpc timeout (ms)");
 
   public static final ConfigOption<String> RSS_STORAGE_TYPE =
       ConfigOptions.key("rss.storage.type")

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -132,7 +132,8 @@ public class RssBaseConf extends RssConf {
   public static final ConfigOption<Long> RSS_CLIENT_TYPE_GRPC_TIMEOUT_MS =
       ConfigOptions.key("rss.rpc.client.type.grpc.timeout")
           .longType()
-          .checkValue(ConfigUtils.POSITIVE_INTEGER_VALIDATOR, "The value must be positive integer")
+          .checkValue(
+              ConfigUtils.POSITIVE_LONG_VALIDATOR, "The grpc timeout must be positive integer")
           .defaultValue(60 * 1000L)
           .withDescription("Remote shuffle service client type grpc timeout (ms)");
 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -129,6 +129,12 @@ public class RssBaseConf extends RssConf {
           .defaultValue(ClientType.GRPC)
           .withDescription("client type for rss");
 
+  public static final ConfigOption<Long> RSS_CLIENT_GRPC_TIME_OUT =
+      ConfigOptions.key("rss.rpc.client.grpc.timeout")
+          .longType()
+          .defaultValue(60 * 1000L)
+          .withDescription("timeout value of grpc client");
+
   public static final ConfigOption<String> RSS_STORAGE_TYPE =
       ConfigOptions.key("rss.storage.type")
           .stringType()

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -35,7 +35,7 @@ public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManag
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleManagerGrpcClient.class);
   private static RssBaseConf rssConf = new RssBaseConf();
-  private long rpcTimeout = rssConf.getLong(RssBaseConf.RSS_CLIENT_TYPE_GRPC_TIMEOUT);
+  private long rpcTimeout = rssConf.getLong(RssBaseConf.RSS_CLIENT_TYPE_GRPC_TIMEOUT_MS);
   private ShuffleManagerGrpc.ShuffleManagerBlockingStub blockingStub;
 
   public ShuffleManagerGrpcClient(String host, int port) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
+import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureRequest;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureResponse;
@@ -33,8 +34,8 @@ import org.apache.uniffle.proto.ShuffleManagerGrpc;
 public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManagerClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleManagerGrpcClient.class);
-  private static final long RPC_TIMEOUT_DEFAULT_MS = 60000;
-  private long rpcTimeout = RPC_TIMEOUT_DEFAULT_MS;
+  private static RssBaseConf rssConf = new RssBaseConf();
+  private long rpcTimeout = rssConf.getLong(RssBaseConf.RSS_CLIENT_TYPE_GRPC_TIMEOUT);
   private ShuffleManagerGrpc.ShuffleManagerBlockingStub blockingStub;
 
   public ShuffleManagerGrpcClient(String host, int port) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -61,6 +61,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
+import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.NotRetryException;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
@@ -105,8 +106,10 @@ import org.apache.uniffle.proto.ShuffleServerGrpc.ShuffleServerBlockingStub;
 public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServerClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleServerGrpcClient.class);
+  private static RssBaseConf rssConf;
   protected static final long FAILED_REQUIRE_ID = -1;
-  protected static final long RPC_TIMEOUT_DEFAULT_MS = 60000;
+  protected static final long RPC_TIMEOUT_DEFAULT_MS =
+      rssConf.getLong(RssBaseConf.RSS_CLIENT_GRPC_TIME_OUT);
   private long rpcTimeout = RPC_TIMEOUT_DEFAULT_MS;
   private ShuffleServerBlockingStub blockingStub;
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -61,7 +61,6 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
-import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.NotRetryException;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
@@ -106,10 +105,8 @@ import org.apache.uniffle.proto.ShuffleServerGrpc.ShuffleServerBlockingStub;
 public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServerClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleServerGrpcClient.class);
-  private static RssBaseConf rssConf;
   protected static final long FAILED_REQUIRE_ID = -1;
-  protected static final long RPC_TIMEOUT_DEFAULT_MS =
-      rssConf.getLong(RssBaseConf.RSS_CLIENT_GRPC_TIME_OUT);
+  protected static final long RPC_TIMEOUT_DEFAULT_MS = 60000;
   private long rpcTimeout = RPC_TIMEOUT_DEFAULT_MS;
   private ShuffleServerBlockingStub blockingStub;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make shuffle manager client RPC timeout configurable

### Why are the changes needed?

Fix: #973 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

current UT and Integration testing
