### PR TITLE
[#1071] fix: incorrect capacity check in Server#LocalStorage

### DIFF
--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -73,22 +73,6 @@ public class LocalStorageTest {
   }
 
   @Test
-  public void canWriteTest() {
-    LocalStorage item = createTestStorage(testBaseDir);
-
-    item.getMetaData().updateDiskSize(20);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(65);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(10);
-    assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
-    assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
-    assertTrue(item.canWrite());
-  }
-
-  @Test
   public void getCapacityInitTest() {
     LocalStorage item =
         LocalStorage.newBuilder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

When uniffle shuffle-servers colocate with other services (like Hadoop HDFS data), they shares the same mounted disks.

If so, the current capacity checking is wrong, it only will check the uniffle's data used size instead of using the free disk size.



### Why are the changes needed?

Fix: #1071 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Will be added later
