### PR TITLE
[#1081] fix(tez): shuffle can not read the data which is flushed to hdfs

### DIFF
--- a/client-tez/pom.xml
+++ b/client-tez/pom.xml
@@ -105,6 +105,17 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-yarn-client</artifactId>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
 
     <build>

--- a/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
@@ -174,6 +174,8 @@ public class RssTezConfig {
 
   public static final String RSS_REMOTE_STORAGE_PATH =
       TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_REMOTE_STORAGE_PATH;
+  public static final String RSS_REMOTE_STORAGE_CONF =
+      TEZ_RSS_CONFIG_PREFIX + "rss.remote.storage.conf";
 
   // Whether enable test mode for the MR Client
   public static final String RSS_TEST_MODE_ENABLE =

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.CallableWithNdc;
 import org.apache.tez.common.RssTezConfig;
@@ -43,6 +42,7 @@ import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.request.CreateShuffleReadClientRequest;
+import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.UnitConverter;
 
@@ -68,6 +68,7 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
 
   private String storageType;
   private String basePath;
+  private RemoteStorageInfo remoteStorageInfo;
   private final int readBufferSize;
   private final int partitionNumPerRange;
   private final int partitionNum;
@@ -117,6 +118,9 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
     this.storageType =
         conf.get(RssTezConfig.RSS_STORAGE_TYPE, RssTezConfig.RSS_STORAGE_TYPE_DEFAULT_VALUE);
     LOG.info("RssTezFetcherTask storageType:{}", storageType);
+    this.basePath = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_PATH);
+    String remoteStorageConf = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_CONF);
+    this.remoteStorageInfo = new RemoteStorageInfo(basePath, remoteStorageConf);
 
     String readBufferSize =
         conf.get(
@@ -171,7 +175,7 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
     if (!taskIdBitmap.isEmpty()) {
       LOG.info(
           "In reduce: " + reduceId + ", Rss Tez client starts to fetch blocks from RSS server");
-      JobConf readerJobConf = getRemoteConf();
+      Configuration hadoopConf = getRemoteConf();
       LOG.info("RssTezFetcherTask storageType:{}", storageType);
       boolean expectedTaskIdsBitmapFilterEnable = serverInfoSet.size() > 1;
       CreateShuffleReadClientRequest request =
@@ -185,7 +189,7 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
               blockIdBitmap,
               taskIdBitmap,
               new ArrayList<>(serverInfoSet),
-              readerJobConf,
+              hadoopConf,
               expectedTaskIdsBitmapFilterEnable,
               RssTezConfig.toRssConf(this.conf));
       ShuffleReadClient shuffleReadClient =
@@ -209,8 +213,14 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
 
   public void shutdown() {}
 
-  private JobConf getRemoteConf() {
-    return new JobConf(conf);
+  private Configuration getRemoteConf() {
+    Configuration remoteConf = new Configuration(conf);
+    if (!remoteStorageInfo.isEmpty()) {
+      for (Map.Entry<String, String> entry : remoteStorageInfo.getConfItems().entrySet()) {
+        remoteConf.set(entry.getKey(), entry.getValue());
+      }
+    }
+    return remoteConf;
   }
 
   public int getPartitionId() {

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
@@ -61,7 +61,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.CallableWithNdc;
 import org.apache.tez.common.InputContextUtils;
@@ -97,6 +96,7 @@ import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.request.CreateShuffleReadClientRequest;
+import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.UnitConverter;
@@ -280,6 +280,7 @@ class RssShuffleScheduler extends ShuffleScheduler {
   private final int readBufferSize;
   private final int partitionNumPerRange;
   private String basePath;
+  private RemoteStorageInfo remoteStorageInfo;
   private int indexReadLimit;
 
   RssShuffleScheduler(
@@ -535,6 +536,9 @@ class RssShuffleScheduler extends ShuffleScheduler {
         conf.getInt(
             RssTezConfig.RSS_PARTITION_NUM_PER_RANGE,
             RssTezConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
+    this.basePath = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_PATH);
+    String remoteStorageConf = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_CONF);
+    this.remoteStorageInfo = new RemoteStorageInfo(basePath, remoteStorageConf);
 
     LOG.info(
         "RSSShuffleScheduler running for sourceVertex: "
@@ -1788,8 +1792,14 @@ class RssShuffleScheduler extends ShuffleScheduler {
     return true;
   }
 
-  private JobConf getRemoteConf() {
-    return new JobConf(conf);
+  private Configuration getRemoteConf() {
+    Configuration remoteConf = new Configuration(conf);
+    if (!remoteStorageInfo.isEmpty()) {
+      for (Map.Entry<String, String> entry : remoteStorageInfo.getConfItems().entrySet()) {
+        remoteConf.set(entry.getKey(), entry.getValue());
+      }
+    }
+    return remoteConf;
   }
 
   private synchronized void waitAndNotifyProgress() throws InterruptedException {
@@ -1839,7 +1849,7 @@ class RssShuffleScheduler extends ShuffleScheduler {
           "In reduce: "
               + inputContext.getTaskVertexName()
               + ", Rss Tez client starts to fetch blocks from RSS server");
-      JobConf readerJobConf = getRemoteConf();
+      Configuration hadoopConf = getRemoteConf();
 
       int partitionNum = partitionToServers.size();
       boolean expectedTaskIdsBitmapFilterEnable = shuffleServerInfoSet.size() > 1;
@@ -1855,7 +1865,7 @@ class RssShuffleScheduler extends ShuffleScheduler {
               blockIdBitmap,
               taskIdBitmap,
               shuffleServerInfoList,
-              readerJobConf,
+              hadoopConf,
               new TezIdHelper(),
               expectedTaskIdsBitmapFilterEnable,
               RssTezConfig.toRssConf(conf));

--- a/client-tez/src/test/java/org/apache/tez/dag/app/TezRemoteShuffleManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/dag/app/TezRemoteShuffleManagerTest.java
@@ -116,7 +116,7 @@ public class TezRemoteShuffleManagerTest {
       secretManager.addTokenForJob(tokenIdentifier, sessionToken);
       TezRemoteShuffleManager tezRemoteShuffleManager =
           new TezRemoteShuffleManager(
-              appId.toString(), sessionToken, conf, appId.toString(), client);
+              appId.toString(), sessionToken, conf, appId.toString(), client, null);
       tezRemoteShuffleManager.initialize();
       tezRemoteShuffleManager.start();
 
@@ -224,7 +224,7 @@ public class TezRemoteShuffleManagerTest {
       secretManager.addTokenForJob(tokenIdentifier, sessionToken);
       TezRemoteShuffleManager tezRemoteShuffleManager =
           new TezRemoteShuffleManager(
-              appId.toString(), sessionToken, conf, appId.toString(), client);
+              appId.toString(), sessionToken, conf, appId.toString(), client, null);
       tezRemoteShuffleManager.initialize();
       tezRemoteShuffleManager.start();
 

--- a/pom.xml
+++ b/pom.xml
@@ -1979,6 +1979,12 @@
           </dependency>
           <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-common</artifactId>
             <version>${hadoop.version}</version>
           </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apply remote storage configuration.

### Why are the changes needed?

Reduce does not load remote storage path. If shuffle data have flushed to remote storage, reduce can not read. 

Fix: #1081

### How was this patch tested?

test in cluster.