### PR TITLE
[#363] refactor: Make the coordinator client managed by CoordinatorClientFactory singleton

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -46,8 +46,6 @@ import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.util.ClientUtils;
-import org.apache.uniffle.client.util.RssClientConfig;
-import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
@@ -108,9 +106,8 @@ public class RssSparkShuffleUtils {
   public static List<CoordinatorClient> createCoordinatorClients(SparkConf sparkConf) {
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
-    CoordinatorClientFactory coordinatorClientFactory =
-        new CoordinatorClientFactory(ClientType.valueOf(clientType));
-    return coordinatorClientFactory.createCoordinatorClient(coordinators);
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
+    return factory.getOrCreateCoordinatorClients(clientType, coordinators);
   }
 
   public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -46,6 +46,8 @@ import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -77,7 +77,6 @@ import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.client.response.RssUnregisterShuffleResponse;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.client.util.ClientUtils;
-import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -161,7 +160,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.clientType = clientType;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
-    this.coordinatorClientFactory = new CoordinatorClientFactory(ClientType.valueOf(clientType));
+    this.coordinatorClientFactory = CoordinatorClientFactory.getInstance();
     this.heartBeatExecutorService =
         ThreadUtils.getDaemonFixedThreadPool(heartBeatThreadNum, "client-heartbeat");
     this.replica = replica;
@@ -566,7 +565,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
   @Override
   public void registerCoordinators(String coordinators) {
     List<CoordinatorClient> clients =
-        coordinatorClientFactory.createCoordinatorClient(coordinators);
+        coordinatorClientFactory.getOrCreateCoordinatorClients(clientType, coordinators);
     coordinatorClients.addAll(clients);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -172,9 +172,10 @@ public class AccessClusterTest extends CoordinatorTestBase {
     shuffleServer.start();
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
     CoordinatorClient client =
-        new CoordinatorClientFactory(ClientType.GRPC)
-            .createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
+        factory.getOrCreateCoordinatorClient(
+            ClientType.GRPC.name(), LOCALHOST, COORDINATOR_PORT_1 + 13);
     request =
         new RssAccessClusterRequest(
             accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000, "user");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorTestBase.java
@@ -26,13 +26,15 @@ import org.apache.uniffle.common.ClientType;
 
 public class CoordinatorTestBase extends IntegrationTestBase {
 
-  protected CoordinatorClientFactory factory = new CoordinatorClientFactory(ClientType.GRPC);
+  protected CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
   protected CoordinatorGrpcClient coordinatorClient;
 
   @BeforeEach
   public void createClient() {
     coordinatorClient =
-        (CoordinatorGrpcClient) factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1);
+        (CoordinatorGrpcClient)
+            factory.getOrCreateCoordinatorClient(
+                ClientType.GRPC.name(), LOCALHOST, COORDINATOR_PORT_1);
   }
 
   @AfterEach

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -53,7 +53,7 @@ public class CoordinatorClientFactory {
         return coordinatorClient;
       }
     }
-
+    typeToClients = new java.util.HashMap<>();
     switch (ClientType.valueOf(type)) {
       case GRPC:
         CoordinatorClient grpcClient = new CoordinatorGrpcClient(host, port);
@@ -74,14 +74,6 @@ public class CoordinatorClientFactory {
     }
     List<CoordinatorClient> coordinatorClients = Lists.newLinkedList();
     for (String coordinator : coordinatorList) {
-      clients.computeIfAbsent(type, key -> JavaUtils.newConcurrentMap());
-      Map<String, CoordinatorClient> typeToClients = clients.get(type);
-      CoordinatorClient coordinatorClient = typeToClients.get(coordinator);
-      if (coordinatorClient != null) {
-        coordinatorClients.add(coordinatorClient);
-        continue;
-      }
-      LOG.info("Start to create coordinator clients from {}", coordinator);
       String[] ipPort = coordinator.trim().split(":");
       if (ipPort.length != 2) {
         String msg = "Invalid coordinator format " + Arrays.toString(ipPort);

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -86,7 +86,7 @@ public class CoordinatorClientFactory {
         CoordinatorClient newClient = getOrCreateCoordinatorClient(type, host, port);
         coordinatorClients.add(newClient);
         LOG.info("Add coordinator client {}", newClient.getDesc());
-      } catch(UnsupportedOperationException e) {
+      } catch (UnsupportedOperationException e) {
         throw e;
       }
     }

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -82,8 +82,13 @@ public class CoordinatorClientFactory {
       }
       String host = ipPort[0];
       int port = Integer.parseInt(ipPort[1]);
-      CoordinatorClient newClient = getOrCreateCoordinatorClient(type, host, port);
-      coordinatorClients.add(newClient);
+      try {
+        CoordinatorClient newClient = getOrCreateCoordinatorClient(type, host, port);
+        coordinatorClients.add(newClient);
+        LOG.info("Add coordinator client {}", newClient.getDesc());
+      } catch(UnsupportedOperationException e) {
+        throw e;
+      }
     }
     LOG.info(
         "Finish create coordinator clients {}",

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -57,9 +57,10 @@ public class RegisterHeartBeat {
     this.heartBeatInitialDelay = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_DELAY);
     this.heartBeatInterval = conf.getLong(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL);
     this.coordinatorQuorum = conf.getString(ShuffleServerConf.RSS_COORDINATOR_QUORUM);
-    CoordinatorClientFactory factory =
-        new CoordinatorClientFactory(conf.get(ShuffleServerConf.RSS_CLIENT_TYPE));
-    this.coordinatorClients = factory.createCoordinatorClient(this.coordinatorQuorum);
+    CoordinatorClientFactory factory = CoordinatorClientFactory.getInstance();
+    this.coordinatorClients =
+        factory.getOrCreateCoordinatorClients(
+            conf.get(ShuffleServerConf.RSS_CLIENT_TYPE).name(), this.coordinatorQuorum);
     this.shuffleServer = shuffleServer;
     this.heartBeatExecutorService =
         ThreadUtils.getDaemonFixedThreadPool(


### PR DESCRIPTION
Hi @zuston @jerqi @xianjingfeng 

I am re-submitting a PR to prevent potential conflict since the last PR is been a while, any comments and suggestions would be appreciated if you are available, thank you.

### What changes were proposed in this pull request?

Make the coordinator client managed by CoordinatorClientFactory singleton

### Why are the changes needed?

Fix: #363

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

current UT