### PR TITLE
[#825] feat(spark): Dynamic shuffle server assignment.

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -20,11 +20,14 @@ package org.apache.spark.shuffle.writer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.spark.TaskContext;
+
 import org.apache.uniffle.common.ShuffleBlockInfo;
 
 public class AddBlockEvent {
 
   private String taskId;
+  private TaskContext taskContext;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.ThreadUtils;
 
@@ -54,6 +56,7 @@ public class DataPusher implements Closeable {
   private final Map<String, Set<Long>> taskToSuccessBlockIds;
   // Must be thread safe
   private final Map<String, Set<Long>> taskToFailedBlockIds;
+  private final Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer;
   private String rssAppId;
   // Must be thread safe
   private final Set<String> failedTaskIds;
@@ -62,12 +65,14 @@ public class DataPusher implements Closeable {
       ShuffleWriteClient shuffleWriteClient,
       Map<String, Set<Long>> taskToSuccessBlockIds,
       Map<String, Set<Long>> taskToFailedBlockIds,
+      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
       Set<String> failedTaskIds,
       int threadPoolSize,
       int threadKeepAliveTime) {
     this.shuffleWriteClient = shuffleWriteClient;
     this.taskToSuccessBlockIds = taskToSuccessBlockIds;
     this.taskToFailedBlockIds = taskToFailedBlockIds;
+    this.taskToFailedBlockIdsAndServer = taskToFailedBlockIdsAndServer;
     this.failedTaskIds = failedTaskIds;
     this.executorService =
         new ThreadPoolExecutor(
@@ -93,6 +98,7 @@ public class DataPusher implements Closeable {
                     rssAppId, shuffleBlockInfoList, () -> !isValidTask(taskId));
             putBlockId(taskToSuccessBlockIds, taskId, result.getSuccessBlockIds());
             putBlockId(taskToFailedBlockIds, taskId, result.getFailedBlockIds());
+            putBlockIdAndShuffle(taskToFailedBlockIdsAndServer, taskId, result.getSendFailedBlockIds());
           } finally {
             List<Runnable> callbackChain =
                 Optional.of(event.getProcessedCallbackChain()).orElse(Collections.EMPTY_LIST);
@@ -116,6 +122,17 @@ public class DataPusher implements Closeable {
     taskToBlockIds
         .computeIfAbsent(taskAttemptId, x -> Sets.newConcurrentHashSet())
         .addAll(blockIds);
+  }
+
+  private synchronized void putBlockIdAndShuffle(
+      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
+      String taskAttemptId,
+      Map<Long, List<ShuffleServerInfo>> blockIdsAndServer) {
+    if (blockIdsAndServer == null || blockIdsAndServer.isEmpty()) {
+      return;
+    }
+    taskToFailedBlockIdsAndServer.computeIfAbsent(taskAttemptId,
+        x -> Maps.newConcurrentMap()).putAll(blockIdsAndServer);
   }
 
   public boolean isValidTask(String taskId) {

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.shuffle.manager;
 
 import org.apache.spark.SparkException;
+import org.apache.spark.shuffle.ShuffleHandleInfo;
 
 /**
  * This is a proxy interface that mainly delegates the un-registration of shuffles to the
@@ -54,4 +55,19 @@ public interface RssShuffleManagerInterface {
    * @throws SparkException
    */
   void unregisterAllMapOutput(int shuffleId) throws SparkException;
+
+  /**
+   * Add the shuffleServer that failed to write to the failure list
+   * @param shuffleServerId
+   */
+  void addFailuresShuffleServerInfos(String shuffleServerId);
+
+  /**
+   * Get ShuffleHandleInfo with ShuffleId
+   * @param shuffleId
+   * @return ShuffleHandleInfo
+   */
+  ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId);
+
+  boolean reShuffleAssignments(int stageId,int stageAttemptNumber,int shuffleId, int numMaps);
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -17,15 +17,21 @@
 
 package org.apache.uniffle.shuffle.manager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 
+import com.google.common.collect.Maps;
 import io.grpc.stub.StreamObserver;
+import org.apache.spark.shuffle.ShuffleHandleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.proto.ShuffleManagerGrpc.ShuffleManagerImplBase;
@@ -33,11 +39,72 @@ import org.apache.uniffle.proto.ShuffleManagerGrpc.ShuffleManagerImplBase;
 public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleManagerGrpcService.class);
   private final Map<Integer, RssShuffleStatus> shuffleStatus = JavaUtils.newConcurrentMap();
+  // The shuffleId mapping records the number of ShuffleServer write failures
+  private final Map<Integer, ShuffleServerFailureRecord> shuffleWrtieStatus = JavaUtils.newConcurrentMap();
   private final RssShuffleManagerInterface shuffleManager;
 
   public ShuffleManagerGrpcService(RssShuffleManagerInterface shuffleManager) {
     this.shuffleManager = shuffleManager;
   }
+
+  @Override
+  public void reportShuffleWriteFailure(RssProtos.ReportShuffleWriteFailureRequest request,
+                                        StreamObserver<RssProtos.ReportShuffleWriteFailureResponse> responseObserver) {
+    String appId = request.getAppId();
+    int shuffleId = request.getShuffleId();
+    int stageAttemptNumber = request.getStageAttemptNumber();
+    List<RssProtos.ShuffleServerId> shuffleServerIdsList = request.getShuffleServerIdsList();
+    RssProtos.StatusCode code;
+    boolean reSubmitWholeStage;
+    String msg;
+    if (!appId.equals(shuffleManager.getAppId())) {
+      msg = String.format("got a wrong shuffle write failure report from appId: %s, expected appId: %s",
+          appId, shuffleManager.getAppId());
+      LOG.warn(msg);
+      code = RssProtos.StatusCode.INVALID_REQUEST;
+      reSubmitWholeStage = false;
+    } else {
+      Map<String,Integer> shuffleServerInfoIntegerMap = Maps.newConcurrentMap();
+      List<ShuffleServerInfo> shuffleServerInfos = ShuffleServerInfo.fromProto(shuffleServerIdsList);
+      shuffleServerInfos.forEach(shuffleServerInfo -> {
+        shuffleServerInfoIntegerMap.put(shuffleServerInfo.getId(), 0);
+      });
+      ShuffleServerFailureRecord shuffleServerFailureRecord = shuffleWrtieStatus.computeIfAbsent(shuffleId,
+          key -> new ShuffleServerFailureRecord(shuffleServerInfoIntegerMap, stageAttemptNumber)
+      );
+      int c = shuffleServerFailureRecord.resetStageAttemptIfNecessary(stageAttemptNumber);
+      if (c < 0) {
+        msg = String.format("got an old stage(%d vs %d) shuffle write failure report, which should be impossible.",
+            shuffleServerFailureRecord.getStageAttempt(), stageAttemptNumber);
+        LOG.warn(msg);
+        code = RssProtos.StatusCode.INVALID_REQUEST;
+        reSubmitWholeStage = false;
+      } else {
+        code = RssProtos.StatusCode.SUCCESS;
+        // update the stage shuffleServer write failed count
+        boolean fetchFailureflag = shuffleServerFailureRecord
+            .incPartitionWriteFailure(stageAttemptNumber, shuffleServerInfos, shuffleManager);
+        if (fetchFailureflag) {
+          reSubmitWholeStage = true;
+          msg = String.format("report shuffle write failure as maximum number(%d) of shuffle write is occurred",
+              shuffleManager.getMaxFetchFailures());
+        } else {
+          reSubmitWholeStage = false;
+          msg = "don't report shuffle write failure";
+        }
+      }
+    }
+
+    RssProtos.ReportShuffleWriteFailureResponse reply = RssProtos.ReportShuffleWriteFailureResponse
+        .newBuilder()
+        .setStatus(code)
+        .setReSubmitWholeStage(reSubmitWholeStage)
+        .setMsg(msg)
+        .build();
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+
 
   @Override
   public void reportShuffleFetchFailure(
@@ -101,6 +168,59 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
     responseObserver.onCompleted();
   }
 
+  @Override
+  public void getPartitionToShufflerServer(RssProtos.PartitionToShuffleServerRequest request,
+                                           StreamObserver<RssProtos.PartitionToShuffleServerResponse> responseObserver) {
+    RssProtos.PartitionToShuffleServerResponse reply;
+    RssProtos.StatusCode code;
+    int shuffleId = request.getShuffleId();
+    ShuffleHandleInfo shuffleHandleInfoByShuffleId = shuffleManager.getShuffleHandleInfoByShuffleId(shuffleId);
+    if (shuffleHandleInfoByShuffleId != null) {
+      code = RssProtos.StatusCode.SUCCESS;
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers = shuffleHandleInfoByShuffleId.getPartitionToServers();
+      Map<Integer, RssProtos.GetShuffleServerListResponse> protopartitionToServers  = Maps.newConcurrentMap();
+      for (Map.Entry<Integer, List<ShuffleServerInfo>> integerListEntry : partitionToServers.entrySet()) {
+        List<RssProtos.ShuffleServerId> shuffleServerIds = ShuffleServerInfo.toProto(integerListEntry.getValue());
+        RssProtos.GetShuffleServerListResponse getShuffleServerListResponse =
+            RssProtos.GetShuffleServerListResponse.newBuilder().addAllServers(shuffleServerIds).build();
+        protopartitionToServers.put(integerListEntry.getKey(),getShuffleServerListResponse);
+      }
+      reply = RssProtos.PartitionToShuffleServerResponse
+          .newBuilder()
+          .setStatus(code)
+          .putAllPartitionToShuffleServer(protopartitionToServers)
+          .build();
+    } else {
+      code = RssProtos.StatusCode.INVALID_REQUEST;
+      reply = RssProtos.PartitionToShuffleServerResponse
+          .newBuilder()
+          .setStatus(code)
+          .putAllPartitionToShuffleServer(null)
+          .build();
+    }
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void reallocationShuffleServers(RssProtos.ReallocationServersRequest request,
+                                         StreamObserver<RssProtos.ReallocationServersReponse> responseObserver) {
+    int stageId = request.getStageId();
+    int stageAttemptNumber = request.getStageAttemptNumber();
+    int shuffleId = request.getShuffleId();
+    int numPartitions = request.getNumPartitions();
+    boolean reallocationFlag = shuffleManager
+        .reShuffleAssignments(stageId, stageAttemptNumber, shuffleId, numPartitions);
+    RssProtos.StatusCode code = RssProtos.StatusCode.SUCCESS;
+    RssProtos.ReallocationServersReponse reply = RssProtos.ReallocationServersReponse
+        .newBuilder()
+        .setStatus(code)
+        .setReallocationFlag(reallocationFlag)
+        .build();
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+
   /**
    * Remove the no longer used shuffle id's rss shuffle status. This is called when ShuffleManager
    * unregisters the corresponding shuffle id.
@@ -109,6 +229,81 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
    */
   public void unregisterShuffle(int shuffleId) {
     shuffleStatus.remove(shuffleId);
+  }
+
+  private static class ShuffleServerFailureRecord {
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+    private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+    private final Map<String, Integer> shuffleServerFailureRecordCount;
+    private int stageAttemptNumber;
+
+    private ShuffleServerFailureRecord(Map<String, Integer> shuffleServerFailureRecordCount,
+                                       int stageAttemptNumber) {
+      this.shuffleServerFailureRecordCount = shuffleServerFailureRecordCount;
+      this.stageAttemptNumber = stageAttemptNumber;
+    }
+
+    private <T> T withReadLock(Supplier<T> fn) {
+      readLock.lock();
+      try {
+        return fn.get();
+      } finally {
+        readLock.unlock();
+      }
+    }
+
+    private <T> T withWriteLock(Supplier<T> fn) {
+      writeLock.lock();
+      try {
+        return fn.get();
+      } finally {
+        writeLock.unlock();
+      }
+    }
+
+    public int getStageAttempt() {
+      return withReadLock(() -> this.stageAttemptNumber);
+    }
+
+    public int resetStageAttemptIfNecessary(int stageAttemptNumber) {
+      return withWriteLock(() -> {
+        if (this.stageAttemptNumber < stageAttemptNumber) {
+          // a new stage attempt is issued. Record the shuffleServer status of the Map should be clear and reset.
+          shuffleServerFailureRecordCount.clear();
+          this.stageAttemptNumber = stageAttemptNumber;
+          return 1;
+        } else if (this.stageAttemptNumber > stageAttemptNumber) {
+          return -1;
+        }
+        return 0;
+      });
+    }
+
+    public boolean incPartitionWriteFailure(int stageAttemptNumber,
+                                            List<ShuffleServerInfo> shuffleServerInfos,
+                                            RssShuffleManagerInterface shuffleManager) {
+      return withWriteLock(() -> {
+        if (this.stageAttemptNumber != stageAttemptNumber) {
+          // do nothing here
+          return false;
+        } else {
+          shuffleServerInfos.forEach(shuffleServerInfo -> {
+            Integer errCnt = shuffleServerFailureRecordCount.get(shuffleServerInfo.getId()) + 1;
+            shuffleServerFailureRecordCount.put(shuffleServerInfo.getId(),errCnt);
+          });
+          List<Map.Entry<String,Integer>> list = new ArrayList(shuffleServerFailureRecordCount.entrySet());
+          Collections.sort(list, (o1, o2) -> (o1.getValue() - o2.getValue()));
+          Map.Entry<String, Integer> shuffleServerInfoIntegerEntry = list.get(0);
+          if (shuffleServerInfoIntegerEntry.getValue() > shuffleManager.getMaxFetchFailures()) {
+            shuffleManager.addFailuresShuffleServerInfos(shuffleServerInfoIntegerEntry.getKey());
+            return true;
+          } else {
+            return false;
+          }
+        }
+      });
+    }
   }
 
   private static class RssShuffleStatus {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,11 +94,12 @@ public class DataPusherTest {
 
     Map<String, Set<Long>> taskToSuccessBlockIds = Maps.newConcurrentMap();
     Map<String, Set<Long>> taskToFailedBlockIds = Maps.newConcurrentMap();
+    Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer = Maps.newConcurrentMap();
     Set<String> failedTaskIds = new HashSet<>();
 
     DataPusher dataPusher =
         new DataPusher(
-            shuffleWriteClient, taskToSuccessBlockIds, taskToFailedBlockIds, failedTaskIds, 1, 2);
+            shuffleWriteClient, taskToSuccessBlockIds, taskToFailedBlockIds,taskToFailedBlockIdsAndServer, failedTaskIds, 1, 2);
     dataPusher.setRssAppId("testSendData_appId");
 
     // sync send
@@ -106,7 +108,7 @@ public class DataPusherTest {
             "taskId",
             Arrays.asList(new ShuffleBlockInfo(1, 1, 1, 1, 1, new byte[1], null, 1, 100, 1)));
     shuffleWriteClient.setFakedShuffleDataResult(
-        new SendShuffleDataResult(Sets.newHashSet(1L, 2L), Sets.newHashSet(3L, 4L)));
+        new SendShuffleDataResult(Sets.newHashSet(1L, 2L), Sets.newHashSet(3L, 4L),Maps.newConcurrentMap()));
     CompletableFuture<Long> future = dataPusher.send(event);
     long memoryFree = future.get();
     assertEquals(100, memoryFree);

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
@@ -20,6 +20,8 @@ package org.apache.uniffle.shuffle.manager;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.spark.shuffle.ShuffleHandleInfo;
+
 public class DummyRssShuffleManager implements RssShuffleManagerInterface {
   public Set<Integer> unregisteredShuffleIds = new LinkedHashSet<>();
 
@@ -46,5 +48,20 @@ public class DummyRssShuffleManager implements RssShuffleManagerInterface {
   @Override
   public void unregisterAllMapOutput(int shuffleId) {
     unregisteredShuffleIds.add(shuffleId);
+  }
+
+  @Override
+  public void addFailuresShuffleServerInfos(String shuffleServerId) {
+
+  }
+
+  @Override
+  public ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId) {
+    return null;
+  }
+
+  @Override
+  public boolean reShuffleAssignments(int stageId, int stageAttemptNumber, int shuffleId, int numMaps) {
+    return false;
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle.reader;
 
 import java.util.List;
+import java.util.Map;
 
 import scala.Function0;
 import scala.Option;
@@ -84,7 +85,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       int partitionNum,
       Roaring64NavigableMap blockIdBitmap,
       Roaring64NavigableMap taskIdBitmap,
-      RssConf rssConf) {
+      RssConf rssConf,
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers) {
     this.appId = rssShuffleHandle.getAppId();
     this.startPartition = startPartition;
     this.endPartition = endPartition;
@@ -100,7 +102,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     this.taskIdBitmap = taskIdBitmap;
     this.hadoopConf = hadoopConf;
     this.shuffleServerInfoList =
-        (List<ShuffleServerInfo>) (rssShuffleHandle.getPartitionToServers().get(startPartition));
+        (List<ShuffleServerInfo>) (partitionToServers.get(startPartition));
     this.rssConf = rssConf;
     expectedTaskIdsBitmapFilterEnable = shuffleServerInfoList.size() > 1;
   }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -98,7 +98,7 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 10,
                 blockIdBitmap,
                 taskIdBitmap,
-                rssConf));
+                rssConf,null));
 
     validateResult(rssShuffleReaderSpy.read(), expectedData, 10);
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -96,7 +96,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       Roaring64NavigableMap taskIdBitmap,
       ShuffleReadMetrics readMetrics,
       RssConf rssConf,
-      ShuffleDataDistributionType dataDistributionType) {
+      ShuffleDataDistributionType dataDistributionType,
+      Map<Integer, List<ShuffleServerInfo>> allPartitionToServers) {
     this.appId = rssShuffleHandle.getAppId();
     this.startPartition = startPartition;
     this.endPartition = endPartition;
@@ -114,7 +115,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     this.taskIdBitmap = taskIdBitmap;
     this.hadoopConf = hadoopConf;
     this.readMetrics = readMetrics;
-    this.partitionToShuffleServers = rssShuffleHandle.getPartitionToServers();
+    this.partitionToShuffleServers = allPartitionToServers;
     this.rssConf = rssConf;
     this.dataDistributionType = dataDistributionType;
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -30,7 +30,18 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.apache.spark.shuffle.FetchFailedException;
+import org.apache.spark.shuffle.RssSparkShuffleUtils;
+import org.apache.spark.shuffle.ShuffleHandleInfo;
+import org.apache.uniffle.client.api.ShuffleManagerClient;
+import org.apache.uniffle.client.request.RssReallocationServersRequest;
+import org.apache.uniffle.client.request.RssReportShuffleWriteFailureRequest;
+import org.apache.uniffle.client.response.RssReallocationServersReponse;
+import org.apache.uniffle.client.response.RssReportShuffleWriteFailureResponse;
+import org.apache.uniffle.common.exception.RssSendFailedException;
+import org.apache.uniffle.common.exception.RssWaitFailedException;
 import scala.Function1;
 import scala.Option;
 import scala.Product2;
@@ -87,6 +98,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private final boolean isMemoryShuffleEnabled;
   private final Function<String, Boolean> taskFailureCallback;
   private final Set<Long> blockIds = Sets.newConcurrentHashSet();
+  private TaskContext taskContext;
+  private ShuffleManagerClient shuffleManagerClient;
 
   /** used by columnar rss shuffle writer implementation */
   protected final long taskAttemptId;
@@ -105,7 +118,10 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       RssShuffleManager shuffleManager,
       SparkConf sparkConf,
       ShuffleWriteClient shuffleWriteClient,
-      RssShuffleHandle<K, V, C> rssHandle) {
+      RssShuffleHandle<K, V, C> rssHandle,
+      ShuffleHandleInfo shuffleHandleInfo,
+      TaskContext context,
+      ShuffleManagerClient shuffleManagerClient) {
     this(
         appId,
         shuffleId,
@@ -116,7 +132,10 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         sparkConf,
         shuffleWriteClient,
         rssHandle,
-        (tid) -> true);
+        (tid) -> true,
+        shuffleHandleInfo,
+        context,
+        shuffleManagerClient);
     this.bufferManager = bufferManager;
   }
 
@@ -130,7 +149,10 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       SparkConf sparkConf,
       ShuffleWriteClient shuffleWriteClient,
       RssShuffleHandle<K, V, C> rssHandle,
-      Function<String, Boolean> taskFailureCallback) {
+      Function<String, Boolean> taskFailureCallback,
+      ShuffleHandleInfo shuffleHandleInfo,
+      TaskContext context,
+      ShuffleManagerClient shuffleManagerClient) {
     LOG.warn("RssShuffle start write taskAttemptId data" + taskAttemptId);
     this.shuffleManager = shuffleManager;
     this.appId = appId;
@@ -147,13 +169,15 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     this.bitmapSplitNum = sparkConf.get(RssSparkConfig.RSS_CLIENT_BITMAP_SPLIT_NUM);
     this.partitionToBlockIds = Maps.newHashMap();
     this.shuffleWriteClient = shuffleWriteClient;
-    this.shuffleServersForData = rssHandle.getShuffleServersForData();
+    this.shuffleServersForData = shuffleHandleInfo.getShuffleServersForData();
     this.partitionLengths = new long[partitioner.numPartitions()];
     Arrays.fill(partitionLengths, 0);
-    partitionToServers = rssHandle.getPartitionToServers();
+    partitionToServers = shuffleHandleInfo.getPartitionToServers();
     this.isMemoryShuffleEnabled =
         isMemoryShuffleEnabled(sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key()));
     this.taskFailureCallback = taskFailureCallback;
+    this.taskContext = context;
+    this.shuffleManagerClient = shuffleManagerClient;
   }
 
   public RssShuffleWriter(
@@ -167,7 +191,9 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       ShuffleWriteClient shuffleWriteClient,
       RssShuffleHandle<K, V, C> rssHandle,
       Function<String, Boolean> taskFailureCallback,
-      TaskContext context) {
+      TaskContext context,
+      ShuffleHandleInfo shuffleHandleInfo,
+      ShuffleManagerClient shuffleManagerClient) {
     this(
         appId,
         shuffleId,
@@ -178,7 +204,10 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         sparkConf,
         shuffleWriteClient,
         rssHandle,
-        taskFailureCallback);
+        taskFailureCallback,
+        shuffleHandleInfo,
+        context,
+        shuffleManagerClient);
     BufferManagerOptions bufferOptions = new BufferManagerOptions(sparkConf);
     final WriteBufferManager bufferManager =
         new WriteBufferManager(
@@ -187,7 +216,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             taskAttemptId,
             bufferOptions,
             rssHandle.getDependency().serializer(),
-            rssHandle.getPartitionToServers(),
+            shuffleHandleInfo.getPartitionToServers(),
             context.taskMemoryManager(),
             shuffleWriteMetrics,
             RssSparkConfig.toRssConf(sparkConf),
@@ -205,7 +234,11 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       writeImpl(records);
     } catch (Exception e) {
       taskFailureCallback.apply(taskId);
-      throw e;
+      if (shuffleManager.isRssResubmitStage()) {
+        throw generateFetchFailedIfNecessary(e);
+      } else {
+        throw e;
+      }
     }
   }
 
