### PR TITLE
[#1132] improvement(spark): Unregister shuffle explicitly when Spark application is stopped.

### DIFF
--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -496,5 +496,8 @@ public class SortWriteBufferManagerTest {
 
     @Override
     public void unregisterShuffle(String appId, int shuffleId) {}
+
+    @Override
+    public void unregisterShuffle(String appId) {}
   }
 }

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -560,6 +560,9 @@ public class FetcherTest {
 
     @Override
     public void unregisterShuffle(String appId, int shuffleId) {}
+
+    @Override
+    public void unregisterShuffle(String appId) {}
   }
 
   static class MockedShuffleReadClient implements ShuffleReadClient {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -540,7 +540,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         LOG.warn("Errors on closing data pusher", e);
       }
     }
-    shuffleWriteClient.close();
+    if (shuffleWriteClient != null) {
+      // Unregister shuffle before closing shuffle write client.
+      shuffleWriteClient.unregisterShuffle(appId);
+      shuffleWriteClient.close();
+    }
   }
 
   @Override

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -772,6 +772,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       heartBeatScheduledExecutorService.shutdownNow();
     }
     if (shuffleWriteClient != null) {
+      // Unregister shuffle before closing shuffle write client.
+      shuffleWriteClient.unregisterShuffle(getAppId());
       shuffleWriteClient.close();
     }
     if (dataPusher != null) {

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -655,5 +655,8 @@ public class WriteBufferManagerTest {
 
     @Override
     public void unregisterShuffle(String appId, int shuffleId) {}
+
+    @Override
+    public void unregisterShuffle(String appId) {}
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -95,4 +95,6 @@ public interface ShuffleWriteClient {
   void close();
 
   void unregisterShuffle(String appId, int shuffleId);
+
+  void unregisterShuffle(String appId);
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -995,6 +995,15 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
   }
 
+  @Override
+  public void unregisterShuffle(String appId) {
+    Map<Integer, Set<ShuffleServerInfo>> appServerMap = shuffleServerInfoMap.get(appId);
+    if (appServerMap == null) {
+      return;
+    }
+    appServerMap.keySet().forEach(shuffleId -> unregisterShuffle(appId, shuffleId));
+  }
+
   private void throwExceptionIfNecessary(ClientResponse response, String errorMsg) {
     if (response != null && response.getStatusCode() != StatusCode.SUCCESS) {
       LOG.error(errorMsg);

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -116,6 +116,12 @@ public class ShuffleWriteClientImplTest {
     shuffleWriteClient.addShuffleServer(appId1, 1, server1);
     shuffleWriteClient.unregisterShuffle(appId1, 1);
     assertEquals(1, shuffleWriteClient.getAllShuffleServers(appId1).size());
+    shuffleWriteClient.unregisterShuffle(appId1);
+    assertEquals(0, shuffleWriteClient.getAllShuffleServers(appId1).size());
+    shuffleWriteClient.addShuffleServer(appId2, 2, server1);
+    assertEquals(2, shuffleWriteClient.getAllShuffleServers(appId2).size());
+    shuffleWriteClient.unregisterShuffle(appId2);
+    assertEquals(0, shuffleWriteClient.getAllShuffleServers(appId2).size());
   }
 
   @Test


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Unregister shuffle explicitly when Spark application is stopped.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/1132

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add more test cases.
