### PR TITLE
[#825][part-2] feat(spark): Report failed blocks and a list of ShuffleServer

### DIFF
--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
@@ -34,6 +34,8 @@ import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.util.JavaUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,11 +81,19 @@ public class DataPusherTest {
 
     Map<String, Set<Long>> taskToSuccessBlockIds = Maps.newConcurrentMap();
     Map<String, Set<Long>> taskToFailedBlockIds = Maps.newConcurrentMap();
+    Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
+        JavaUtils.newConcurrentMap();
     Set<String> failedTaskIds = new HashSet<>();
 
     DataPusher dataPusher =
         new DataPusher(
-            shuffleWriteClient, taskToSuccessBlockIds, taskToFailedBlockIds, failedTaskIds, 1, 2);
+            shuffleWriteClient,
+            taskToSuccessBlockIds,
+            taskToFailedBlockIds,
+            taskToFailedBlockIdsAndServer,
+            failedTaskIds,
+            1,
+            2);
     dataPusher.setRssAppId("testSendData_appId");
 
     // sync send

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -86,6 +86,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private ShuffleWriteClient shuffleWriteClient;
   private Map<String, Set<Long>> taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
   private Map<String, Set<Long>> taskToFailedBlockIds = JavaUtils.newConcurrentMap();
+  // Record both the block that failed to be sent and the ShuffleServer
+  private final Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
+      JavaUtils.newConcurrentMap();
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
@@ -212,6 +215,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
               shuffleWriteClient,
               taskToSuccessBlockIds,
               taskToFailedBlockIds,
+              taskToFailedBlockIdsAndServer,
               failedTaskIds,
               poolSize,
               keepAliveTime);
@@ -691,5 +695,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       throw RssSparkShuffleUtils.reportRssFetchFailedException(
           e, sparkConf, appId, shuffleId, stageAttemptId, Sets.newHashSet(partitionId));
     }
+  }
+
+  /**
+   * The ShuffleServer list of block sending failures is returned using the shuffle task ID
+   *
+   * @param taskId Shuffle taskId
+   * @return List of failed ShuffleServer blocks
+   */
+  public Map<Long, List<ShuffleServerInfo>> getFailedBlockIdsWithShuffleServer(String taskId) {
+    Map<Long, List<ShuffleServerInfo>> result = taskToFailedBlockIdsAndServer.get(taskId);
+    if (result == null) {
+      result = JavaUtils.newConcurrentMap();
+    }
+    return result;
   }
 }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -155,13 +155,14 @@ public class RssShuffleWriterTest {
     private final Function<AddBlockEvent, CompletableFuture<Long>> sendFunc;
 
     FakedDataPusher(Function<AddBlockEvent, CompletableFuture<Long>> sendFunc) {
-      this(null, null, null, null, 1, 1, sendFunc);
+      this(null, null, null, null, null, 1, 1, sendFunc);
     }
 
     private FakedDataPusher(
         ShuffleWriteClient shuffleWriteClient,
         Map<String, Set<Long>> taskToSuccessBlockIds,
         Map<String, Set<Long>> taskToFailedBlockIds,
+        Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
         Set<String> failedTaskIds,
         int threadPoolSize,
         int threadKeepAliveTime,
@@ -170,6 +171,7 @@ public class RssShuffleWriterTest {
           shuffleWriteClient,
           taskToSuccessBlockIds,
           taskToFailedBlockIds,
+          taskToFailedBlockIdsAndServer,
           failedTaskIds,
           threadPoolSize,
           threadKeepAliveTime);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -17,12 +17,15 @@
 
 package org.apache.spark.shuffle;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.writer.DataPusher;
+
+import org.apache.uniffle.common.ShuffleServerInfo;
 
 public class TestUtils {
 
@@ -33,8 +36,10 @@ public class TestUtils {
       Boolean isDriver,
       DataPusher dataPusher,
       Map<String, Set<Long>> successBlockIds,
-      Map<String, Set<Long>> failBlockIds) {
-    return new RssShuffleManager(conf, isDriver, dataPusher, successBlockIds, failBlockIds);
+      Map<String, Set<Long>> failBlockIds,
+      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer) {
+    return new RssShuffleManager(
+        conf, isDriver, dataPusher, successBlockIds, failBlockIds, taskToFailedBlockIdsAndServer);
   }
 
   public static boolean isMacOnAppleSilicon() {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -151,7 +151,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       String appId,
       Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
       Map<ShuffleServerInfo, List<Long>> serverToBlockIds,
-      Map<Long, AtomicInteger> blockIdsTracker,
+      Map<Long, List<ShuffleServerInfo>> blockIdsSendSuccessTracker,
+      Map<Long, List<ShuffleServerInfo>> blockIdsSendFailTracker,
       boolean allowFastFail,
       Supplier<Boolean> needCancelRequest) {
 
@@ -193,7 +194,11 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                     // mark a replica of block that has been sent
                     serverToBlockIds
                         .get(ssi)
-                        .forEach(block -> blockIdsTracker.get(block).incrementAndGet());
+                        .forEach(
+                            blockId ->
+                                blockIdsSendSuccessTracker
+                                    .computeIfAbsent(blockId, id -> Lists.newArrayList())
+                                    .add(ssi));
                     if (defectiveServers != null) {
                       defectiveServers.remove(ssi);
                     }
@@ -201,6 +206,13 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                       LOG.debug("{} successfully.", logMsg);
                     }
                   } else {
+                    serverToBlockIds
+                        .get(ssi)
+                        .forEach(
+                            blockId ->
+                                blockIdsSendFailTracker
+                                    .computeIfAbsent(blockId, id -> Lists.newArrayList())
+                                    .add(ssi));
                     if (defectiveServers != null) {
                       defectiveServers.add(ssi);
                     }
@@ -208,6 +220,13 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                     return false;
                   }
                 } catch (Exception e) {
+                  serverToBlockIds
+                      .get(ssi)
+                      .forEach(
+                          blockId ->
+                              blockIdsSendFailTracker
+                                  .computeIfAbsent(blockId, id -> Lists.newArrayList())
+                                  .add(ssi));
                   if (defectiveServers != null) {
                     defectiveServers.add(ssi);
                   }
@@ -335,27 +354,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             false);
       }
     }
