### PR TITLE
[#1095] doc: Add slack link to the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently it supports [Apache Spark][1], [Apache Hadoop MapReduce][2] and [Apach
 [![Codecov](https://codecov.io/gh/apache/incubator-uniffle/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-uniffle)
 [![License](https://img.shields.io/github/license/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/v/release/apache/incubator-uniffle)](https://github.com/apache/incubator-uniffle/releases)
+[![Slack](https://img.shields.io/badge/chat-on%20Slack-brightgreen.svg)](https://join.slack.com/t/the-asf/shared_invite/zt-1fm9561yr-uzTpjqg3jf5nxSJV5AE3KQ)
 
 ## Architecture
 ![Rss Architecture](docs/asset/rss_architecture.png)


### PR DESCRIPTION
<!--
1. Title: [#1095] Docs: Added Slack link to the README.md
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

I have added the Slack link to the README.md to make it easier for anyone to get access to the Slack workspace.

### Why are the changes needed?

Without the Slack link it was confusing if anyone wanted to contact the team.

Fix: #1095

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A