@@ -320,7 +353,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                 + sendCheckTimeout
                 + " ms.";
         LOG.error(errorMsg);
-        throw new RssException(errorMsg);
+        throw new RssWaitFailedException(errorMsg);
       }
     }
   }
@@ -336,7 +369,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
               + failedBlockIds.size()
               + " blocks can't be sent to shuffle server.";
       LOG.error(errorMsg);
-      throw new RssException(errorMsg);
+      throw new RssSendFailedException(errorMsg);
     }
   }
 
@@ -429,5 +462,35 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   @VisibleForTesting
   public WriteBufferManager getBufferManager() {
     return bufferManager;
+  }
+
+
+  private RssException generateFetchFailedIfNecessary(Exception e) {
+    // The shuffleServer is registered only when a Block fails to be sent
+    if (e instanceof RssSendFailedException) {
+      Map<Long, List<ShuffleServerInfo>> failedBlockIds = shuffleManager.getFailedBlockIdsWithShuffleServer(taskId);
+      List<ShuffleServerInfo> shuffleServerInfos = Lists.newArrayList();
+      for (Map.Entry<Long, List<ShuffleServerInfo>> longListEntry : failedBlockIds.entrySet()) {
+        shuffleServerInfos.addAll(longListEntry.getValue());
+      }
+      LOG.info("发送了一场了吗？app:{},shuffle:{},attemptId:{},stageAttemptNumber:{},shuffleServers:{}",appId,shuffleId,taskContext.stageId(),taskContext.stageAttemptNumber(),
+          Arrays.asList(shuffleServerInfos.stream().map(a->a.getId()).collect(Collectors.toList())));
+      RssReportShuffleWriteFailureRequest req = new RssReportShuffleWriteFailureRequest(
+          appId, shuffleId, taskContext.stageAttemptNumber(), shuffleServerInfos, e.getMessage());
+      RssReportShuffleWriteFailureResponse response = shuffleManagerClient.reportShuffleWriteFailure(req);
+      if (response.getReSubmitWholeStage()) {
+        RssReallocationServersRequest rssReallocationServersRequest
+            = new RssReallocationServersRequest(taskContext.stageId(),
+            taskContext.stageAttemptNumber(), shuffleId, partitioner.numPartitions());
+        RssReallocationServersReponse rssReallocationServersReponse
+            = shuffleManagerClient.reallocationShuffleServers(rssReallocationServersRequest);
+        LOG.info("Whether the reassignment is successful: {}", rssReallocationServersReponse.isReallocationFlag());
+        // since we are going to roll out the whole stage, mapIndex shouldn't matter, hence -1 is provided.
+        FetchFailedException ffe = RssSparkShuffleUtils.createFetchFailedException(shuffleId, -1,
+            taskContext.stageAttemptNumber(), e);
+        return new RssException(ffe);
+      }
+    }
+    return new RssException(e);
   }
 }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -17,12 +17,14 @@
 
 package org.apache.spark.shuffle;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.writer.DataPusher;