-
-    // maintain the count of blocks that have been sent to the server
-    // unnecessary to use concurrent hashmap here unless you need to insert or delete entries in
-    // other threads
-    // AtomicInteger is enough to reflect value changes in other threads
-    Map<Long, AtomicInteger> blockIdsTracker = Maps.newHashMap();
-    primaryServerToBlockIds
-        .values()
-        .forEach(
-            blockList ->
-                blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0))));
-    secondaryServerToBlockIds
-        .values()
-        .forEach(
-            blockList ->
-                blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0))));
-
-    Set<Long> failedBlockIds = Sets.newConcurrentHashSet();
-    Set<Long> successBlockIds = Sets.newConcurrentHashSet();
-    // if send block failed, the task will fail
-    // todo: better to have fallback solution when send to multiple servers
+    /** Records the ShuffleServer that successfully or failed to send blocks */
+    Map<Long, List<ShuffleServerInfo>> blockIdSendSuccessTracker = JavaUtils.newConcurrentMap();
+    Map<Long, List<ShuffleServerInfo>> blockIdsSendFailTracker = JavaUtils.newConcurrentMap();
 
     // sent the primary round of blocks.
     boolean isAllSuccess =
@@ -363,7 +364,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             appId,
             primaryServerToBlocks,
             primaryServerToBlockIds,
-            blockIdsTracker,
+            blockIdSendSuccessTracker,
+            blockIdsSendFailTracker,
             secondaryServerToBlocks.isEmpty(),
             needCancelRequest);
 
@@ -378,25 +380,31 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           appId,
           secondaryServerToBlocks,
           secondaryServerToBlockIds,
-          blockIdsTracker,
+          blockIdSendSuccessTracker,
+          blockIdsSendFailTracker,
           true,
           needCancelRequest);
     }
 
