### PR TITLE
[MINOR] chore(asf): stop forwarding GitHub issues to dev mail list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,5 +57,5 @@ github:
 
 notifications:
   commits: commits@uniffle.apache.org
-  issues: dev@uniffle.apache.org
+  issues: issues@uniffle.apache.org
   pullrequests: issues@uniffle.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

Stop forwarding GitHub issues to dev mail list,
instead, forwarding them to issues mail list.

### Why are the changes needed?

Many contributors are not subscribed to the dev mail list,
probably because it's noisy (~200 emails per month).

Let's leave dev mail list for the most important (or general) messages, 
such as: votes, announcements, general discussions, user feedbacks. 

### Does this PR introduce _any_ user-facing change?

Users still wishing to receive all GitHub issues updates through email
should subscribe to `issues@uniffle.apache.org`, or alternatively,
watch the GitHub repository. 

### How was this patch tested?

No need.