### PR TITLE
[#1066] fix: The Jetty server fails to start when compiled with JDK 8 but runtime version is JDK 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the JDK 11 removed jar package.

### Why are the changes needed?

Fix:  #1066

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Tested in our cluster.