+import org.apache.uniffle.common.ShuffleServerInfo;
 
 public class TestUtils {
 
@@ -33,8 +35,9 @@ public class TestUtils {
       Boolean isDriver,
       DataPusher dataPusher,
       Map<String, Set<Long>> successBlockIds,
-      Map<String, Set<Long>> failBlockIds) {
-    return new RssShuffleManager(conf, isDriver, dataPusher, successBlockIds, failBlockIds);
+      Map<String, Set<Long>> failBlockIds,
+      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsWithShuffleServer) {
+    return new RssShuffleManager(conf, isDriver, dataPusher, successBlockIds, failBlockIds,taskToFailedBlockIdsWithShuffleServer);
   }
 
   public static boolean isMacOnAppleSilicon() {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -109,7 +109,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                null));
     validateResult(rssShuffleReaderSpy.read(), expectedData, 10);
 
     writeTestData(
@@ -131,7 +132,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                null));
     validateResult(rssShuffleReaderSpy1.read(), expectedData, 18);
 
     RssShuffleReader<String, String> rssShuffleReaderSpy2 =
@@ -150,7 +152,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 Roaring64NavigableMap.bitmapOf(),
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                null));
     validateResult(rssShuffleReaderSpy2.read(), Maps.newHashMap(), 0);
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -78,6 +78,16 @@ public interface ShuffleWriteClient {
       int assignmentShuffleServerNumber,
       int estimateTaskConcurrency);
 
