### PR TITLE
[#993] feat(tez): Optimize the method of obtain the application attem…

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/common/IdUtils.java
+++ b/client-tez/src/main/java/org/apache/tez/common/IdUtils.java
@@ -17,9 +17,6 @@
 
 package org.apache.tez.common;
 
-import org.apache.hadoop.yarn.api.ApplicationConstants;
-import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
-import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,21 +33,5 @@ public class IdUtils {
   public static TezTaskAttemptID convertTezTaskAttemptID(String pathComponent) {
     LOG.info("convertTezTaskAttemptID, pathComponent:{}", pathComponent);
     return TezTaskAttemptID.fromString(pathComponent.substring(0, pathComponent.length() - 6));
-  }
-
-  /** @return ApplicationAttemptId, eg: appattempt_1681717153064_2719964_000001 */
-  public static ApplicationAttemptId getApplicationAttemptId() {
-    String containerIdStr = System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name());
-    ContainerId containerId = ContainerId.fromString(containerIdStr);
-    return containerId.getApplicationAttemptId();
-  }
-
-  /**
-   * Get application id attempt.
-   *
-   * @return ApplicationAttemptId attempt id, eg: 1, 2, 3
-   */
-  public static int getAppAttemptId() {
-    return getApplicationAttemptId().getAttemptId();
   }
 }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManager.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.util.Time;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.CallableWithNdc;
 import org.apache.tez.common.InputContextUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
