### PR TITLE
[#1020] feat(spark): Support hybrid shuffle manager

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/HybridRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/HybridRssShuffleManager.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.client.api.CoordinatorClient;
+import org.apache.uniffle.client.request.RssAccessClusterRequest;
+import org.apache.uniffle.client.response.RssAccessClusterResponse;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.common.util.RetryUtils;
+
+import static org.apache.uniffle.common.util.Constants.ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM;
+
+public class HybridRssShuffleManager implements ShuffleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HybridRssShuffleManager.class);
+
+  private ShuffleManager essShuffleManager;
+  private ShuffleManager rssShuffleManager;
+  private final List<CoordinatorClient> coordinatorClients;
+  private Set<Integer> rssShuffleIds;
+  private final int accessTimeoutMs;
+  private final SparkConf sparkConf;
+  private boolean isDriver;
+  private String user;
+  private String uuid;
+
+  public HybridRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
+    this.sparkConf = sparkConf;
+    this.isDriver = isDriver;
+    accessTimeoutMs = sparkConf.get(RssSparkConfig.RSS_ACCESS_TIMEOUT_MS);
+
+    coordinatorClients = createCoordinatorClients(isDriver, sparkConf);
+    essShuffleManager = null;
+    rssShuffleManager = null;
+
+    rssShuffleIds = Sets.newConcurrentHashSet();
+  }
+
+  private List<CoordinatorClient> createCoordinatorClients(boolean isDriver, SparkConf sparkConf) {
+    List<CoordinatorClient> coordinatorClients;
+    if (isDriver) {
+      coordinatorClients = RssSparkShuffleUtils.createCoordinatorClients(sparkConf);
+    } else {
+      coordinatorClients = Lists.newArrayList();
+    }
+    return coordinatorClients;
+  }
+
+  private ShuffleManager createEssShuffleManager(SparkConf sparkConf, boolean isDriver)
+      throws RssException {
+    ShuffleManager shuffleManager;
+
+    try {
+      shuffleManager =
+          RssSparkShuffleUtils.loadShuffleManager(
+              Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, true);
+      if (isDriver) {
+        sparkConf.set(RssSparkConfig.RSS_ENABLED.key(), "false");
+        sparkConf.set("spark.shuffle.manager", "sort");
+      }
+    } catch (Exception e) {
+      throw new RssException(e.getMessage());
+    }
+
+    return shuffleManager;
+  }
+
+  private ShuffleManager createRssShuffleManager(SparkConf sparkConf, boolean isDriver)
+      throws RssException {
+    ShuffleManager shuffleManager = null;
+    if (isDriver) {
+      user = "user";
+      try {
+        user = UserGroupInformation.getCurrentUser().getShortUserName();
+      } catch (Exception e) {
+        LOG.error("Error on getting user from ugi." + e);
+      }
+      boolean canAccess = tryAccessCluster();
+      if (uuid == null || "".equals(uuid)) {
+        uuid = String.valueOf(System.currentTimeMillis());
+      }
+
+      if (canAccess) {
+        try {
+          sparkConf.set("spark.rss.quota.user", user);
+          sparkConf.set("spark.rss.quota.uuid", uuid);
+          shuffleManager = new RssShuffleManager(sparkConf, true);
+          sparkConf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+          sparkConf.set("spark.shuffle.manager", RssShuffleManager.class.getCanonicalName());
+          LOG.info("Use RssShuffleManager");
+          return shuffleManager;
+        } catch (Exception exception) {
+          LOG.warn(
+              "Fail to create RssShuffleManager, fallback to SortShuffleManager {}",
+              exception.getMessage());
+        }
+      }
+    } else {
+      boolean useRSS = sparkConf.get(RssSparkConfig.RSS_ENABLED);
+      if (useRSS) {
+        // Executor will not do any fallback
+        try {
+          shuffleManager = new RssShuffleManager(sparkConf, false);
+          LOG.info("Use RssShuffleManager");
+        } catch (Exception exception) {
+          LOG.warn(
+              "Fail to create RssShuffleManager, fallback to SortShuffleManager {}",
+              exception.getMessage());
+        }
+      }
+    }
+    return shuffleManager;
+  }
+
+  private boolean tryAccessCluster() {
+    String accessId = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID.key(), "").trim();
+    if (StringUtils.isEmpty(accessId)) {
+      LOG.warn("Access id key is empty");
+      return false;
+    }
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
+
+    int assignmentShuffleNodesNum =
+        sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
+    Map<String, String> extraProperties = Maps.newHashMap();
+    extraProperties.put(
+        ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM, String.valueOf(assignmentShuffleNodesNum));
+
+    for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
+      boolean canAccess;
+      try {
+        canAccess =
+            RetryUtils.retry(
+                () -> {
+                  RssAccessClusterResponse response =
+                      coordinatorClient.accessCluster(
+                          new RssAccessClusterRequest(
+                              accessId, assignmentTags, accessTimeoutMs, extraProperties, user));
+                  if (response.getStatusCode() == StatusCode.SUCCESS) {
+                    LOG.warn(
+                        "Success to access cluster {} using {}",
+                        coordinatorClient.getDesc(),
+                        accessId);
+                    uuid = response.getUuid();
+                    return true;
+                  } else if (response.getStatusCode() == StatusCode.ACCESS_DENIED) {
+                    throw new RssException(
+                        "Request to access cluster "
+                            + coordinatorClient.getDesc()
+                            + " is denied using "
+                            + accessId
+                            + " for "
+                            + response.getMessage());
+                  } else {
+                    throw new RssException(
+                        "Fail to reach cluster "
+                            + coordinatorClient.getDesc()
+                            + " for "
+                            + response.getMessage());
+                  }
+                },
+                retryInterval,
+                retryTimes);
+        return canAccess;
+      } catch (Throwable e) {
+        LOG.warn(
+            "Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(),
+            accessId,
+            e.getMessage());
+      }
+    }
+
+    return false;
+  }
+
+  private ShuffleManager getOrCreateEssShuffleManager() {
+    if (essShuffleManager == null) essShuffleManager = createEssShuffleManager(sparkConf, isDriver);
+    return essShuffleManager;
+  }
+
+  private ShuffleManager getOrCreateRssShuffleManager() {
+    if (rssShuffleManager == null) rssShuffleManager = createRssShuffleManager(sparkConf, isDriver);
+    return rssShuffleManager;
+  }
+
+  public ShuffleManager registerShuffleManager(int shuffleId) {
+    // If create RssShuffleManager failed, we downgrade to ess shufflemanager
+    if (getOrCreateRssShuffleManager() != null) {
+      rssShuffleIds.add(shuffleId);
+      return getOrCreateRssShuffleManager();
+    }
+    return getOrCreateEssShuffleManager();
+  }
+
+  public ShuffleManager getEssShuffleManager() {
+    return essShuffleManager;
+  }
+
+  public ShuffleManager getRssShuffleManager() {
+    return rssShuffleManager;
+  }
+
+  private ShuffleManager createShuffleManagerInExecutor() throws RssException {
+    ShuffleManager shuffleManager;
+    // get useRSS from spark conf
+    boolean useRSS = sparkConf.get(RssSparkConfig.RSS_ENABLED);
+    if (useRSS) {
+      // Executor will not do any fallback
+      shuffleManager = new RssShuffleManager(sparkConf, false);
+      LOG.info("Use RssShuffleManager");
+    } else {
+      try {
+        shuffleManager =
+            RssSparkShuffleUtils.loadShuffleManager(
+                Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, false);
+        LOG.info("Use SortShuffleManager");
+      } catch (Exception e) {
+        throw new RssException(e.getMessage());
+      }
+    }
+    return shuffleManager;
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(
+      int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+    // If create RssShuffleManager failed, we downgrade to ess shufflemanager
+    return registerShuffleManager(shuffleId).registerShuffle(shuffleId, numMaps, dependency);
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(
+      ShuffleHandle handle, int mapId, TaskContext context) {
+    return rssShuffleIds.contains(handle.shuffleId())
+        ? getOrCreateRssShuffleManager().getWriter(handle, mapId, context)
+        : getOrCreateEssShuffleManager().getWriter(handle, mapId, context);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
+    return rssShuffleIds.contains(handle.shuffleId())
+        ? getOrCreateRssShuffleManager().getReader(handle, startPartition, endPartition, context)
+        : getOrCreateEssShuffleManager().getReader(handle, startPartition, endPartition, context);
+  }
+
+  @Override
+  public boolean unregisterShuffle(int shuffleId) {
+    return rssShuffleIds.contains(shuffleId)
+        ? getOrCreateRssShuffleManager().unregisterShuffle(shuffleId)
+        : getOrCreateEssShuffleManager().unregisterShuffle(shuffleId);
+  }
+
+  @Override
+  public void stop() {
+    if (essShuffleManager != null) essShuffleManager.stop();
+    if (rssShuffleManager != null) rssShuffleManager.stop();
+    coordinatorClients.forEach(CoordinatorClient::close);
+  }
+
+  @Override
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return essShuffleManager.shuffleBlockResolver();
+  }
+}

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/HybridRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/HybridRssShuffleManagerTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.google.common.collect.Lists;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.sort.SortShuffleManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.apache.uniffle.client.api.CoordinatorClient;
+import org.apache.uniffle.client.response.RssAccessClusterResponse;
+import org.apache.uniffle.storage.util.StorageType;
+
+import static org.apache.uniffle.common.rpc.StatusCode.ACCESS_DENIED;
+import static org.apache.uniffle.common.rpc.StatusCode.SUCCESS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+public class HybridRssShuffleManagerTest {
+  private static MockedStatic<RssSparkShuffleUtils> mockedStaticRssShuffleUtils;
+
+  @BeforeAll
+  public static void setUp() {
+    mockedStaticRssShuffleUtils =
+        mockStatic(RssSparkShuffleUtils.class, Mockito.CALLS_REAL_METHODS);
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    mockedStaticRssShuffleUtils.close();
+  }
+
+  @Test
+  public void testCreateInDriverDenied() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .thenReturn(coordinatorClients);
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    assertCreateSortShuffleManager(conf, true);
+  }
+
+  @Test
+  public void testCreateInDriver() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .thenReturn(coordinatorClients);
+
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf, true);
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    assertCreateSortShuffleManager(conf, true);
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    assertCreateRssShuffleManager(conf);
+
+    conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    assertCreateSortShuffleManager(conf, true);
+  }
+
+  @Test
+  public void testCreateInExecutor() throws Exception {
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    HybridRssShuffleManager hybridShuffleManager = new HybridRssShuffleManager(conf, false);
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    hybridShuffleManager.registerShuffleManager(0);
+    assertTrue(hybridShuffleManager.getEssShuffleManager() instanceof SortShuffleManager);
+    assertNotNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+  }
+
+  @Test
+  public void testCreateFallback() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .thenReturn(coordinatorClients);
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+
+    // fall back to SortShuffleManager in driver
+    assertCreateSortShuffleManager(conf, true);
+
+    // No fall back in executor
+    conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+    boolean hasException = false;
+    try {
+      new DelegationRssShuffleManager(conf, false);
+    } catch (NoSuchElementException e) {
+      assertTrue(e.getMessage().startsWith("spark.rss.coordinator.quorum"));
+      hasException = true;
+    }
+    assertTrue(hasException);
+  }
+
+  @Test
+  public void testTryAccessCluster() throws Exception {
+    CoordinatorClient mockDeniedCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockDeniedCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockDeniedCoordinatorClient);
+    mockedStaticRssShuffleUtils
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .thenReturn(coordinatorClients);
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
+    conf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES, 3);
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    assertCreateRssShuffleManager(conf);
+
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any()))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""))
+        .thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> secondCoordinatorClients = Lists.newArrayList();
+    secondCoordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .thenReturn(secondCoordinatorClients);
+    SparkConf secondConf = new SparkConf();
+    secondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
+    secondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES, 3);
+    secondConf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    secondConf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    secondConf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    secondConf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    assertCreateSortShuffleManager(secondConf, true);
+  }
+
+  private void assertCreateSortShuffleManager(SparkConf conf, boolean isDriver) throws Exception {
+    HybridRssShuffleManager hybridShuffleManager = new HybridRssShuffleManager(conf, isDriver);
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    hybridShuffleManager.registerShuffleManager(0);
+    assertTrue(hybridShuffleManager.getEssShuffleManager() instanceof SortShuffleManager);
+    assertNotNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    assertFalse(conf.getBoolean(RssSparkConfig.RSS_ENABLED.key(), false));
+    assertEquals("sort", conf.get("spark.shuffle.manager"));
+  }
+
+  private void assertCreateRssShuffleManager(SparkConf conf) throws Exception {
+    HybridRssShuffleManager hybridShuffleManager = new HybridRssShuffleManager(conf, true);
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    hybridShuffleManager.registerShuffleManager(0);
+    assertTrue(hybridShuffleManager.getRssShuffleManager() instanceof RssShuffleManager);
+    assertNotNull(hybridShuffleManager.getRssShuffleManager());
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertTrue(Boolean.parseBoolean(conf.get(RssSparkConfig.RSS_ENABLED.key())));
+    assertEquals(RssShuffleManager.class.getCanonicalName(), conf.get("spark.shuffle.manager"));
+  }
+}

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/HybridShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/HybridShuffleManager.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.client.api.CoordinatorClient;
+import org.apache.uniffle.client.request.RssAccessClusterRequest;
+import org.apache.uniffle.client.response.RssAccessClusterResponse;
+import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.common.util.RetryUtils;
+
+import static org.apache.uniffle.common.util.Constants.ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM;
+
+public class HybridShuffleManager implements ShuffleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HybridShuffleManager.class);
+
+  private final int accessTimeoutMs;
+  private final SparkConf sparkConf;
+  private ShuffleManager essShuffleManager;
+  private ShuffleManager rssShuffleManager;
+  private List<CoordinatorClient> coordinatorClients;
+  private Set<Integer> rssShuffleIds;
+  private boolean isDriver;
+  private String user;
+  private String uuid;
+
+  public HybridShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
+    this.sparkConf = sparkConf;
+    this.isDriver = isDriver;
+    accessTimeoutMs = sparkConf.get(RssSparkConfig.RSS_ACCESS_TIMEOUT_MS);
+
+    coordinatorClients = createCoordinatorClients(isDriver, sparkConf);
+    essShuffleManager = null;
+    rssShuffleManager = null;
+
+    rssShuffleIds = Sets.newConcurrentHashSet();
+  }
+
+  private List<CoordinatorClient> createCoordinatorClients(boolean isDriver, SparkConf sparkConf) {
+    List<CoordinatorClient> coordinatorClients;
+    if (isDriver) {
+      coordinatorClients = RssSparkShuffleUtils.createCoordinatorClients(sparkConf);
+    } else {
+      coordinatorClients = Lists.newArrayList();
+    }
+    return coordinatorClients;
+  }
+
+  private ShuffleManager createEssShuffleManager(SparkConf sparkConf, boolean isDriver)
+      throws RssException {
+    ShuffleManager shuffleManager;
+
+    try {
+      shuffleManager =
+          RssSparkShuffleUtils.loadShuffleManager(
+              Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, true);
+      if (isDriver) {
+        sparkConf.set(RssSparkConfig.RSS_ENABLED.key(), "false");
+        sparkConf.set("spark.shuffle.manager", "sort");
+      }
+    } catch (Exception e) {
+      throw new RssException(e.getMessage());
+    }
+
+    return shuffleManager;
+  }
+
+  private ShuffleManager createRssShuffleManager(SparkConf sparkConf, boolean isDriver)
+      throws RssException {
+    ShuffleManager shuffleManager = null;
+    if (isDriver) {
+      user = "user";
+      try {
+        user = UserGroupInformation.getCurrentUser().getShortUserName();
+      } catch (Exception e) {
+        LOG.error("Error on getting user from ugi." + e);
+      }
+      boolean canAccess = tryAccessCluster();
+      if (uuid == null || "".equals(uuid)) {
+        uuid = String.valueOf(System.currentTimeMillis());
+      }
+
+      if (canAccess) {
+        try {
+          sparkConf.set("spark.rss.quota.user", user);
+          sparkConf.set("spark.rss.quota.uuid", uuid);
+          shuffleManager = new RssShuffleManager(sparkConf, true);
+          sparkConf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+          sparkConf.set("spark.shuffle.manager", RssShuffleManager.class.getCanonicalName());
+          LOG.info("Use RssShuffleManager");
+          return shuffleManager;
+        } catch (Exception exception) {
+          LOG.warn(
+              "Fail to create RssShuffleManager, fallback to SortShuffleManager {}",
+              exception.getMessage());
+        }
+      }
+    } else {
+      boolean useRSS = sparkConf.get(RssSparkConfig.RSS_ENABLED);
+      if (useRSS) {
+        // Executor will not do any fallback
+        try {
+          shuffleManager = new RssShuffleManager(sparkConf, false);
+          LOG.info("Use RssShuffleManager");
+        } catch (Exception exception) {
+          LOG.warn(
+              "Fail to create RssShuffleManager, fallback to SortShuffleManager {}",
+              exception.getMessage());
+        }
+      }
+    }
+    return shuffleManager;
+  }
+
+  private boolean tryAccessCluster() {
+    String accessId = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID.key(), "").trim();
+    if (StringUtils.isEmpty(accessId)) {
+      LOG.warn("Access id key is empty");
+      return false;
+    }
+    long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
+
+    int assignmentShuffleNodesNum =
+        sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
+    Map<String, String> extraProperties = Maps.newHashMap();
+    extraProperties.put(
+        ACCESS_INFO_REQUIRED_SHUFFLE_NODES_NUM, String.valueOf(assignmentShuffleNodesNum));
+
+    for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
+      boolean canAccess;
+      try {
+        canAccess =
+            RetryUtils.retry(
+                () -> {
+                  RssAccessClusterResponse response =
+                      coordinatorClient.accessCluster(
+                          new RssAccessClusterRequest(
+                              accessId, assignmentTags, accessTimeoutMs, extraProperties, user));
+                  if (response.getStatusCode() == StatusCode.SUCCESS) {
+                    LOG.warn(
+                        "Success to access cluster {} using {}",
+                        coordinatorClient.getDesc(),
+                        accessId);
+                    uuid = response.getUuid();
+                    return true;
+                  } else if (response.getStatusCode() == StatusCode.ACCESS_DENIED) {
+                    throw new RssException(
+                        "Request to access cluster "
+                            + coordinatorClient.getDesc()
+                            + " is denied using "
+                            + accessId
+                            + " for "
+                            + response.getMessage());
+                  } else {
+                    throw new RssException(
+                        "Fail to reach cluster "
+                            + coordinatorClient.getDesc()
+                            + " for "
+                            + response.getMessage());
+                  }
+                },
+                retryInterval,
+                retryTimes);
+        return canAccess;
+      } catch (Throwable e) {
+        LOG.warn(
+            "Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(),
+            accessId,
+            e.getMessage());
+      }
+    }
+
+    return false;
+  }
+
+  private ShuffleManager getOrCreateEssShuffleManager() {
+    if (essShuffleManager == null) essShuffleManager = createEssShuffleManager(sparkConf, isDriver);
+    return essShuffleManager;
+  }
+
+  private ShuffleManager getOrCreateRssShuffleManager() {
+    if (rssShuffleManager == null) rssShuffleManager = createRssShuffleManager(sparkConf, isDriver);
+    return rssShuffleManager;
+  }
+
+  public ShuffleManager registerShuffleManager(int shuffleId) {
+    // If create RssShuffleManager failed, we downgrade to ess shufflemanager
+    if (getOrCreateRssShuffleManager() != null) {
+      rssShuffleIds.add(shuffleId);
+      return getOrCreateRssShuffleManager();
+    }
+    return getOrCreateEssShuffleManager();
+  }
+
+  public ShuffleManager getEssShuffleManager() {
+    return essShuffleManager;
+  }
+
+  public ShuffleManager getRssShuffleManager() {
+    return rssShuffleManager;
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(
+      int shuffleId, ShuffleDependency<K, V, C> dependency) {
+    // If create RssShuffleManager failed, we downgrade to ess shufflemanager
+    return registerShuffleManager(shuffleId).registerShuffle(shuffleId, dependency);
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(
+      ShuffleHandle handle, long mapId, TaskContext context, ShuffleWriteMetricsReporter metrics) {
+    return rssShuffleIds.contains(handle.shuffleId())
+        ? getOrCreateRssShuffleManager().getWriter(handle, mapId, context, metrics)
+        : getOrCreateEssShuffleManager().getWriter(handle, mapId, context, metrics);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    return rssShuffleIds.contains(handle.shuffleId())
+        ? getOrCreateRssShuffleManager()
+            .getReader(handle, startPartition, endPartition, context, metrics)
+        : getOrCreateEssShuffleManager()
+            .getReader(handle, startPartition, endPartition, context, metrics);
+  }
+
+  // The interface is only used for compatibility with spark 3.1.2
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    ShuffleReader<K, C> reader = null;
+    try {
+      reader =
+          rssShuffleIds.contains(handle.shuffleId())
+              ? (ShuffleReader<K, C>)
+                  getOrCreateRssShuffleManager()
+                      .getClass()
+                      .getDeclaredMethod(
+                          "getReader",
+                          ShuffleHandle.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          TaskContext.class,
+                          ShuffleReadMetricsReporter.class)
+                      .invoke(
+                          handle,
+                          startMapIndex,
+                          endMapIndex,
+                          startPartition,
+                          endPartition,
+                          context,
+                          metrics)
+              : (ShuffleReader<K, C>)
+                  getOrCreateEssShuffleManager()
+                      .getClass()
+                      .getDeclaredMethod(
+                          "getReader",
+                          ShuffleHandle.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          TaskContext.class,
+                          ShuffleReadMetricsReporter.class)
+                      .invoke(
+                          handle,
+                          startMapIndex,
+                          endMapIndex,
+                          startPartition,
+                          endPartition,
+                          context,
+                          metrics);
+    } catch (Exception e) {
+      throw new RssException(e);
+    }
+    return reader;
+  }
+
+  // The interface is only used for compatibility with spark 3.0.1
+  public <K, C> ShuffleReader<K, C> getReaderForRange(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    ShuffleReader<K, C> reader = null;
+    try {
+      reader =
+          rssShuffleIds.contains(handle.shuffleId())
+              ? (ShuffleReader<K, C>)
+                  getOrCreateRssShuffleManager()
+                      .getClass()
+                      .getDeclaredMethod(
+                          "getReaderForRange",
+                          ShuffleHandle.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          TaskContext.class,
+                          ShuffleReadMetricsReporter.class)
+                      .invoke(
+                          handle,
+                          startMapIndex,
+                          endMapIndex,
+                          startPartition,
+                          endPartition,
+                          context,
+                          metrics)
+              : (ShuffleReader<K, C>)
+                  getOrCreateEssShuffleManager()
+                      .getClass()
+                      .getDeclaredMethod(
+                          "getReaderForRange",
+                          ShuffleHandle.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          int.class,
+                          TaskContext.class,
+                          ShuffleReadMetricsReporter.class)
+                      .invoke(
+                          handle,
+                          startMapIndex,
+                          endMapIndex,
+                          startPartition,
+                          endPartition,
+                          context,
+                          metrics);
+    } catch (Exception e) {
+      throw new RssException(e);
+    }
+    return reader;
+  }
+
+  @Override
+  public boolean unregisterShuffle(int shuffleId) {
+    return rssShuffleIds.contains(shuffleId)
+        ? getOrCreateRssShuffleManager().unregisterShuffle(shuffleId)
+        : getOrCreateEssShuffleManager().unregisterShuffle(shuffleId);
+  }
+
+  @Override
+  public void stop() {
+    if (getOrCreateEssShuffleManager() != null) {
+      getOrCreateEssShuffleManager().stop();
+    }
+
+    if (getOrCreateRssShuffleManager() != null) {
+      getOrCreateRssShuffleManager().stop();
+    }
+
+    coordinatorClients.forEach(CoordinatorClient::close);
+  }
+
+  @Override
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return getOrCreateEssShuffleManager().shuffleBlockResolver();
+  }
+}

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/HybridShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/HybridShuffleManagerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.sort.SortShuffleManager;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.storage.util.StorageType;
+
+import static org.apache.uniffle.common.rpc.StatusCode.ACCESS_DENIED;
+import static org.apache.uniffle.common.rpc.StatusCode.SUCCESS;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HybridShuffleManagerTest extends RssShuffleManagerTestBase {
+
+  @Test
+  public void testCreateInDriverDenied() throws Exception {
+    setupMockedRssShuffleUtils(ACCESS_DENIED);
+    setupMockedShuffleManager();
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    assertCreateSortShuffleManager(conf, true);
+  }
+
+  @Test
+  public void testCreateInDriver() throws Exception {
+    setupMockedRssShuffleUtils(SUCCESS);
+    setupMockedShuffleManager();
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf, true);
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
+    assertCreateSortShuffleManager(conf, true);
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    assertCreateRssShuffleManager(conf);
+
+    conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    assertCreateSortShuffleManager(conf, true);
+  }
+
+  @Test
+  public void testCreateInExecutor() throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager;
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    assertCreateSortShuffleManager(conf, false);
+  }
+
+  private void assertCreateSortShuffleManager(SparkConf conf, boolean isDriver) throws Exception {
+    HybridShuffleManager hybridShuffleManager = new HybridShuffleManager(conf, true);
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    hybridShuffleManager.registerShuffleManager(0);
+    assertTrue(hybridShuffleManager.getEssShuffleManager() instanceof SortShuffleManager);
+    assertNotNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    assertFalse(conf.getBoolean(RssSparkConfig.RSS_ENABLED.key(), false));
+    assertEquals("sort", conf.get("spark.shuffle.manager"));
+  }
+
+  private void assertCreateRssShuffleManager(SparkConf conf) throws Exception {
+    HybridShuffleManager hybridShuffleManager = new HybridShuffleManager(conf, true);
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertNull(hybridShuffleManager.getRssShuffleManager());
+    hybridShuffleManager.registerShuffleManager(0);
+    assertTrue(hybridShuffleManager.getRssShuffleManager() instanceof RssShuffleManager);
+    assertNotNull(hybridShuffleManager.getRssShuffleManager());
+    assertNull(hybridShuffleManager.getEssShuffleManager());
+    assertTrue(Boolean.parseBoolean(conf.get(RssSparkConfig.RSS_ENABLED.key())));
+    assertEquals(RssShuffleManager.class.getCanonicalName(), conf.get("spark.shuffle.manager"));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Delegation shuffle manager has been supported in uniffle, which is useful for avoiding instability of uniffle cluster.

But this is not enough, we hope the hybrid shuffle manager could be supported, that will support using ESS or Uniffle on different stages in one App

### Why are the changes needed?

  1. Add HybridShuffleManager.
  2. Add UnitTests.

Fix: https://github.com/apache/incubator-uniffle/issues/1020

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  3. Addition or removal of property keys.)

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  3. If you fix a flaky test, repeat it for many times to prove it works.)
