### PR TITLE
Fix the flaky test GrpcServerTest

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -49,6 +49,7 @@ public class GrpcServer implements ServerInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(GrpcServer.class);
 
+  public static int testVarCount=0;
   private Server server;
   private final int port;
   private int listenPort;
@@ -157,6 +158,7 @@ public class GrpcServer implements ServerInterface {
       grpcMetrics.incGauge(GRPCMetrics.GRPC_SERVER_EXECUTOR_ACTIVE_THREADS_KEY);
       grpcMetrics.setGauge(
           GRPCMetrics.GRPC_SERVER_EXECUTOR_BLOCKING_QUEUE_SIZE_KEY, getQueue().size());
+      testVarCount=1;
       super.beforeExecute(t, r);
     }
 

--- a/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
@@ -69,6 +69,7 @@ public class GrpcServerTest {
           });
     }
 
+    while(org.apache.uniffle.common.rpc.GrpcServer.testVarCount < 1) { Thread.yield(); }
     Thread.sleep(120);
     double activeThreads =
         grpcMetrics.getGaugeMap().get(GRPC_SERVER_EXECUTOR_ACTIVE_THREADS_KEY).get();


### PR DESCRIPTION
### **What changes were proposed in this pull request?**

I observed a previous fix injected some delay to fix the flaky test, but I believe that fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the source code location whose slow execution leads to the flaky test failure, where if common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java#157 slows the grpcMetrics.incGauge() and grpcMetrics.setGauge(), then the test fails (https://github.com/apache/incubator-uniffle/blob/master/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java#L157 and https://github.com/apache/incubator-uniffle/blob/master/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java#L158). Hence, I introduce one variable in this class [GrpcServer.java](https://github.com/apache/incubator-uniffle/blob/master/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java#L158) that is only there to provide some synchronization. Basically, until these two statements are executed, I force the thread that the test runs on to wait before it accesses the value of grpcMetrics.getGaugeMap(). The waiting location is at https://github.com/apache/incubator-uniffle/blob/master/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java#L72


### **Why are the changes needed?**

This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.
Failure:
[INFO] Running org.apache.uniffle.common.rpc.GrpcServerTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.185 s <<< FAILURE! - in org.apache.uniffle.common.rpc.GrpcServerTest
[ERROR] testGrpcExecutorPool Time elapsed: 0.142 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <2.0> but was: <0.0>
at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:70)
at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:65)
at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:885)
at org.apache.uniffle.common.rpc.GrpcServerTest.testGrpcExecutorPool(GrpcServerTest.java:76)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

[ERROR] Failures:
[ERROR] GrpcServerTest.testGrpcExecutorPool:76 expected: <2.0> but was: <0.0>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

### **How was this patch tested?**
I run this test more than 1000 times and the test always passes.