@@ -112,6 +113,7 @@ public class RssShuffleManager extends ShuffleManager {
   private final InputContext inputContext;
   private final int numInputs;
   private final int shuffleId;
+  private final ApplicationAttemptId applicationAttemptId;
 
   private final DecimalFormat mbpsFormat = new DecimalFormat("0.00");
 
@@ -224,7 +226,8 @@ public class RssShuffleManager extends ShuffleManager {
       int ifileReadAheadLength,
       CompressionCodec codec,
       FetchedInputAllocator inputAllocator,
-      int shuffleId)
+      int shuffleId,
+      ApplicationAttemptId applicationAttemptId)
       throws IOException {
     super(
         inputContext,
@@ -239,6 +242,7 @@ public class RssShuffleManager extends ShuffleManager {
     this.conf = conf;
     this.numInputs = numInputs;
     this.shuffleId = shuffleId;
+    this.applicationAttemptId = applicationAttemptId;
 
     this.shuffledInputsCounter =
         inputContext.getCounters().findCounter(TaskCounter.NUM_SHUFFLED_INPUTS);
@@ -593,6 +597,7 @@ public class RssShuffleManager extends ShuffleManager {
                         inputManager,
                         partition,
                         shuffleId,
+                        applicationAttemptId,
                         partitionToInput.get(partition),
                         new HashSet<ShuffleServerInfo>(partitionToServers.get(partition)),
                         rssAllBlockIdBitmapMap,

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
@@ -146,7 +146,8 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
         shuffleId,
         partition);
     Roaring64NavigableMap blockIdBitmap =
-        writeClient.getShuffleResult(clientType, serverInfoSet, applicationAttemptId.toString(), shuffleId, partition);
+        writeClient.getShuffleResult(
+            clientType, serverInfoSet, applicationAttemptId.toString(), shuffleId, partition);
     writeClient.close();
     rssAllBlockIdBitmapMap.put(partition, blockIdBitmap);
 
@@ -235,7 +236,12 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(partition, numPhysicalInputs, dagIdentifier, vertexIndex, reduceId,
+    return Objects.hash(
+        partition,
+        numPhysicalInputs,
+        dagIdentifier,
+        vertexIndex,
+        reduceId,
         applicationAttemptId.toString());
   }
 }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffle.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffle.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.CallableWithNdc;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.TezUtilsInternal;
@@ -104,7 +105,8 @@ public class RssShuffle implements ExceptionReporter {
       Configuration conf,
       int numInputs,
       long initialMemoryAvailable,
-      int shuffleId)
+      int shuffleId,
+      ApplicationAttemptId applicationAttemptId)
       throws IOException {
     this.inputContext = inputContext;
     this.conf = conf;
@@ -188,7 +190,8 @@ public class RssShuffle implements ExceptionReporter {
             ifileReadAhead,
             ifileReadAheadLength,
             srcNameTrimmed,
-            shuffleId);
+            shuffleId,
+            applicationAttemptId);
 
     this.mergePhaseTime = inputContext.getCounters().findCounter(TaskCounter.MERGE_PHASE_TIME);
     this.shufflePhaseTime = inputContext.getCounters().findCounter(TaskCounter.SHUFFLE_PHASE_TIME);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
@@ -1814,7 +1814,11 @@ class RssShuffleScheduler extends ShuffleScheduler {
     String clientType = "";
     Roaring64NavigableMap blockIdBitmap =
         writeClient.getShuffleResult(
-            clientType, shuffleServerInfoSet, applicationAttemptId.toString(), shuffleId, mapHost.getPartitionId());
+            clientType,
+            shuffleServerInfoSet,
+            applicationAttemptId.toString(),
+            shuffleId,
+            mapHost.getPartitionId());
     writeClient.close();
 
     int appAttemptId = applicationAttemptId.getAttemptId();

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
@@ -25,10 +25,7 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
-import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.tez.common.RssTezConfig;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.dag.records.TezTaskAttemptID;
@@ -63,6 +60,7 @@ public class RssSorter extends ExternalSorter {
       int numOutputs,
       long initialMemoryAvailable,
       int shuffleId,
+      ApplicationAttemptId applicationAttemptId,
       Map<Integer, List<ShuffleServerInfo>> partitionToServers)
       throws IOException {
     super(outputContext, conf, numOutputs, initialMemoryAvailable);
@@ -135,11 +133,6 @@ public class RssSorter extends ExternalSorter {
       LOG.info("bitmapSplitNum is {}", bitmapSplitNum);
     }
 
-    String containerIdStr = System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name());
-    ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
-    ApplicationAttemptId applicationAttemptId = containerId.getApplicationAttemptId();
-    LOG.info("containerIdStr is {}", containerIdStr);
-    LOG.info("containerId is {}", containerId);
     LOG.info("applicationAttemptId is {}", applicationAttemptId.toString());
 
     bufferManager =

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
@@ -25,10 +25,7 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
-import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.tez.common.RssTezConfig;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.dag.records.TezTaskAttemptID;
@@ -62,6 +59,7 @@ public class RssUnSorter extends ExternalSorter {
       int numOutputs,
       long initialMemoryAvailable,
       int shuffleId,
+      ApplicationAttemptId applicationAttemptId,
       Map<Integer, List<ShuffleServerInfo>> partitionToServers)
       throws IOException {
     super(outputContext, conf, numOutputs, initialMemoryAvailable);
@@ -133,11 +131,6 @@ public class RssUnSorter extends ExternalSorter {
       LOG.info("bitmapSplitNum is {}", bitmapSplitNum);
     }
 
-    String containerIdStr = System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name());
-    ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
-    ApplicationAttemptId applicationAttemptId = containerId.getApplicationAttemptId();
-    LOG.info("containerIdStr is {}", containerIdStr);
-    LOG.info("containerId is {}", containerId);
     LOG.info("applicationAttemptId is {}", applicationAttemptId.toString());
 
     bufferManager =

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInput.java
@@ -141,7 +141,8 @@ public class RssOrderedGroupedKVInput extends AbstractLogicalInput {
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
     this.applicationAttemptId =
-        ApplicationAttemptId.newInstance(getContext().getApplicationId(), getContext().getDAGAttemptNumber());
+        ApplicationAttemptId.newInstance(
+            getContext().getApplicationId(), getContext().getDAGAttemptNumber());
     return Collections.emptyList();
   }
 

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInput.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.RawComparator;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.TezUtils;
@@ -86,6 +87,7 @@ public class RssOrderedGroupedKVInput extends AbstractLogicalInput {
   protected RssShuffle shuffle;
   protected MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
   private int shuffleId;
+  private ApplicationAttemptId applicationAttemptId;
   private final BlockingQueue<Event> pendingEvents = new LinkedBlockingQueue<>();
   private long firstEventReceivedTime = -1;
 
@@ -138,6 +140,8 @@ public class RssOrderedGroupedKVInput extends AbstractLogicalInput {
     assert destinationVertexId != -1;
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(getContext().getApplicationId(), getContext().getDAGAttemptNumber());
     return Collections.emptyList();
   }
 
@@ -169,7 +173,8 @@ public class RssOrderedGroupedKVInput extends AbstractLogicalInput {
         conf,
         getNumPhysicalInputs(),
         memoryUpdateCallbackHandler.getMemoryAssigned(),
-        shuffleId);
+        shuffleId,
+        applicationAttemptId);
   }
 
   /**

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssUnorderedKVInput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssUnorderedKVInput.java
@@ -135,7 +135,8 @@ public class RssUnorderedKVInput extends AbstractLogicalInput {
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
     this.applicationAttemptId =
-        ApplicationAttemptId.newInstance(getContext().getApplicationId(), getContext().getDAGAttemptNumber());
+        ApplicationAttemptId.newInstance(
+            getContext().getApplicationId(), getContext().getDAGAttemptNumber());
     return Collections.emptyList();
   }
 

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssUnorderedKVInput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/input/RssUnorderedKVInput.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.TezUtils;
@@ -92,6 +93,7 @@ public class RssUnorderedKVInput extends AbstractLogicalInput {
   private SimpleFetchedInputAllocator inputManager;
   private ShuffleEventHandler inputEventHandler;
   private int shuffleId;
+  private ApplicationAttemptId applicationAttemptId;
 
   public RssUnorderedKVInput(InputContext inputContext, int numPhysicalInputs) {
     super(inputContext, numPhysicalInputs);
@@ -132,6 +134,8 @@ public class RssUnorderedKVInput extends AbstractLogicalInput {
     assert destinationVertexId != -1;
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(getContext().getApplicationId(), getContext().getDAGAttemptNumber());
     return Collections.emptyList();
   }
 
@@ -192,7 +196,8 @@ public class RssUnorderedKVInput extends AbstractLogicalInput {
               ifileReadAheadLength,
               codec,
               inputManager,
-              shuffleId);
+              shuffleId,
+              applicationAttemptId);
 
       this.inputEventHandler =
           new ShuffleInputEventHandlerImpl(

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
@@ -115,7 +115,8 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
     this.taskVertexName = outputContext.getTaskVertexName();
     this.destinationVertexName = outputContext.getDestinationVertexName();
     this.applicationAttemptId =
-        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
+        ApplicationAttemptId.newInstance(
+            outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     LOG.info("taskAttemptId is {}", taskAttemptId.toString());
     LOG.info("taskVertexName is {}", taskVertexName);
     LOG.info("destinationVertexName is {}", destinationVertexName);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.GetShuffleServerRequest;
 import org.apache.tez.common.GetShuffleServerResponse;
@@ -99,6 +100,7 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
   private String taskVertexName;
   private String destinationVertexName;
   private int shuffleId;
+  private ApplicationAttemptId applicationAttemptId;
 
   public RssOrderedPartitionedKVOutput(OutputContext outputContext, int numPhysicalOutputs) {
     super(outputContext, numPhysicalOutputs);
@@ -112,6 +114,8 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
             RssTezUtils.uniqueIdentifierToAttemptId(outputContext.getUniqueIdentifier()));
     this.taskVertexName = outputContext.getTaskVertexName();
     this.destinationVertexName = outputContext.getDestinationVertexName();
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     LOG.info("taskAttemptId is {}", taskAttemptId.toString());
     LOG.info("taskVertexName is {}", taskVertexName);
     LOG.info("destinationVertexName is {}", destinationVertexName);
@@ -216,6 +220,7 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
               numOutputs,
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
+              applicationAttemptId,
               partitionToServers);
       LOG.info("Initialized RssSorter.");
       isStarted.set(true);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.GetShuffleServerRequest;
 import org.apache.tez.common.GetShuffleServerResponse;
@@ -99,6 +100,7 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
   private String taskVertexName;
   private String destinationVertexName;
   private int shuffleId;
+  private ApplicationAttemptId applicationAttemptId;
 
   public RssUnorderedKVOutput(OutputContext outputContext, int numPhysicalOutputs) {
     super(outputContext, numPhysicalOutputs);
@@ -168,6 +170,8 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
     assert destinationVertexId != -1;
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     GetShuffleServerRequest request =
         new GetShuffleServerRequest(
             this.taskAttemptId, this.mapNum, this.numOutputs, this.shuffleId);
@@ -221,6 +225,7 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
               numOutputs,
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
+              applicationAttemptId,
               partitionToServers);
       LOG.info("Initialized RssUnSorter.");
       isStarted.set(true);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
@@ -171,7 +171,8 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
     this.applicationAttemptId =
-        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
+        ApplicationAttemptId.newInstance(
+            outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     GetShuffleServerRequest request =
         new GetShuffleServerRequest(
             this.taskAttemptId, this.mapNum, this.numOutputs, this.shuffleId);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
@@ -169,7 +169,8 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
     this.applicationAttemptId =
-        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
+        ApplicationAttemptId.newInstance(
+            outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     GetShuffleServerRequest request =
         new GetShuffleServerRequest(
             this.taskAttemptId, this.mapNum, this.numOutputs, this.shuffleId);

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.GetShuffleServerRequest;
 import org.apache.tez.common.GetShuffleServerResponse;
@@ -100,6 +101,7 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
   private String taskVertexName;
   private String destinationVertexName;
   private int shuffleId;
+  private ApplicationAttemptId applicationAttemptId;
 
   public RssUnorderedPartitionedKVOutput(OutputContext outputContext, int numPhysicalOutputs) {
     super(outputContext, numPhysicalOutputs);
@@ -166,6 +168,8 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
     assert destinationVertexId != -1;
     this.shuffleId =
         RssTezUtils.computeShuffleId(tezDAGID.getId(), sourceVertexId, destinationVertexId);
+    this.applicationAttemptId =
+        ApplicationAttemptId.newInstance(outputContext.getApplicationId(), outputContext.getDAGAttemptNumber());
     GetShuffleServerRequest request =
         new GetShuffleServerRequest(
             this.taskAttemptId, this.mapNum, this.numOutputs, this.shuffleId);
@@ -219,6 +223,7 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
               numOutputs,
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
+              applicationAttemptId,
               partitionToServers);
       LOG.info("Initialized RssUnSorter.");
       isStarted.set(true);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManagerTest.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.TezExecutors;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.TezSharedExecutor;
@@ -81,6 +83,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RssShuffleManagerTest {
+  public static final ApplicationId APP_ID = ApplicationId.newInstance(9999, 72);
+  public static final ApplicationAttemptId APPATTEMPT_ID = ApplicationAttemptId.newInstance(APP_ID, 1);
   private static final String FETCHER_HOST = "localhost";
   private static final int PORT = 8080;
   private static final String PATH_COMPONENT = "attempttmp";
@@ -119,6 +123,8 @@ public class RssShuffleManagerTest {
     doReturn("Reducer 1").when(inputContext).getTaskVertexName();
     when(inputContext.getUniqueIdentifier())
         .thenReturn("attempt_1685094627632_0157_1_01_000000_0_10006");
+    doReturn(APP_ID).when(inputContext).getApplicationId();
+    doReturn(APPATTEMPT_ID.getAttemptId()).when(inputContext).getDAGAttemptNumber();
     return inputContext;
   }
 
@@ -296,7 +302,8 @@ public class RssShuffleManagerTest {
           ifileReadAheadLength,
           codec,
           inputAllocator,
-          0);
+          0,
+          APPATTEMPT_ID);
     }
 
     @Override

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManagerTest.java
@@ -84,7 +84,8 @@ import static org.mockito.Mockito.when;
 
 public class RssShuffleManagerTest {
   public static final ApplicationId APP_ID = ApplicationId.newInstance(9999, 72);
-  public static final ApplicationAttemptId APPATTEMPT_ID = ApplicationAttemptId.newInstance(APP_ID, 1);
+  public static final ApplicationAttemptId APPATTEMPT_ID =
+      ApplicationAttemptId.newInstance(APP_ID, 1);
   private static final String FETCHER_HOST = "localhost";
   private static final int PORT = 8080;
   private static final String PATH_COMPONENT = "attempttmp";

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleSchedulerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleSchedulerTest.java
@@ -89,9 +89,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth1() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       Configuration conf = new TezConfiguration();
       testReducerHealth1(conf);
@@ -177,9 +175,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth2() throws IOException, InterruptedException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis() - 500000;
       Shuffle shuffle = mock(Shuffle.class);
@@ -338,9 +334,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth3() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis() - 500000;
       Shuffle shuffle = mock(Shuffle.class);
@@ -427,9 +421,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth4() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis() - 500000;
       Shuffle shuffle = mock(Shuffle.class);
@@ -570,9 +562,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth5() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis() - 500000;
       Shuffle shuffle = mock(Shuffle.class);
@@ -656,9 +646,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth6() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       Configuration conf = new TezConfiguration();
       conf.setBoolean(
@@ -759,9 +747,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testReducerHealth7() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis() - 500000;
       Shuffle shuffle = mock(Shuffle.class);
@@ -861,9 +847,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testPenalty() throws IOException, InterruptedException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis();
       Shuffle shuffle = mock(Shuffle.class);
@@ -899,9 +883,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testProgressDuringGetHostWait() throws IOException, InterruptedException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       long startTime = System.currentTimeMillis();
       Configuration conf = new TezConfiguration();
@@ -930,9 +912,7 @@ public class RssShuffleSchedulerTest {
   @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testShutdownWithInterrupt() throws Exception {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       InputContext inputContext = createTezInputContext();
       Configuration conf = new TezConfiguration();

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleTest.java
@@ -80,9 +80,7 @@ public class RssShuffleTest {
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulerTerminatesOnException() throws IOException, InterruptedException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       InputContext inputContext = createTezInputContext();
       TezConfiguration conf = new TezConfiguration();
@@ -117,9 +115,7 @@ public class RssShuffleTest {
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testKillSelf() throws IOException, InterruptedException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
 
       InputContext inputContext = createTezInputContext();
       TezConfiguration conf = new TezConfiguration();

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleTest.java
@@ -24,9 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.tez.common.IdUtils;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezExecutors;
 import org.apache.tez.common.TezSharedExecutor;
@@ -51,6 +49,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import static org.apache.tez.runtime.library.common.shuffle.impl.RssShuffleManagerTest.APPATTEMPT_ID;
+import static org.apache.tez.runtime.library.common.shuffle.impl.RssShuffleManagerTest.APP_ID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,42 +79,36 @@ public class RssShuffleTest {
   @Test
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulerTerminatesOnException() throws IOException, InterruptedException {
-    try (MockedStatic<IdUtils> idUtils = Mockito.mockStatic(IdUtils.class)) {
-      ApplicationId appId = ApplicationId.newInstance(9999, 72);
-      ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
-      idUtils.when(IdUtils::getApplicationAttemptId).thenReturn(appAttemptId);
+    try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
+      shuffleUtils
+          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
+          .thenReturn(4);
 
-      try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-        shuffleUtils
-            .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-            .thenReturn(4);
+      InputContext inputContext = createTezInputContext();
+      TezConfiguration conf = new TezConfiguration();
+      conf.setLong(Constants.TEZ_RUNTIME_TASK_MEMORY, 300000L);
+      RssShuffle shuffle = new RssShuffle(inputContext, conf, 1, 3000000L, 0, APPATTEMPT_ID);
+      try {
+        shuffle.run();
+        ShuffleScheduler scheduler = shuffle.rssScheduler;
+        MergeManager mergeManager = shuffle.merger;
+        assertFalse(scheduler.isShutdown());
+        assertFalse(mergeManager.isShutdown());
 
-        InputContext inputContext = createTezInputContext();
-        TezConfiguration conf = new TezConfiguration();
-        conf.setLong(Constants.TEZ_RUNTIME_TASK_MEMORY, 300000L);
-        RssShuffle shuffle = new RssShuffle(inputContext, conf, 1, 3000000L, 0);
-        try {
-          shuffle.run();
-          ShuffleScheduler scheduler = shuffle.rssScheduler;
-          MergeManager mergeManager = shuffle.merger;
-          assertFalse(scheduler.isShutdown());
-          assertFalse(mergeManager.isShutdown());
+        String exceptionMessage = "Simulating fetch failure";
+        shuffle.reportException(new IOException(exceptionMessage));
 
-          String exceptionMessage = "Simulating fetch failure";
-          shuffle.reportException(new IOException(exceptionMessage));
-
-          while (!scheduler.isShutdown()) {
-            Thread.sleep(100L);
-          }
-          assertTrue(scheduler.isShutdown());
-
-          while (!mergeManager.isShutdown()) {
-            Thread.sleep(100L);
-          }
-          assertTrue(mergeManager.isShutdown());
-        } finally {
-          shuffle.shutdown();
+        while (!scheduler.isShutdown()) {
+          Thread.sleep(100L);
         }
+        assertTrue(scheduler.isShutdown());
+
+        while (!mergeManager.isShutdown()) {
+          Thread.sleep(100L);
+        }
+        assertTrue(mergeManager.isShutdown());
+      } finally {
+        shuffle.shutdown();
       }
     }
   }
@@ -122,45 +116,39 @@ public class RssShuffleTest {
   @Test
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testKillSelf() throws IOException, InterruptedException {
-    try (MockedStatic<IdUtils> idUtils = Mockito.mockStatic(IdUtils.class)) {
-      ApplicationId appId = ApplicationId.newInstance(9999, 72);
-      ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
-      idUtils.when(IdUtils::getApplicationAttemptId).thenReturn(appAttemptId);
+    try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
+      shuffleUtils
+          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
+          .thenReturn(4);
 
-      try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-        shuffleUtils
-            .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-            .thenReturn(4);
+      InputContext inputContext = createTezInputContext();
+      TezConfiguration conf = new TezConfiguration();
+      conf.setLong(Constants.TEZ_RUNTIME_TASK_MEMORY, 300000L);
+      RssShuffle shuffle = new RssShuffle(inputContext, conf, 1, 3000000L, 0, APPATTEMPT_ID);
+      try {
+        shuffle.run();
+        ShuffleScheduler scheduler = shuffle.rssScheduler;
+        assertFalse(scheduler.isShutdown());
 
-        InputContext inputContext = createTezInputContext();
-        TezConfiguration conf = new TezConfiguration();
-        conf.setLong(Constants.TEZ_RUNTIME_TASK_MEMORY, 300000L);
-        RssShuffle shuffle = new RssShuffle(inputContext, conf, 1, 3000000L, 0);
-        try {
-          shuffle.run();
-          ShuffleScheduler scheduler = shuffle.rssScheduler;
-          assertFalse(scheduler.isShutdown());
+        // killSelf() would invoke close(). Internally Shuffle --> merge.close() --> finalMerge()
+        // gets called. In MergeManager::finalMerge(), it would throw illegal argument exception
+        // as
+        // uniqueIdentifier is not present in inputContext. This is used as means of simulating
+        // exception.
+        scheduler.killSelf(new Exception(), "due to internal error");
+        assertTrue(scheduler.isShutdown());
 
-          // killSelf() would invoke close(). Internally Shuffle --> merge.close() --> finalMerge()
-          // gets called. In MergeManager::finalMerge(), it would throw illegal argument exception
-          // as
-          // uniqueIdentifier is not present in inputContext. This is used as means of simulating
-          // exception.
-          scheduler.killSelf(new Exception(), "due to internal error");
-          assertTrue(scheduler.isShutdown());
-
-          // killSelf() should not result in reporting failure to AM
-          ArgumentCaptor<Throwable> throwableArgumentCaptor =
-              ArgumentCaptor.forClass(Throwable.class);
-          ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-          verify(inputContext, times(0))
-              .reportFailure(
-                  eq(TaskFailureType.NON_FATAL),
-                  throwableArgumentCaptor.capture(),
-                  stringArgumentCaptor.capture());
-        } finally {
-          shuffle.shutdown();
-        }
+        // killSelf() should not result in reporting failure to AM
+        ArgumentCaptor<Throwable> throwableArgumentCaptor =
+            ArgumentCaptor.forClass(Throwable.class);
+        ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(inputContext, times(0))
+            .reportFailure(
+                eq(TaskFailureType.NON_FATAL),
+                throwableArgumentCaptor.capture(),
+                stringArgumentCaptor.capture());
+      } finally {
+        shuffle.shutdown();
       }
     }
   }
@@ -190,6 +178,8 @@ public class RssShuffleTest {
             new JobTokenIdentifier(new Text("text")), new JobTokenSecretManager());
     ByteBuffer tokenBuffer = TezCommonUtils.serializeServiceData(sessionToken);
     doReturn(tokenBuffer).when(inputContext).getServiceConsumerMetaData(anyString());
+    doReturn(APP_ID).when(inputContext).getApplicationId();
+    doReturn(APPATTEMPT_ID.getAttemptId()).when(inputContext).getDAGAttemptNumber();
     return inputContext;
   }
 }

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssSorterTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssSorterTest.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.runtime.api.OutputContext;
@@ -78,6 +80,8 @@ public class RssSorterTest {
   public void testCollectAndRecordsPerPartition() throws IOException, InterruptedException {
     TezTaskAttemptID tezTaskAttemptID =
         TezTaskAttemptID.fromString("attempt_1681717153064_3770270_1_00_000000_0");
+    ApplicationAttemptId applicationAttemptId =
+        ApplicationAttemptId.newInstance(ApplicationId.newInstance(1681717153064L, 3770270), 0);
 
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
 
@@ -93,6 +97,7 @@ public class RssSorterTest {
             5,
             initialMemoryAvailable,
             shuffleId,
+            applicationAttemptId,
             partitionToServers);
 
     rssSorter.collect(new Text("0"), new Text("0"), 0);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorterTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorterTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
 
+import static org.apache.tez.runtime.library.common.shuffle.impl.RssShuffleManagerTest.APPATTEMPT_ID;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssUnSorterTest {
@@ -91,6 +92,7 @@ public class RssUnSorterTest {
             5,
             initialMemoryAvailable,
             shuffleId,
+            APPATTEMPT_ID,
             partitionToServers);
 
     rssSorter.collect(new Text("0"), new Text("0"), 0);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInputTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/input/RssOrderedGroupedKVInputTest.java
@@ -55,15 +55,14 @@ import static org.mockito.Mockito.when;
 public class RssOrderedGroupedKVInputTest {
 
   private static final ApplicationId APPID = ApplicationId.newInstance(9999, 72);
-  private static final ApplicationAttemptId APPATTEMPT_ID = ApplicationAttemptId.newInstance(APPID, 1);
+  private static final ApplicationAttemptId APPATTEMPT_ID =
+      ApplicationAttemptId.newInstance(APPID, 1);
 
   @Test
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInterruptWhileAwaitingInput() throws IOException {
     try (MockedStatic<ShuffleUtils> shuffleUtils = Mockito.mockStatic(ShuffleUtils.class)) {
-      shuffleUtils
-          .when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any()))
-          .thenReturn(4);
+      shuffleUtils.when(() -> ShuffleUtils.deserializeShuffleProviderMetaData(any())).thenReturn(4);
       InputContext inputContext = createMockInputContext();
       RssOrderedGroupedKVInput kvInput = new OrderedGroupedKVInputForTest(inputContext, 10);
       kvInput.initialize();

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
@@ -74,6 +74,7 @@ public class OutputTestHelpers {
     doReturn(statsReporter).when(ctx).getStatisticsReporter();
     doReturn(new ExecutionContextImpl("localhost")).when(ctx).getExecutionContext();
     doReturn(APP_ID).when(ctx).getApplicationId();
+    doReturn(APP_ATTEMPT_ID.getAttemptId()).when(ctx).getDAGAttemptNumber();
     return ctx;
   }
 }

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutputTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutputTest.java
@@ -135,8 +135,7 @@ public class RssUnorderedKVOutputTest {
           new ShuffleAssignmentsInfoWritable(shuffleAssignmentsInfo));
       doReturn(response).when(protocol).getShuffleAssignments(any());
       rpc.when(() -> RPC.getProxy(any(), anyLong(), any(), any())).thenReturn(protocol);
-      try (MockedStatic<ConverterUtils> converterUtils =
-               Mockito.mockStatic(ConverterUtils.class)) {
+      try (MockedStatic<ConverterUtils> converterUtils = Mockito.mockStatic(ConverterUtils.class)) {
         ContainerId containerId = ContainerId.newContainerId(OutputTestHelpers.APP_ATTEMPT_ID, 1);
         converterUtils.when(() -> ConverterUtils.toContainerId(null)).thenReturn(containerId);
         converterUtils

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutputTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutputTest.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.tez.common.GetShuffleServerResponse;
-import org.apache.tez.common.IdUtils;
 import org.apache.tez.common.ShuffleAssignmentsInfoWritable;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRemoteShuffleUmbilicalProtocol;
@@ -136,28 +135,20 @@ public class RssUnorderedKVOutputTest {
           new ShuffleAssignmentsInfoWritable(shuffleAssignmentsInfo));
       doReturn(response).when(protocol).getShuffleAssignments(any());
       rpc.when(() -> RPC.getProxy(any(), anyLong(), any(), any())).thenReturn(protocol);
-      try (MockedStatic<IdUtils> idUtils = Mockito.mockStatic(IdUtils.class)) {
-        idUtils
-            .when(() -> IdUtils.getApplicationAttemptId())
-            .thenReturn(OutputTestHelpers.APP_ATTEMPT_ID);
-        idUtils
-            .when(() -> IdUtils.getAppAttemptId())
-            .thenReturn(OutputTestHelpers.APP_ATTEMPT_ID.getAttemptId());
-        try (MockedStatic<ConverterUtils> converterUtils =
-            Mockito.mockStatic(ConverterUtils.class)) {
-          ContainerId containerId = ContainerId.newContainerId(OutputTestHelpers.APP_ATTEMPT_ID, 1);
-          converterUtils.when(() -> ConverterUtils.toContainerId(null)).thenReturn(containerId);
-          converterUtils
-              .when(() -> ConverterUtils.toContainerId(anyString()))
-              .thenReturn(containerId);
-          OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
-          int numPartitions = 1;
-          RssUnorderedKVOutput output = new RssUnorderedKVOutput(outputContext, numPartitions);
-          output.initialize();
-          output.start();
-          Assertions.assertNotNull(output.getWriter());
-          output.close();
-        }
+      try (MockedStatic<ConverterUtils> converterUtils =
+               Mockito.mockStatic(ConverterUtils.class)) {
+        ContainerId containerId = ContainerId.newContainerId(OutputTestHelpers.APP_ATTEMPT_ID, 1);
+        converterUtils.when(() -> ConverterUtils.toContainerId(null)).thenReturn(containerId);
+        converterUtils
+            .when(() -> ConverterUtils.toContainerId(anyString()))
+            .thenReturn(containerId);
+        OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
+        int numPartitions = 1;
+        RssUnorderedKVOutput output = new RssUnorderedKVOutput(outputContext, numPartitions);
+        output.initialize();
+        output.start();
+        Assertions.assertNotNull(output.getWriter());
+        output.close();
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the method of obtain application attempt id. 

### Why are the changes needed?

For now, we parse ApplicationAttemptId from env CONTAINER_ID. But for tez local mode, CONTAINER_ID is empty.
We can just construct ApplicationAttemptId from ApplicationId and DAGAttemptNumber, because DAGAttemptNumber is just the app attempt id.

Fix: #993

### How was this patch tested?

integration test, unit test, test on yarn.