### PR TITLE
[MINOR] fix(mr): fix default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ rss-xxx.tgz will be generated for deployment
     # multiple remote storages are supported, and client will get assignment from coordinator
     rss.coordinator.remote.storage.path hdfs://cluster1/path,hdfs://cluster2/path
     rss.writer.require.memory.retryMax 1200
-    rss.client.retry.max 100
+    rss.client.retry.max 50
     rss.writer.send.check.timeout 600000
     rss.client.read.buffer.size 14m
    ```

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -137,7 +137,7 @@ public class RssMRAppMaster extends MRAppMaster {
         assignmentTags.addAll(Arrays.asList(rawTags.split(",")));
       }
       assignmentTags.add(Constants.SHUFFLE_SERVER_VERSION);
-      String clientType = conf.get(RssMRConfig.RSS_CLIENT_TYPE);
+      String clientType = conf.get(RssMRConfig.RSS_CLIENT_TYPE, RssMRConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
       ClientUtils.validateClientType(clientType);
       assignmentTags.add(clientType);
 

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -137,7 +137,8 @@ public class RssMRAppMaster extends MRAppMaster {
         assignmentTags.addAll(Arrays.asList(rawTags.split(",")));
       }
       assignmentTags.add(Constants.SHUFFLE_SERVER_VERSION);
-      String clientType = conf.get(RssMRConfig.RSS_CLIENT_TYPE, RssMRConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
+      String clientType =
+          conf.get(RssMRConfig.RSS_CLIENT_TYPE, RssMRConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
       ClientUtils.validateClientType(clientType);
       assignmentTags.add(clientType);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When configured as README.md, MapReduce will throw these errors. It is not helpful for beginner.
```
Exception in thread "main" java.lang.IllegalArgumentException: mapreduce.rss.client.retry.max(100) * mapreduce.rss.client.retry.interval.max(10000) should not bigger than mapreduce.rss.client.send.check.timeout.ms(600000)
	at org.apache.hadoop.mapreduce.RssMRUtils.validateRssClientConf(RssMRUtils.java:307)
	at org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster.main(RssMRAppMaster.java:189)
```
and
```
Exception in thread "main" java.lang.IllegalArgumentException: The value of null should be one of [GRPC_NETTY, GRPC]
	at org.apache.uniffle.client.util.ClientUtils.validateClientType(ClientUtils.java:144)
	at org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster.main(RssMRAppMaster.java:141)
```

### How was this patch tested?

test in yarn cluster.