### PR TITLE
[#1101] improvement(tez): Release server resources as soon as possible in RssDAGAppMaster.

### DIFF
--- a/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
+++ b/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
@@ -239,9 +239,6 @@ public class RssDAGAppMasterForWordCountWithFailures extends RssDAGAppMaster {
               jobUserName,
               amPluginDescriptorProto,
               testMode);
-      ShutdownHookManager.get()
-          .addShutdownHook(
-              new RssDAGAppMaster.RssDAGAppMasterShutdownHook(appMaster), SHUTDOWN_HOOK_PRIORITY);
 
       // log the system properties
       if (LOG.isInfoEnabled()) {

--- a/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
+++ b/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.YarnUncaughtExceptionHandler;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -238,6 +239,10 @@ public class RssDAGAppMasterForWordCountWithFailures extends RssDAGAppMaster {
               jobUserName,
               amPluginDescriptorProto,
               testMode);
+      ShutdownHookManager.get()
+          .addShutdownHook(
+              new RssDAGAppMaster.RssDAGAppMasterShutdownHook(appMaster),
+              RSS_SHUTDOWN_HOOK_PRIORITY);
 
       // log the system properties
       if (LOG.isInfoEnabled()) {

--- a/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
+++ b/integration-test/tez/src/test/java/org/apache/tez/dag/app/RssDAGAppMasterForWordCountWithFailures.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.hadoop.yarn.YarnUncaughtExceptionHandler;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Only when the JVM is about to exit, the server resources will be released. In some scenarios, it will occupy server resources for a long time. For example, when enable history logging service and timeline service.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/1101

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests can cover it.