+  ShuffleAssignmentsInfo getReShuffleAssignments(
+      String appId,
+      int shuffleId,
+      int partitionNum,
+      int partitionNumPerRange,
+      Set<String> requiredTags,
+      int assignmentShuffleServerNumber,
+      int estimateTaskConcurrency,
+      Set<String> failuresShuffleServerIds);
+
   Roaring64NavigableMap getShuffleResult(
       String clientType,
       Set<ShuffleServerInfo> shuffleServerInfoSet,

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -18,6 +18,10 @@
 package org.apache.uniffle.common;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.uniffle.proto.RssProtos;
 
 public class ShuffleServerInfo implements Serializable {
 
@@ -107,5 +111,38 @@ public class ShuffleServerInfo implements Serializable {
           + grpcPort
           + "]}";
     }
+  }
+
+  private static ShuffleServerInfo convertToShuffleServerId(
+      RssProtos.ShuffleServerId shuffleServerId) {
+    ShuffleServerInfo shuffleServerInfo =
+        new ShuffleServerInfo(
+            shuffleServerId.getId(), shuffleServerId.getIp(), shuffleServerId.getPort(), 0);
+    return shuffleServerInfo;
+  }
+
+  private static RssProtos.ShuffleServerId convertToShuffleServerId(
+      ShuffleServerInfo shuffleServerInfo) {
+    RssProtos.ShuffleServerId shuffleServerId =
+        RssProtos.ShuffleServerId.newBuilder()
+            .setId(shuffleServerInfo.getId())
+            .setIp(shuffleServerInfo.getHost())
+            .setPort(shuffleServerInfo.grpcPort)
+            .setNettyPort(shuffleServerInfo.nettyPort)
+            .build();
+    return shuffleServerId;
+  }
+
+  public static List<ShuffleServerInfo> fromProto(List<RssProtos.ShuffleServerId> servers) {
+    return servers.stream()
+        .map(server -> convertToShuffleServerId(server))
+        .collect(Collectors.toList());
+  }
+
+  public static List<RssProtos.ShuffleServerId> toProto(
+      List<ShuffleServerInfo> shuffleServerInfos) {
+    return shuffleServerInfos.stream()
+        .map(server -> convertToShuffleServerId(server))
+        .collect(Collectors.toList());
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.strategy.assignment;
+package org.apache.uniffle.common.exception;
 
-import java.util.Set;
+public class RssSendFailedException extends RuntimeException {
+  public RssSendFailedException(String message) {
+    super(message);
+  }
 
-public interface AssignmentStrategy {
+  public RssSendFailedException(Throwable e) {
+    super(e);
+  }
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency,
-      Set<String> serversList);
-
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency);
+  public RssSendFailedException(String message, Throwable e) {
+    super(message, e);
+  }
 }

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssWaitFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssWaitFailedException.java
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.strategy.assignment;
+package org.apache.uniffle.common.exception;
 
-import java.util.Set;
+public class RssWaitFailedException extends RuntimeException {
+  public RssWaitFailedException(String message) {
+    super(message);
+  }
 
-public interface AssignmentStrategy {
+  public RssWaitFailedException(Throwable e) {
+    super(e);
+  }
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency,
-      Set<String> serversList);
-
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency);
+  public RssWaitFailedException(String message, Throwable e) {
+    super(message, e);
+  }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -36,6 +36,15 @@ public interface ClusterManager extends Closeable, Reconfigurable {
    * Get available nodes from the cluster
    *
    * @param requiredTags tags for filter
+   * @param excludeServerNodes servernode information that is excluded because of an exception
+   * @return list of available server nodes
+   */
+  List<ServerNode> getServerList(Set<String> requiredTags, Set<String> excludeServerNodes);
+
+  /**
+   * Get available nodes from the cluster
+   *
+   * @param requiredTags tags for filter
    * @return list of available server nodes
    */
   List<ServerNode> getServerList(Set<String> requiredTags);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -17,8 +17,10 @@
 
 package org.apache.uniffle.coordinator;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
 
@@ -261,5 +263,23 @@ public class ServerNode implements Comparable<ServerNode> {
 
   public int getNettyPort() {
     return nettyPort;
+  }
+
+  private static ServerNode convertToServerNode(ShuffleServerId shuffleServerId) {
+    ServerNode serverNode =
+        new ServerNode(
+            shuffleServerId.getId(),
+            shuffleServerId.getIp(),
+            shuffleServerId.getPort(),
+            0L,
+            0L,
+            0L,
+            0,
+            null);
+    return serverNode;
+  }
+
+  public static List<ServerNode> fromProto(List<ShuffleServerId> servers) {
+    return servers.stream().map(server -> convertToServerNode(server)).collect(Collectors.toList());
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -241,6 +241,32 @@ public class SimpleClusterManager implements ClusterManager {
   }
 
   @Override
+  public List<ServerNode> getServerList(Set<String> requiredTags, Set<String> excludeServerNodes) {
+    List<ServerNode> availableNodes = Lists.newArrayList();
+    for (ServerNode node : servers.values()) {
+      if (!ServerStatus.ACTIVE.equals(node.getStatus())) {
+        continue;
+      }
+      // If the excludeServerNodes is null, the exclusion operation is not performed
+      if (excludeServerNodes != null) {
+        if (!excludeServerNodes.contains(node.getId())
+            && !excludeNodes.contains(node.getId())
+            && node.getTags().containsAll(requiredTags)
+            && ServerStatus.ACTIVE.equals(node.getStatus())) {
+          availableNodes.add(node);
+        }
+      } else {
+        if (!excludeNodes.contains(node.getId())
+            && node.getTags().containsAll(requiredTags)
+            && ServerStatus.ACTIVE.equals(node.getStatus())) {
+          availableNodes.add(node);
+        }
+      }
+    }
+    return availableNodes;
+  }
+
+  @Override
   public List<ServerNode> getServerList(Set<String> requiredTags) {
     List<ServerNode> availableNodes = Lists.newArrayList();
     for (ServerNode node : servers.values()) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -33,6 +33,7 @@ import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
 import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.apache.uniffle.server.MockedShuffleServer;
+import org.apache.uniffle.server.MockedWriteShuffleServer;
 import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.ShuffleServerMetrics;
@@ -139,6 +140,11 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
 
   protected static void createShuffleServer(ShuffleServerConf serverConf) throws Exception {
     shuffleServers.add(new ShuffleServer(serverConf));
+  }
+
+  protected static void createWriteMockedShuffleServer(ShuffleServerConf serverConf)
+      throws Exception {
+    shuffleServers.add(new MockedWriteShuffleServer(serverConf));
   }
 
   protected static void createMockedShuffleServer(ShuffleServerConf serverConf) throws Exception {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.test;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mortbay.log.Log;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
@@ -1032,6 +1034,10 @@ public class QuorumTest extends ShuffleReadWriteBase {
                   shuffleServerInfo3,
                   shuffleServerInfo4));
       SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+      Log.info(
+          "SendShuffleDataResult:{}---{}",
+          Arrays.asList(result.getSuccessBlockIds().toArray()),
+          Arrays.asList(result.getFailedBlockIds().toArray()));
       assertTrue(result.getSuccessBlockIds().size() == 3);
       assertTrue(result.getFailedBlockIds().size() == 0);
     }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageDynamicServerReWriteTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageDynamicServerReWriteTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.test;
+
+import com.google.common.collect.Maps;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssSparkConfig;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.storage.util.StorageType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+public class RSSStageDynamicServerReWriteTest extends SparkIntegrationTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RSSStageDynamicServerReWriteTest.class);
+
+  private static int maxTaskFailures = 3;
+
+  @BeforeAll
+  public static void setupServers(@TempDir File tmpDir) throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    Map<String, String> dynamicConf = Maps.newHashMap();
+    dynamicConf.put(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key(), HDFS_URI + "rss/test");
+    dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
+    addDynamicConf(coordinatorConf, dynamicConf);
+    createCoordinatorServer(coordinatorConf);
+    createServer(0, tmpDir,true);
+    createServer(1, tmpDir, false);
+    createServer(2, tmpDir,false);
+    startServers();
+  }
+
+  public static void createServer(int id, File tmpDir , boolean abnormalFlag) throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 8000);
+    shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
+    File dataDir1 = new File(tmpDir, id + "_1");
+    File dataDir2 = new File(tmpDir, id + "_2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE.name());
+    shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + id);
+    shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
+    shuffleServerConf.setString("rss.storage.basePath", basePath);
+    if(abnormalFlag) {
+      createWriteMockedShuffleServer(shuffleServerConf);
+    } else {
+      createShuffleServer(shuffleServerConf);
+    }
+  }
+
+
+  @Override
+  public Map runTest(SparkSession spark, String fileName) throws Exception {
+    List<Row> rows = spark.range(0, 1000, 1, 4)
+        .repartition(2).groupBy("id").count()
+        .collectAsList();
+    Map<String, Long> result = Maps.newHashMap();
+    for (Row row: rows) {
+      result.put(row.get(0).toString(), row.getLong(1));
+    }
+    return result;
+  }
+
+  @Override
+  protected SparkConf createSparkConf() {
+    return new SparkConf()
+        .setAppName(this.getClass().getSimpleName())
+        .setMaster(String.format("local[4,%d]", maxTaskFailures));
+  }
+
+  @Override
+  public void updateSparkConfCustomer(SparkConf sparkConf) {
+    sparkConf.set(RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_RESUBMIT_STAGE, "true");
+    sparkConf.set("spark.task.maxFailures", String.valueOf(maxTaskFailures));
+  }
+
+  @Test
+  public void testRSSStageResubmit() throws Exception {
+    run();
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/CoordinatorClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/CoordinatorClient.java
@@ -22,6 +22,7 @@ import org.apache.uniffle.client.request.RssAppHeartBeatRequest;
 import org.apache.uniffle.client.request.RssApplicationInfoRequest;
 import org.apache.uniffle.client.request.RssFetchClientConfRequest;
 import org.apache.uniffle.client.request.RssFetchRemoteStorageRequest;
+import org.apache.uniffle.client.request.RssGetReShuffleAssignmentsRequest;
 import org.apache.uniffle.client.request.RssGetShuffleAssignmentsRequest;
 import org.apache.uniffle.client.request.RssSendHeartBeatRequest;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
@@ -41,6 +42,9 @@ public interface CoordinatorClient {
   RssSendHeartBeatResponse sendHeartBeat(RssSendHeartBeatRequest request);
 
   RssGetShuffleAssignmentsResponse getShuffleAssignments(RssGetShuffleAssignmentsRequest request);
+
+  RssGetShuffleAssignmentsResponse getReShuffleAssignments(
+      RssGetReShuffleAssignmentsRequest request);
 
   RssAccessClusterResponse accessCluster(RssAccessClusterRequest request);
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
@@ -19,10 +19,24 @@ package org.apache.uniffle.client.api;
 
 import java.io.Closeable;
 
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.request.RssReallocationServersRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
+import org.apache.uniffle.client.request.RssReportShuffleWriteFailureRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
+import org.apache.uniffle.client.response.RssReallocationServersReponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
+import org.apache.uniffle.client.response.RssReportShuffleWriteFailureResponse;
 
 public interface ShuffleManagerClient extends Closeable {
   RssReportShuffleFetchFailureResponse reportShuffleFetchFailure(
       RssReportShuffleFetchFailureRequest request);
+
+  RssReportShuffleWriteFailureResponse reportShuffleWriteFailure(
+      RssReportShuffleWriteFailureRequest req);
+
+  RssPartitionToShuffleServerResponse getPartitionToShufflerServer(
+      RssPartitionToShuffleServerRequest req);
+
+  RssReallocationServersReponse reallocationShuffleServers(RssReallocationServersRequest req);
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
@@ -38,6 +38,7 @@ import org.apache.uniffle.client.request.RssAppHeartBeatRequest;
 import org.apache.uniffle.client.request.RssApplicationInfoRequest;
 import org.apache.uniffle.client.request.RssFetchClientConfRequest;
 import org.apache.uniffle.client.request.RssFetchRemoteStorageRequest;
+import org.apache.uniffle.client.request.RssGetReShuffleAssignmentsRequest;
 import org.apache.uniffle.client.request.RssGetShuffleAssignmentsRequest;
 import org.apache.uniffle.client.request.RssSendHeartBeatRequest;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
@@ -188,6 +189,33 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
     return blockingStub.getShuffleAssignments(getServerRequest);
   }
 
+  public RssProtos.GetShuffleAssignmentsResponse doGetReShuffleAssignments(
+      String appId,
+      int shuffleId,
+      int numMaps,
+      int partitionNumPerRange,
+      int dataReplica,
+      Set<String> requiredTags,
+      int assignmentShuffleServerNumber,
+      int estimateTaskConcurrency,
+      Set<String> shuffleServerInfos) {
+
+    RssProtos.GetReShuffleServerRequest getServerRequest =
+        RssProtos.GetReShuffleServerRequest.newBuilder()
+            .setApplicationId(appId)
+            .setShuffleId(shuffleId)
+            .setPartitionNum(numMaps)
+            .setPartitionNumPerRange(partitionNumPerRange)
+            .setDataReplica(dataReplica)
+            .addAllRequireTags(requiredTags)
+            .setAssignmentShuffleServerNumber(assignmentShuffleServerNumber)
+            .setEstimateTaskConcurrency(estimateTaskConcurrency)
+            .addAllShuffleServerIds(shuffleServerInfos)
+            .build();
+
+    return blockingStub.getReShuffleAssignments(getServerRequest);
+  }
+
   @Override
   public RssSendHeartBeatResponse sendHeartBeat(RssSendHeartBeatRequest request) {
     ShuffleServerHeartBeatResponse rpcResponse =
@@ -276,6 +304,46 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
             request.getRequiredTags(),
             request.getAssignmentShuffleServerNumber(),
             request.getEstimateTaskConcurrency());
+
+    RssGetShuffleAssignmentsResponse response;
+    RssProtos.StatusCode statusCode = rpcResponse.getStatus();
+    switch (statusCode) {
+      case SUCCESS:
+        response = new RssGetShuffleAssignmentsResponse(StatusCode.SUCCESS);
+        // get all register info according to coordinator's response
+        Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges =
+            getServerToPartitionRanges(rpcResponse);
+        Map<Integer, List<ShuffleServerInfo>> partitionToServers =
+            getPartitionToServers(rpcResponse);
+        response.setServerToPartitionRanges(serverToPartitionRanges);
+        response.setPartitionToServers(partitionToServers);
+        break;
+      case TIMEOUT:
+        response = new RssGetShuffleAssignmentsResponse(StatusCode.TIMEOUT);
+        break;
+      default:
+        response =
+            new RssGetShuffleAssignmentsResponse(
+                StatusCode.INTERNAL_ERROR, rpcResponse.getRetMsg());
+    }
+
+    return response;
+  }
+
+  @Override
+  public RssGetShuffleAssignmentsResponse getReShuffleAssignments(
+      RssGetReShuffleAssignmentsRequest request) {
+    RssProtos.GetShuffleAssignmentsResponse rpcResponse =
+        doGetReShuffleAssignments(
+            request.getAppId(),
+            request.getShuffleId(),
+            request.getPartitionNum(),
+            request.getPartitionNumPerRange(),
+            request.getDataReplica(),
+            request.getRequiredTags(),
+            request.getAssignmentShuffleServerNumber(),
+            request.getEstimateTaskConcurrency(),
+            request.getShuffleServerIds());
 
     RssGetShuffleAssignmentsResponse response;
     RssProtos.StatusCode statusCode = rpcResponse.getStatus();

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -23,10 +23,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleManagerClient;
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.request.RssReallocationServersRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
+import org.apache.uniffle.client.request.RssReportShuffleWriteFailureRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
+import org.apache.uniffle.client.response.RssReallocationServersReponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
+import org.apache.uniffle.client.response.RssReportShuffleWriteFailureResponse;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureRequest;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureResponse;
 import org.apache.uniffle.proto.ShuffleManagerGrpc;
@@ -73,5 +80,40 @@ public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManag
       LOG.warn(msg, e);
       throw new RssException(msg, e);
     }
+  }
+
+  @Override
+  public RssReportShuffleWriteFailureResponse reportShuffleWriteFailure(
+      RssReportShuffleWriteFailureRequest request) {
+    RssProtos.ReportShuffleWriteFailureRequest protoRequest = request.toProto();
+    try {
+      RssProtos.ReportShuffleWriteFailureResponse response =
+          getBlockingStub().reportShuffleWriteFailure(protoRequest);
+      return RssReportShuffleWriteFailureResponse.fromProto(response);
+    } catch (Exception e) {
+      String msg = "Report shuffle fetch failure to host:port[" + host + ":" + port + "] failed";
+      LOG.warn(msg, e);
+      throw new RssException(msg, e);
+    }
+  }
+
+  @Override
+  public RssPartitionToShuffleServerResponse getPartitionToShufflerServer(
+      RssPartitionToShuffleServerRequest req) {
+    RssProtos.PartitionToShuffleServerRequest protoRequest = req.toProto();
+    RssProtos.PartitionToShuffleServerResponse partitionToShufflerServer =
+        getBlockingStub().getPartitionToShufflerServer(protoRequest);
+    RssPartitionToShuffleServerResponse rssPartitionToShuffleServerResponse =
+        RssPartitionToShuffleServerResponse.fromProto(partitionToShufflerServer);
+    return rssPartitionToShuffleServerResponse;
+  }
+
+  @Override
+  public RssReallocationServersReponse reallocationShuffleServers(
+      RssReallocationServersRequest req) {
+    RssProtos.ReallocationServersRequest reallocationServersRequest = req.toProto();
+    RssProtos.ReallocationServersReponse reallocationServersReponse =
+        getBlockingStub().reallocationShuffleServers(reallocationServersRequest);
+    return RssReallocationServersReponse.fromProto(reallocationServersReponse);
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetReShuffleAssignmentsRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetReShuffleAssignmentsRequest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.request;
+
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class RssGetReShuffleAssignmentsRequest {
+  private String appId;
+  private int shuffleId;
+  private int partitionNum;
+  private int partitionNumPerRange;
+  private int dataReplica;
+  private Set<String> requiredTags;
+  private int assignmentShuffleServerNumber;
+  private int estimateTaskConcurrency;
+  private Set<String> shuffleServerIds;
+
+  @VisibleForTesting
+  public RssGetReShuffleAssignmentsRequest(
+      String appId,
+      int shuffleId,
+      int partitionNum,
+      int partitionNumPerRange,
+      int dataReplica,
+      Set<String> requiredTags,
+      Set<String> shuffleServerIds) {
+    this(
+        appId,
+        shuffleId,
+        partitionNum,
+        partitionNumPerRange,
+        dataReplica,
+        requiredTags,
+        -1,
+        -1,
+        shuffleServerIds);
+  }
+
+  public RssGetReShuffleAssignmentsRequest(
+      String appId,
+      int shuffleId,
+      int partitionNum,
+      int partitionNumPerRange,
+      int dataReplica,
+      Set<String> requiredTags,
+      int assignmentShuffleServerNumber,
+      int estimateTaskConcurrency,
+      Set<String> shuffleServerIds) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+    this.partitionNum = partitionNum;
+    this.partitionNumPerRange = partitionNumPerRange;
+    this.dataReplica = dataReplica;
+    this.requiredTags = requiredTags;
+    this.assignmentShuffleServerNumber = assignmentShuffleServerNumber;
+    this.estimateTaskConcurrency = estimateTaskConcurrency;
+    this.shuffleServerIds = shuffleServerIds;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public int getPartitionNum() {
+    return partitionNum;
+  }
+
+  public int getPartitionNumPerRange() {
+    return partitionNumPerRange;
+  }
+
+  public int getDataReplica() {
+    return dataReplica;
+  }
+
+  public Set<String> getRequiredTags() {
+    return requiredTags;
+  }
+
+  public int getAssignmentShuffleServerNumber() {
+    return assignmentShuffleServerNumber;
+  }
+
+  public int getEstimateTaskConcurrency() {
+    return estimateTaskConcurrency;
+  }
+
+  public Set<String> getShuffleServerIds() {
+    return shuffleServerIds;
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssPartitionToShuffleServerRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssPartitionToShuffleServerRequest.java
@@ -15,26 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.strategy.assignment;
+package org.apache.uniffle.client.request;
 
-import java.util.Set;
+import org.apache.uniffle.proto.RssProtos;
 
-public interface AssignmentStrategy {
+public class RssPartitionToShuffleServerRequest {
+  private int shuffleId;
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency,
-      Set<String> serversList);
+  public RssPartitionToShuffleServerRequest(int shuffleId) {
+    this.shuffleId = shuffleId;
+  }
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency);
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public RssProtos.PartitionToShuffleServerRequest toProto() {
+    RssProtos.PartitionToShuffleServerRequest.Builder builder =
+        RssProtos.PartitionToShuffleServerRequest.newBuilder();
+    builder.setShuffleId(shuffleId);
+    return builder.build();
+  }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReallocationServersRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReallocationServersRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.request;
+
+import org.apache.uniffle.proto.RssProtos;
+
+public class RssReallocationServersRequest {
+  private int stageId;
+  private int stageAttemptNumber;
+  private int shuffleId;
+  private int numPartitions;
+
+  public RssReallocationServersRequest(
+      int stageId, int stageAttemptNumber, int shuffleId, int numPartitions) {
+    this.stageId = stageId;
+    this.stageAttemptNumber = stageAttemptNumber;
+    this.shuffleId = shuffleId;
+    this.numPartitions = numPartitions;
+  }
+
+  public RssProtos.ReallocationServersRequest toProto() {
+    RssProtos.ReallocationServersRequest.Builder builder =
+        RssProtos.ReallocationServersRequest.newBuilder()
+            .setStageId(stageId)
+            .setStageAttemptNumber(stageAttemptNumber)
+            .setShuffleId(shuffleId)
+            .setNumPartitions(numPartitions);
+    return builder.build();
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteFailureRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleWriteFailureRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.request;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.proto.RssProtos.ReportShuffleWriteFailureRequest;
+import org.apache.uniffle.proto.RssProtos.ShuffleServerId;
+
+public class RssReportShuffleWriteFailureRequest {
+  private String appId;
+  private int shuffleId;
+  private int stageAttemptNumber;
+  private List<ShuffleServerInfo> shuffleServerInfos;
+  private String exception;
+
+  public RssReportShuffleWriteFailureRequest(
+      String appId,
+      int shuffleId,
+      int stageAttemptNumber,
+      List<ShuffleServerInfo> shuffleServerInfos,
+      String exception) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+    this.stageAttemptNumber = stageAttemptNumber;
+    this.shuffleServerInfos = shuffleServerInfos;
+    this.exception = exception;
+  }
+
+  public ReportShuffleWriteFailureRequest toProto() {
+    List<ShuffleServerId> shuffleServerIds = Lists.newArrayList();
+    for (ShuffleServerInfo shuffleServerInfo : shuffleServerInfos) {
+      shuffleServerIds.add(
+          ShuffleServerId.newBuilder()
+              .setId(shuffleServerInfo.getId())
+              .setPort(shuffleServerInfo.getGrpcPort())
+              .setIp(shuffleServerInfo.getHost())
+              .build());
+    }
+    ReportShuffleWriteFailureRequest.Builder builder =
+        ReportShuffleWriteFailureRequest.newBuilder();
+    builder
+        .setAppId(appId)
+        .setShuffleId(shuffleId)
+        .setStageAttemptNumber(stageAttemptNumber)
+        .addAllShuffleServerIds(shuffleServerIds);
+    if (exception != null) {
+      builder.setException(exception);
+    }
+    return builder.build();
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssPartitionToShuffleServerResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssPartitionToShuffleServerResponse.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
+
+public class RssPartitionToShuffleServerResponse extends ClientResponse {
+
+  private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+  private Set<ShuffleServerInfo> shuffleServersForData;
+  private RemoteStorageInfo remoteStorageInfo;
+
+  public RssPartitionToShuffleServerResponse(
+      StatusCode statusCode,
+      String message,
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      Set<ShuffleServerInfo> shuffleServersForData,
+      RemoteStorageInfo remoteStorageInfo) {
+    super(statusCode, message);
+    this.partitionToServers = partitionToServers;
+    this.remoteStorageInfo = remoteStorageInfo;
+    this.shuffleServersForData = shuffleServersForData;
+  }
+
+  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+    return partitionToServers;
+  }
+
+  public Set<ShuffleServerInfo> getShuffleServersForData() {
+    return shuffleServersForData;
+  }
+
+  public RemoteStorageInfo getRemoteStorageInfo() {
+    return remoteStorageInfo;
+  }
+
+  public static RssPartitionToShuffleServerResponse fromProto(
+      RssProtos.PartitionToShuffleServerResponse response) {
+    Map<Integer, RssProtos.GetShuffleServerListResponse> partitionToShuffleServerMap =
+        response.getPartitionToShuffleServerMap();
+    Map<Integer, List<ShuffleServerInfo>> rpcPartitionToShuffleServerInfos = Maps.newHashMap();
+    Set<Map.Entry<Integer, RssProtos.GetShuffleServerListResponse>> entries =
+        partitionToShuffleServerMap.entrySet();
+    for (Map.Entry<Integer, RssProtos.GetShuffleServerListResponse> entry : entries) {
+      Integer partitionId = entry.getKey();
+      List<ShuffleServerInfo> shuffleServerInfos = Lists.newArrayList();
+      List<? extends RssProtos.ShuffleServerIdOrBuilder> serversOrBuilderList =
+          entry.getValue().getServersOrBuilderList();
+      for (RssProtos.ShuffleServerIdOrBuilder shuffleServerIdOrBuilder : serversOrBuilderList) {
+        shuffleServerInfos.add(
+            new ShuffleServerInfo(
+                shuffleServerIdOrBuilder.getId(),
+                shuffleServerIdOrBuilder.getIp(),
+                shuffleServerIdOrBuilder.getPort(),
+                shuffleServerIdOrBuilder.getNettyPort()));
+      }
+
+      rpcPartitionToShuffleServerInfos.put(partitionId, shuffleServerInfos);
+    }
+    Set<ShuffleServerInfo> rpcShuffleServersForData = Sets.newHashSet();
+    for (List<ShuffleServerInfo> ssis : rpcPartitionToShuffleServerInfos.values()) {
+      rpcShuffleServersForData.addAll(ssis);
+    }
+    RssProtos.RemoteStorageInfo protoRemoteStorageInfo = response.getRemoteStorageInfo();
+    RemoteStorageInfo rpcRemoteStorageInfo =
+        new RemoteStorageInfo(
+            protoRemoteStorageInfo.getPath(), protoRemoteStorageInfo.getConfItemsMap());
+    return new RssPartitionToShuffleServerResponse(
+        StatusCode.valueOf(response.getStatus().name()),
+        response.getMsg(),
+        rpcPartitionToShuffleServerInfos,
+        rpcShuffleServersForData,
+        rpcRemoteStorageInfo);
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssReallocationServersReponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssReallocationServersReponse.java
@@ -17,36 +17,29 @@
 
 package org.apache.uniffle.client.response;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
 
-import org.apache.uniffle.common.ShuffleServerInfo;
+public class RssReallocationServersReponse extends ClientResponse {
 
-public class SendShuffleDataResult {
+  private boolean reallocationFlag;
 
-  private Set<Long> successBlockIds;
-  private Set<Long> failedBlockIds;
-  private Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds;
-
-  public SendShuffleDataResult(
-      Set<Long> successBlockIds,
-      Set<Long> failedBlockIds,
-      Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds) {
-    this.successBlockIds = successBlockIds;
-    this.failedBlockIds = failedBlockIds;
-    this.sendFailedBlockIds = sendFailedBlockIds;
+  public RssReallocationServersReponse(
+      StatusCode statusCode, String message, boolean reallocationFlag) {
+    super(statusCode, message);
+    this.reallocationFlag = reallocationFlag;
   }
 
-  public Set<Long> getSuccessBlockIds() {
-    return successBlockIds;
+  public boolean isReallocationFlag() {
+    return reallocationFlag;
   }
 
-  public Set<Long> getFailedBlockIds() {
-    return failedBlockIds;
-  }
-
-  public Map<Long, List<ShuffleServerInfo>> getSendFailedBlockIds() {
-    return sendFailedBlockIds;
+  public static RssReallocationServersReponse fromProto(
+      RssProtos.ReallocationServersReponse response) {
+    return new RssReallocationServersReponse(
+        // todo: [issue#780] add fromProto for StatusCode issue
+        StatusCode.valueOf(response.getStatus().name()),
+        response.getMsg(),
+        response.getReallocationFlag());
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssReportShuffleWriteFailureResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssReportShuffleWriteFailureResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.response;
+
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos.ReportShuffleWriteFailureResponse;
+
+public class RssReportShuffleWriteFailureResponse extends ClientResponse {
+  private boolean reSubmitWholeStage;
+
+  public RssReportShuffleWriteFailureResponse(StatusCode code, String msg, boolean recomputeStage) {
+    super(code, msg);
+    this.reSubmitWholeStage = recomputeStage;
+  }
+
+  public boolean getReSubmitWholeStage() {
+    return this.reSubmitWholeStage;
+  }
+
+  public ReportShuffleWriteFailureResponse toProto() {
+    ReportShuffleWriteFailureResponse.Builder builder =
+        ReportShuffleWriteFailureResponse.newBuilder();
+    return builder
+        .setStatus(getStatusCode().toProto())
+        .setMsg(getMessage())
+        .setReSubmitWholeStage(reSubmitWholeStage)
+        .build();
+  }
+
+  public static RssReportShuffleWriteFailureResponse fromProto(
+      ReportShuffleWriteFailureResponse response) {
+    return new RssReportShuffleWriteFailureResponse(
+        // todo: [issue#780] add fromProto for StatusCode issue
+        StatusCode.valueOf(response.getStatus().name()),
+        response.getMsg(),
+        response.getReSubmitWholeStage());
+  }
+}

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -325,6 +325,8 @@ service CoordinatorServer {
 
   // Ask for suitable Shuffle Servers with partitions
   rpc getShuffleAssignments(GetShuffleServerRequest) returns (GetShuffleAssignmentsResponse);
+  // Assign a Shuffle server to the Partition
+  rpc getReShuffleAssignments(GetReShuffleServerRequest) returns (GetShuffleAssignmentsResponse);
 
   // Heartbeat between Shuffle Server and Coordinator Server
   rpc heartbeat(ShuffleServerHeartBeatRequest) returns (ShuffleServerHeartBeatResponse);
@@ -391,6 +393,21 @@ message GetShuffleServerRequest {
   repeated string requireTags = 9;
   int32 assignmentShuffleServerNumber = 10;
   int32 estimateTaskConcurrency = 11;
+}
+
+message GetReShuffleServerRequest {
+  string clientHost = 1;
+  string clientPort = 2;
+  string clientProperty = 3;
+  string applicationId = 4;
+  int32 shuffleId = 5;
+  int32 partitionNum = 6;
+  int32 partitionNumPerRange = 7;
+  int32 dataReplica = 8;
+  repeated string requireTags = 9;
+  int32 assignmentShuffleServerNumber = 10;
+  int32 estimateTaskConcurrency = 11;
+  repeated string shuffleServerIds = 12;
 }
 
 message PartitionRangeAssignment {
@@ -496,6 +513,9 @@ message CancelDecommissionResponse {
 // per application.
 service ShuffleManager {
   rpc reportShuffleFetchFailure (ReportShuffleFetchFailureRequest) returns (ReportShuffleFetchFailureResponse);
+  rpc reportShuffleWriteFailure (ReportShuffleWriteFailureRequest) returns (ReportShuffleWriteFailureResponse);
+  rpc getPartitionToShufflerServer(PartitionToShuffleServerRequest) returns (PartitionToShuffleServerResponse);
+  rpc reallocationShuffleServers(ReallocationServersRequest) returns (ReallocationServersReponse);
 }
 
 message ReportShuffleFetchFailureRequest {
@@ -513,5 +533,47 @@ message ReportShuffleFetchFailureRequest {
 message ReportShuffleFetchFailureResponse {
   StatusCode status = 1;
   bool reSubmitWholeStage = 2;
+  string msg = 3;
+}
+message ReportShuffleWriteFailureRequest {
+  string appId = 1;
+  int32 shuffleId = 2;
+  int32 stageAttemptNumber = 3;
+  repeated ShuffleServerId shuffleServerIds= 5;
+  string exception = 6;
+}
+
+message ReportShuffleWriteFailureResponse {
+  StatusCode status = 1;
+  bool reSubmitWholeStage = 2;
+  string msg = 3;
+}
+
+message PartitionToShuffleServerRequest {
+  int32 shuffleId = 2;
+}
+
+message PartitionToShuffleServerResponse {
+  StatusCode status = 1;
+  map<int32,GetShuffleServerListResponse> partitionToShuffleServer = 2;
+  RemoteStorageInfo remote_storage_info = 3;
+  string msg = 4;
+}
+
+message RemoteStorageInfo{
+  string path = 1;
+  map<string, string> confItems = 2;
+}
+
+message ReallocationServersRequest{
+  int32 stageId = 1;
+  int32 stageAttemptNumber = 2;
+  int32 shuffleId = 3;
+  int32 numPartitions = 4;
+}
+
+message ReallocationServersReponse{
+  StatusCode status = 1;
+  bool reallocationFlag = 2;
   string msg = 3;
 }

--- a/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerWriteGrpcService.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerWriteGrpcService.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.proto.RssProtos;
+
+public class MockedShuffleServerWriteGrpcService extends ShuffleServerGrpcService {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MockedShuffleServerWriteGrpcService.class);
+  /** Abnormal node flag */
+  private boolean taskExcptionFlag = true;
+
+  private AtomicInteger failedWriteRequest = new AtomicInteger(0);
+
+  public MockedShuffleServerWriteGrpcService(ShuffleServer shuffleServer) {
+    super(shuffleServer);
+    LOG.info("create MockedShuffleServerWriteGrpcService");
+  }
+
+  @Override
+  public void sendShuffleData(
+      RssProtos.SendShuffleDataRequest req,
+      StreamObserver<RssProtos.SendShuffleDataResponse> responseObserver) {
+    if (taskExcptionFlag) {
+      failedWriteRequest.incrementAndGet();
+      throw new RuntimeException(
+          "This write request is failed as mocked failure,failed times: "
+              + failedWriteRequest.get());
+    }
+    super.sendShuffleData(req, responseObserver);
+  }
+}

--- a/server/src/test/java/org/apache/uniffle/server/MockedShuffleWriteGrpcServer.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedShuffleWriteGrpcServer.java
@@ -15,26 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.strategy.assignment;
+package org.apache.uniffle.server;
 
-import java.util.Set;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.tuple.Pair;
 
-public interface AssignmentStrategy {
+import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.metrics.GRPCMetrics;
+import org.apache.uniffle.common.rpc.GrpcServer;
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency,
-      Set<String> serversList);
+public class MockedShuffleWriteGrpcServer extends GrpcServer {
+  MockedShuffleServerWriteGrpcService service;
 
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency);
+  public MockedShuffleWriteGrpcServer(
+      RssBaseConf conf, MockedShuffleServerWriteGrpcService service, GRPCMetrics grpcMetrics) {
+    super(conf, Lists.newArrayList(Pair.of(service, Lists.newArrayList())), grpcMetrics);
+    this.service = service;
+  }
+
+  public MockedShuffleServerWriteGrpcService getService() {
+    return service;
+  }
 }

--- a/server/src/test/java/org/apache/uniffle/server/MockedWriteShuffleServer.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedWriteShuffleServer.java
@@ -15,26 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.strategy.assignment;
+package org.apache.uniffle.server;
 
-import java.util.Set;
+public class MockedWriteShuffleServer extends ShuffleServer {
+  public MockedWriteShuffleServer(ShuffleServerConf shuffleServerConf) throws Exception {
+    super(shuffleServerConf);
+  }
 
-public interface AssignmentStrategy {
-
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency,
-      Set<String> serversList);
-
-  PartitionRangeAssignment assign(
-      int totalPartitionNum,
-      int partitionNumPerRange,
-      int replica,
-      Set<String> requiredTags,
-      int requiredShuffleServerNumber,
-      int estimateTaskConcurrency);
+  @Override
+  public void setServer() {
+    setServer(new MockedWriteShuffleServerFactory(this).getServer());
+  }
 }

--- a/server/src/test/java/org/apache/uniffle/server/MockedWriteShuffleServerFactory.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedWriteShuffleServerFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.common.rpc.ServerInterface;
+import org.apache.uniffle.common.rpc.ServerType;
+
+public class MockedWriteShuffleServerFactory extends ShuffleServerFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MockedShuffleServerFactory.class);
+
+  public MockedWriteShuffleServerFactory(MockedWriteShuffleServer shuffleServer) {
+    super(shuffleServer);
+  }
+
+  @Override
+  public ServerInterface getServer() {
+    ShuffleServerConf conf = getConf();
+    ShuffleServer shuffleServer = getShuffleServer();
+    ServerType type = conf.get(ShuffleServerConf.RPC_SERVER_TYPE);
+    LOG.info("MockedWriteShuffleServerFactory execute le mei");
+    if (type == ServerType.GRPC) {
+      return new MockedShuffleWriteGrpcServer(
+          conf,
+          new MockedShuffleServerWriteGrpcService(shuffleServer),
+          shuffleServer.getGrpcMetrics());
+    } else {
+      throw new UnsupportedOperationException("Unsupported server type " + type);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. During the shuffle write phase, the ShuffleServer reports faulty nodes and reallocates the ShuffleServer list;
2. Triggers a Stage level retry of SPARK. The shuffleServer node is excluded and reallocated before the retry.

![image](https://github.com/apache/incubator-uniffle/assets/33595968/866c8292-e0ff-4532-b519-02f424f4c2fc)

As shown in the picture above:
1. During Shuffle registration, obtain the ShuffleServer list to be written through the RPC interface of a Coordinator Client by following the solid blue line step. The list is bound using ShuffleID.
2, the Task of Stage starts, solid steps, in accordance with the green by ShuffleManager Client RPC interface gets to be written for shuffleIdToShuffleHandleInfo ShuffleServer list;
3. In the Stage, if Task fails to write blocks to the ShuffleServer, press the steps in red to report ShuffleServer to FailedShuffleServerList in RSSShuffleManager through the RPC interface.
4. FailedShuffleServerList records the number of ShuffleServer failures. After the number of failures reaches the maximum number of retries of the Task level, follow the steps in dotted orange lines. Through the RPC interface of a Coordinator Client, obtain the list of ShuffleServer files to be written (the ShuffleServer files that fail to be written are excluded). After obtaining the list, go to Step 5 of the dotted orange line. Throwing a FetchFailed Exception triggers a stage-level retry for SPARK;
5. Attempt 1 is generated by the SPARK Stage level again. Pull the corresponding ShuffleServer list according to the green dotted line.
6. Repeat the above steps for the remaining stages;

### Why are the changes needed?

Add fault tolerance to the shuffle write phase

Fix: #825 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT as well as adding an integration test:RSSStageDynamicServerReWriteTest