-    // check success and failed blocks according to the replicaWrite
-    blockIdsTracker
+    blockIdSendSuccessTracker
         .entrySet()
         .forEach(
-            blockCt -> {
-              long blockId = blockCt.getKey();
-              int count = blockCt.getValue().get();
-              if (count >= replicaWrite) {
-                successBlockIds.add(blockId);
+            successBlockId -> {
+              if (successBlockId.getValue().size() < replicaWrite) {
+                // Removes blocks that do not reach replicaWrite from the success queue
+                blockIdSendSuccessTracker.remove(successBlockId.getKey());
               } else {
-                failedBlockIds.add(blockId);
+                // If the replicaWrite to be sent is reached,
+                // no matter whether the block fails to be sent or not,
+                // the block is considered to have been sent successfully and is removed from the
+                // failed block tracker
+                blockIdsSendFailTracker.remove(successBlockId.getKey());
               }
             });
-    return new SendShuffleDataResult(successBlockIds, failedBlockIds);
+    return new SendShuffleDataResult(
+        blockIdSendSuccessTracker.keySet(),
+        blockIdsSendFailTracker.keySet(),
+        blockIdsSendFailTracker);
   }
 
   /**

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -17,16 +17,32 @@
 
 package org.apache.uniffle.client.response;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.util.JavaUtils;
 
 public class SendShuffleDataResult {
 
   private Set<Long> successBlockIds;
   private Set<Long> failedBlockIds;
+  private Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds;
 
   public SendShuffleDataResult(Set<Long> successBlockIds, Set<Long> failedBlockIds) {
     this.successBlockIds = successBlockIds;
     this.failedBlockIds = failedBlockIds;
+    this.sendFailedBlockIds = JavaUtils.newConcurrentMap();
+  }
+
+  public SendShuffleDataResult(
+      Set<Long> successBlockIds,
+      Set<Long> failedBlockIds,
+      Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds) {
+    this.successBlockIds = successBlockIds;
+    this.failedBlockIds = failedBlockIds;
+    this.sendFailedBlockIds = sendFailedBlockIds;
   }
 
   public Set<Long> getSuccessBlockIds() {
@@ -35,5 +51,9 @@ public class SendShuffleDataResult {
 
   public Set<Long> getFailedBlockIds() {
     return failedBlockIds;
+  }
+
+  public Map<Long, List<ShuffleServerInfo>> getSendFailedBlockIds() {
+    return sendFailedBlockIds;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The ShuffleServer corresponding to the block that failed to be sent needs to be reported.

Ⅰ. Overall objective:

1. During the shuffle write phase, the ShuffleServer reports faulty nodes and reallocates the ShuffleServer list;
2. Triggers a Stage level retry of SPARK. The shuffleServer node is excluded and reallocated before the retry.

Ⅱ. Implementation logic diagram:

![image](https://github.com/apache/incubator-uniffle/assets/33595968/866c8292-e0ff-4532-b519-02f424f4c2fc)

Ⅲ. As shown in the picture above:

1. During Shuffle registration, obtain the ShuffleServer list to be written through the RPC interface of a Coordinator Client by following the solid blue line step. The list is bound using ShuffleID.
2, the Task of Stage starts, solid steps, in accordance with the green by ShuffleManager Client RPC interface gets to be written for shuffleIdToShuffleHandleInfo ShuffleServer list;
3. In the Stage, if Task fails to write blocks to the ShuffleServer, press the steps in red to report ShuffleServer to FailedShuffleServerList in RSSShuffleManager through the RPC interface.
4. FailedShuffleServerList records the number of ShuffleServer failures. After the number of failures reaches the maximum number of retries of the Task level, follow the steps in dotted orange lines. Through the RPC interface of a Coordinator Client, obtain the list of ShuffleServer files to be written (the ShuffleServer files that fail to be written are excluded). After obtaining the list, go to Step 5 of the dotted orange line. Throwing a FetchFailed Exception triggers a stage-level retry for SPARK;
5. Attempt 1 is generated by the SPARK Stage level again. Pull the corresponding ShuffleServer list according to the green dotted line.

### Why are the changes needed?

Reports the ShuffleServer corresponding to the block that failed to be sent

Fix: #825 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT
