### PR TITLE
[#1115] improvement: Unregister shuffle explicitly when application i…

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -289,8 +289,6 @@ public class RssDAGAppMaster extends DAGAppMaster {
 
     @Override
     public void run() {
-      releaseRssResources(appMaster);
-
       LOG.info(
           "RssDAGAppMaster received a signal. Signaling RMCommunicator and JobHistoryEventHandler.");
       this.appMaster.stop();
@@ -301,20 +299,14 @@ public class RssDAGAppMaster extends DAGAppMaster {
     try {
       LOG.info("RssDAGAppMaster releaseRssResources invoked");
       appMaster.heartBeatExecutorService.shutdownNow();
-
+      if (appMaster.tezRemoteShuffleManager != null) {
+        appMaster.tezRemoteShuffleManager.shutdown();
+        appMaster.tezRemoteShuffleManager = null;
+      }
       if (appMaster.shuffleWriteClient != null) {
         appMaster.shuffleWriteClient.close();
+        appMaster.shuffleWriteClient = null;
       }
-      appMaster.shuffleWriteClient = null;
-
-      if (appMaster.tezRemoteShuffleManager != null) {
-        try {
-          appMaster.tezRemoteShuffleManager.shutdown();
-        } catch (Exception e) {
-          LOG.info("Failed to shutdown TezRemoteShuffleManager.", e);
-        }
-      }
-      appMaster.tezRemoteShuffleManager = null;
     } catch (Throwable t) {
       LOG.error("Failed to release Rss resources.", t);
     }

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -109,6 +109,14 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
 
   @Override
   public void shutdown() throws Exception {
+    if (rssClient != null) {
+      LOG.info("unregister all shuffle for appid {}", appId);
+      Map<Integer, ShuffleAssignmentsInfo> infos =
+          tezRemoteShuffleUmbilical.getShuffleIdToShuffleAssignsInfo();
+      for (Map.Entry<Integer, ShuffleAssignmentsInfo> entry : infos.entrySet()) {
+        rssClient.unregisterShuffle(appId, entry.getKey());
+      }
+    }
     server.stop();
   }
 
@@ -172,6 +180,10 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
       }
 
       return response;
+    }
+
+    Map<Integer, ShuffleAssignmentsInfo> getShuffleIdToShuffleAssignsInfo() {
+      return shuffleIdToShuffleAssignsInfo;
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

For MR/Tez, as applications is stopped, we should unregister shuffle explicitly. There are no need to wait timeout.

### Why are the changes needed?

Fix: #1115 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

test in yarn cluster
