### PR TITLE
fix: strictly verify whether app is registered especially after server restart

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -409,10 +409,15 @@ public class ShuffleTaskManager {
 
   public long requireBuffer(
       String appId, int shuffleId, List<Integer> partitionIds, int requireSize) {
-    ShuffleTaskInfo shuffleTaskInfo = shuffleTaskInfos.get(appId);
-    if (null == shuffleTaskInfo) {
+    // Once the shuffle server is restarted, the following shuffleTaskInfo may exist as
+    // a result of the refreshAppId() method being invoked during the process of sending/getting data
+    // from the client side. However, it is essential for the app's buffer pool to exist once it has been registered.
+    // This can serve as a crucial criterion for determining whether the app is not registered,
+    // especially following a server restart.
+    if (null == shuffleTaskInfos.get(appId) || !shuffleBufferManager.containsBufferByApp(appId)) {
       return RequireBufferStatusCode.NO_REGISTER.statusCode();
     }
+
     for (int partitionId : partitionIds) {
       long partitionUsedDataSize = getPartitionDataSize(appId, shuffleId, partitionId);
       if (shuffleBufferManager.limitHugePartition(

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -654,4 +654,8 @@ public class ShuffleBufferManager {
     }
     return false;
   }
+
+  public boolean containsBufferByApp(String appId) {
+    return bufferPool.containsKey(appId);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

After merging #1058 , I found the appId existence check is not enough. 

Once the shuffle server is restarted, the following shuffleTaskInfo may exist as
a result of the refreshAppId() method being invoked during the process of sending/getting data
from the client side. However, it is essential for the app's buffer pool to exist once it has been registered.
This can serve as a crucial criterion for determining whether the app is not registered,
 especially following a server restart.

### Why are the changes needed?

Follow up the PR #1058 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. Existing UTs
