### PR TITLE
[#825][part-3] feat(spark): Get the ShuffleServer corresponding to the partition from ShuffleManager

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.shuffle.manager;
 
 import org.apache.spark.SparkException;
+import org.apache.spark.shuffle.ShuffleHandleInfo;
 
 /**
  * This is a proxy interface that mainly delegates the un-registration of shuffles to the
@@ -54,4 +55,12 @@ public interface RssShuffleManagerInterface {
    * @throws SparkException
    */
   void unregisterAllMapOutput(int shuffleId) throws SparkException;
+
+  /**
+   * Get ShuffleHandleInfo with ShuffleId
+   *
+   * @param shuffleId
+   * @return ShuffleHandleInfo
+   */
+  ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId);
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -33,7 +33,6 @@ import scala.collection.Iterator;
 import scala.collection.Seq;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.ShuffleDependency;
@@ -52,14 +51,21 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
+import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
@@ -104,10 +110,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private DataPusher dataPusher;
   private final int maxConcurrencyPerPartitionToWrite;
 
-  private final Map<Integer, Integer> shuffleIdToPartitionNum = Maps.newConcurrentMap();
-  private final Map<Integer, Integer> shuffleIdToNumMapTasks = Maps.newConcurrentMap();
+  private final Map<Integer, Integer> shuffleIdToPartitionNum = JavaUtils.newConcurrentMap();
+  private final Map<Integer, Integer> shuffleIdToNumMapTasks = JavaUtils.newConcurrentMap();
   private GrpcServer shuffleManagerServer;
   private ShuffleManagerGrpcService service;
+  private ShuffleManagerClient shuffleManagerClient;
+  /**
+   * Mapping between ShuffleId and ShuffleServer list. ShuffleServer list is dynamically allocated.
+   * ShuffleServer is not obtained from RssShuffleHandle, but from this mapping.
+   */
+  private Map<Integer, ShuffleHandleInfo> shuffleIdToShuffleHandleInfo =
+      JavaUtils.newConcurrentMap();
+  /** Whether to enable the dynamic shuffleServer function rewrite and reread functions */
+  private boolean rssResubmitStage;
 
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
     if (sparkConf.getBoolean("spark.sql.adaptive.enabled", false)) {
@@ -183,12 +198,14 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     // shuffle cluster, we don't need shuffle data locality
     sparkConf.set("spark.shuffle.reduceLocality.enabled", "false");
     LOG.info("Disable shuffle data locality in RssShuffleManager.");
+    this.rssResubmitStage =
+        rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
+            && RssSparkShuffleUtils.isStageResubmitSupported();
     if (!sparkConf.getBoolean(RssSparkConfig.RSS_TEST_FLAG.key(), false)) {
       if (isDriver) {
         heartBeatScheduledExecutorService =
             ThreadUtils.getDaemonSingleThreadScheduledExecutor("rss-heartbeat");
-        if (sparkConf.get(RssSparkConfig.RSS_RESUBMIT_STAGE)
-            && RssSparkShuffleUtils.isStageResubmitSupported()) {
+        if (rssResubmitStage) {
           LOG.info("stage resubmit is supported and enabled");
           // start shuffle manager server
           rssConf.set(RPC_SERVER_PORT, 0);
@@ -330,6 +347,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
     shuffleIdToPartitionNum.putIfAbsent(shuffleId, dependency.partitioner().numPartitions());
     shuffleIdToNumMapTasks.putIfAbsent(shuffleId, dependency.rdd().partitions().length);
+    if (rssResubmitStage) {
+      ShuffleHandleInfo handleInfo =
+          new ShuffleHandleInfo(shuffleId, partitionToServers, remoteStorage);
+      shuffleIdToShuffleHandleInfo.put(shuffleId, handleInfo);
+    }
     Broadcast<ShuffleHandleInfo> hdlInfoBd =
         RssSparkShuffleUtils.broadcastShuffleHdlInfo(
             RssSparkShuffleUtils.getActiveSparkContext(),
@@ -421,6 +443,15 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
       int shuffleId = rssHandle.getShuffleId();
       String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
+      ShuffleHandleInfo shuffleHandleInfo;
+      if (rssResubmitStage) {
+        // Get the ShuffleServer list from the Driver based on the shuffleId
+        shuffleHandleInfo = getRemoteShuffleHandleInfo(shuffleId);
+      } else {
+        shuffleHandleInfo =
+            new ShuffleHandleInfo(
+                shuffleId, rssHandle.getPartitionToServers(), rssHandle.getRemoteStorage());
+      }
       ShuffleWriteMetrics writeMetrics = context.taskMetrics().shuffleWriteMetrics();
       return new RssShuffleWriter<>(
           rssHandle.getAppId(),
@@ -433,7 +464,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
           shuffleWriteClient,
           rssHandle,
           this::markFailedTask,
-          context);
+          context,
+          shuffleHandleInfo);
     } else {
       throw new RssException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }
@@ -463,8 +495,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
               + startPartition
               + "]");
       start = System.currentTimeMillis();
+      ShuffleHandleInfo shuffleHandleInfo;
+      if (rssResubmitStage) {
+        // Get the ShuffleServer list from the Driver based on the shuffleId
+        shuffleHandleInfo = getRemoteShuffleHandleInfo(shuffleId);
+      } else {
+        shuffleHandleInfo =
+            new ShuffleHandleInfo(
+                shuffleId,
+                rssShuffleHandle.getPartitionToServers(),
+                rssShuffleHandle.getRemoteStorage());
+      }
       Map<Integer, List<ShuffleServerInfo>> partitionToServers =
-          rssShuffleHandle.getPartitionToServers();
+          shuffleHandleInfo.getPartitionToServers();
       Roaring64NavigableMap blockIdBitmap =
           getShuffleResult(
               clientType,
@@ -501,7 +544,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
           partitionNum,
           blockIdBitmap,
           taskIdBitmap,
-          RssSparkConfig.toRssConf(sparkConf));
+          RssSparkConfig.toRssConf(sparkConf),
+          partitionToServers);
     } else {
       throw new RssException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }
@@ -711,5 +755,43 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       result = Collections.emptyMap();
     }
     return result;
+  }
+
+  @Override
+  public ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId) {
+    return shuffleIdToShuffleHandleInfo.get(shuffleId);
+  }
+
+  private ShuffleManagerClient createShuffleManagerClient(String host, int port) {
+    // Host can be inferred from `spark.driver.bindAddress`, which would be set when SparkContext is
+    // constructed.
+    return ShuffleManagerClientFactory.getInstance()
+        .createShuffleManagerClient(ClientType.GRPC, host, port);
+  }
+
+  /**
+   * Get the ShuffleServer list from the Driver based on the shuffleId
+   *
+   * @param shuffleId shuffleId
+   * @return ShuffleHandleInfo
+   */
+  private ShuffleHandleInfo getRemoteShuffleHandleInfo(int shuffleId) {
+    ShuffleHandleInfo shuffleHandleInfo;
+    RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
+    String driver = rssConf.getString("driver.host", "");
+    int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);
+    if (shuffleManagerClient == null) {
+      shuffleManagerClient = createShuffleManagerClient(driver, port);
+    }
+    RssPartitionToShuffleServerRequest rssPartitionToShuffleServerRequest =
+        new RssPartitionToShuffleServerRequest(shuffleId);
+    RssPartitionToShuffleServerResponse rpcPartitionToShufflerServer =
+        shuffleManagerClient.getPartitionToShufflerServer(rssPartitionToShuffleServerRequest);
+    shuffleHandleInfo =
+        new ShuffleHandleInfo(
+            shuffleId,
+            rpcPartitionToShufflerServer.getPartitionToServers(),
+            rpcPartitionToShufflerServer.getRemoteStorageInfo());
+    return shuffleHandleInfo;
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle.reader;
 
 import java.util.List;
+import java.util.Map;
 
 import scala.Function0;
 import scala.Option;
@@ -83,7 +84,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       int partitionNum,
       Roaring64NavigableMap blockIdBitmap,
       Roaring64NavigableMap taskIdBitmap,
-      RssConf rssConf) {
+      RssConf rssConf,
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers) {
     this.appId = rssShuffleHandle.getAppId();
     this.startPartition = startPartition;
     this.endPartition = endPartition;
@@ -98,8 +100,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     this.blockIdBitmap = blockIdBitmap;
     this.taskIdBitmap = taskIdBitmap;
     this.hadoopConf = hadoopConf;
-    this.shuffleServerInfoList =
-        (List<ShuffleServerInfo>) (rssShuffleHandle.getPartitionToServers().get(startPartition));
+    this.shuffleServerInfoList = (List<ShuffleServerInfo>) (partitionToServers.get(startPartition));
     this.rssConf = rssConf;
     expectedTaskIdsBitmapFilterEnable = shuffleServerInfoList.size() > 1;
   }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -98,7 +98,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 10,
                 blockIdBitmap,
                 taskIdBitmap,
-                rssConf));
+                rssConf,
+                partitionToServers));
 
     validateResult(rssShuffleReaderSpy.read(), expectedData, 10);
   }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -37,6 +37,7 @@ import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -45,6 +46,7 @@ import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
 import org.apache.spark.shuffle.RssShuffleManager;
 import org.apache.spark.shuffle.RssSparkConfig;
+import org.apache.spark.shuffle.ShuffleHandleInfo;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
@@ -93,6 +95,8 @@ public class RssShuffleWriterTest {
     when(mockPartitioner.numPartitions()).thenReturn(2);
     when(mockHandle.getPartitionToServers()).thenReturn(Maps.newHashMap());
     TaskMemoryManager mockTaskMemoryManager = mock(TaskMemoryManager.class);
+    TaskContext contextMock = mock(TaskContext.class);
+    ShuffleHandleInfo mockShuffleHandleInfo = mock(ShuffleHandleInfo.class);
 
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
     WriteBufferManager bufferManager =
@@ -119,7 +123,9 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
-            mockHandle);
+            mockHandle,
+            mockShuffleHandleInfo,
+            contextMock);
 
     // case 1: all blocks are sent successfully
     manager.addSuccessBlockIds(taskId, Sets.newHashSet(1L, 2L, 3L));
@@ -274,6 +280,8 @@ public class RssShuffleWriterTest {
             null);
     WriteBufferManager bufferManagerSpy = spy(bufferManager);
     doReturn(1000000L).when(bufferManagerSpy).acquireMemory(anyLong());
+    TaskContext contextMock = mock(TaskContext.class);
+    ShuffleHandleInfo mockShuffleHandleInfo = mock(ShuffleHandleInfo.class);
 
     RssShuffleWriter<String, String, String> rssShuffleWriter =
         new RssShuffleWriter<>(
@@ -286,7 +294,9 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
-            mockHandle);
+            mockHandle,
+            mockShuffleHandleInfo,
+            contextMock);
 
     RssShuffleWriter<String, String, String> rssShuffleWriterSpy = spy(rssShuffleWriter);
     doNothing().when(rssShuffleWriterSpy).sendCommit();
@@ -382,6 +392,8 @@ public class RssShuffleWriterTest {
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     when(mockHandle.getDependency()).thenReturn(mockDependency);
     ShuffleWriteClient mockWriteClient = mock(ShuffleWriteClient.class);
+    TaskContext contextMock = mock(TaskContext.class);
+    ShuffleHandleInfo mockShuffleHandleInfo = mock(ShuffleHandleInfo.class);
 
     RssShuffleWriter<String, String, String> writer =
         new RssShuffleWriter<>(
@@ -394,7 +406,9 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockWriteClient,
-            mockHandle);
+            mockHandle,
+            mockShuffleHandleInfo,
+            contextMock);
     List<ShuffleBlockInfo> shuffleBlockInfoList = createShuffleBlockList(1, 31);
     writer.postBlockEvent(shuffleBlockInfoList);
     Thread.sleep(500);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -36,7 +36,6 @@ import scala.collection.Iterator;
 import scala.collection.Seq;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.conf.Configuration;
@@ -59,9 +58,15 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
+import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.util.ClientUtils;
+import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
@@ -111,8 +116,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private Set<String> failedTaskIds = Sets.newConcurrentHashSet();
   private DataPusher dataPusher;
 
-  private final Map<Integer, Integer> shuffleIdToPartitionNum = Maps.newConcurrentMap();
-  private final Map<Integer, Integer> shuffleIdToNumMapTasks = Maps.newConcurrentMap();
+  private final Map<Integer, Integer> shuffleIdToPartitionNum = JavaUtils.newConcurrentMap();
+  private final Map<Integer, Integer> shuffleIdToNumMapTasks = JavaUtils.newConcurrentMap();
   private ShuffleManagerGrpcService service;
   private GrpcServer shuffleManagerServer;
 
@@ -120,6 +125,15 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   protected SparkConf sparkConf;
 
   protected ShuffleWriteClient shuffleWriteClient;
+
+  private ShuffleManagerClient shuffleManagerClient;
+  /**
+   * Mapping between ShuffleId and ShuffleServer list. ShuffleServer list is dynamically allocated.
+   * ShuffleServer is not obtained from RssShuffleHandle, but from this mapping.
+   */
+  private Map<Integer, ShuffleHandleInfo> shuffleIdToShuffleHandleInfo;
+  /** Whether to enable the dynamic shuffleServer function rewrite and reread functions */
+  private boolean rssResubmitStage;
 
   public RssShuffleManager(SparkConf conf, boolean isDriver) {
     this.sparkConf = conf;
@@ -209,11 +223,13 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
     taskToFailedBlockIds = JavaUtils.newConcurrentMap();
     this.taskToFailedBlockIdsAndServer = JavaUtils.newConcurrentMap();
+    this.rssResubmitStage =
+        rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
+            && RssSparkShuffleUtils.isStageResubmitSupported();
     if (isDriver) {
       heartBeatScheduledExecutorService =
           ThreadUtils.getDaemonSingleThreadScheduledExecutor("rss-heartbeat");
-      if (sparkConf.get(RssSparkConfig.RSS_RESUBMIT_STAGE)
-          && RssSparkShuffleUtils.isStageResubmitSupported()) {
+      if (rssResubmitStage) {
         LOG.info("stage resubmit is supported and enabled");
         // start shuffle manager server
         rssConf.set(RPC_SERVER_PORT, 0);
@@ -244,6 +260,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             failedTaskIds,
             poolSize,
             keepAliveTime);
+    this.shuffleIdToShuffleHandleInfo = JavaUtils.newConcurrentMap();
   }
 
   public CompletableFuture<Long> sendData(AddBlockEvent event) {
@@ -428,6 +445,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
 
     shuffleIdToPartitionNum.putIfAbsent(shuffleId, dependency.partitioner().numPartitions());
     shuffleIdToNumMapTasks.putIfAbsent(shuffleId, dependency.rdd().partitions().length);
+    if (rssResubmitStage) {
+      ShuffleHandleInfo handleInfo =
+          new ShuffleHandleInfo(shuffleId, partitionToServers, remoteStorage);
+      shuffleIdToShuffleHandleInfo.put(shuffleId, handleInfo);
+    }
     Broadcast<ShuffleHandleInfo> hdlInfoBd =
         RssSparkShuffleUtils.broadcastShuffleHdlInfo(
             RssSparkShuffleUtils.getActiveSparkContext(),
@@ -454,14 +476,22 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     RssShuffleHandle<K, V, ?> rssHandle = (RssShuffleHandle<K, V, ?>) handle;
     setPusherAppId(rssHandle);
     int shuffleId = rssHandle.getShuffleId();
-    String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
-
     ShuffleWriteMetrics writeMetrics;
     if (metrics != null) {
       writeMetrics = new WriteMetrics(metrics);
     } else {
       writeMetrics = context.taskMetrics().shuffleWriteMetrics();
     }
+    ShuffleHandleInfo shuffleHandleInfo;
+    if (rssResubmitStage) {
+      // Get the ShuffleServer list from the Driver based on the shuffleId
+      shuffleHandleInfo = getRemoteShuffleHandleInfo(shuffleId);
+    } else {
+      shuffleHandleInfo =
+          new ShuffleHandleInfo(
+              shuffleId, rssHandle.getPartitionToServers(), rssHandle.getRemoteStorage());
+    }
+    String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
     LOG.info("RssHandle appId {} shuffleId {} ", rssHandle.getAppId(), rssHandle.getShuffleId());
     return new RssShuffleWriter<>(
         rssHandle.getAppId(),
@@ -474,7 +504,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         shuffleWriteClient,
         rssHandle,
         this::markFailedTask,
-        context);
+        context,
+        shuffleHandleInfo);
   }
 
   public void setPusherAppId(RssShuffleHandle rssShuffleHandle) {
@@ -582,8 +613,19 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     RssShuffleHandle<K, ?, C> rssShuffleHandle = (RssShuffleHandle<K, ?, C>) handle;
     final int partitionNum = rssShuffleHandle.getDependency().partitioner().numPartitions();
     int shuffleId = rssShuffleHandle.getShuffleId();
+    ShuffleHandleInfo shuffleHandleInfo;
+    if (rssResubmitStage) {
+      // Get the ShuffleServer list from the Driver based on the shuffleId
+      shuffleHandleInfo = getRemoteShuffleHandleInfo(shuffleId);
+    } else {
+      shuffleHandleInfo =
+          new ShuffleHandleInfo(
+              shuffleId,
+              rssShuffleHandle.getPartitionToServers(),
+              rssShuffleHandle.getRemoteStorage());
+    }
     Map<Integer, List<ShuffleServerInfo>> allPartitionToServers =
-        rssShuffleHandle.getPartitionToServers();
+        shuffleHandleInfo.getPartitionToServers();
     Map<Integer, List<ShuffleServerInfo>> requirePartitionToServers =
         allPartitionToServers.entrySet().stream()
             .filter(x -> x.getKey() >= startPartition && x.getKey() < endPartition)
@@ -638,7 +680,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         taskIdBitmap,
         readMetrics,
         RssSparkConfig.toRssConf(sparkConf),
-        dataDistributionType);
+        dataDistributionType,
+        allPartitionToServers);
   }
 
   @SuppressFBWarnings("REC_CATCH_EXCEPTION")
@@ -1010,5 +1053,43 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       result = Collections.emptyMap();
     }
     return result;
+  }
+
+  @Override
+  public ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId) {
+    return shuffleIdToShuffleHandleInfo.get(shuffleId);
+  }
+
+  private ShuffleManagerClient createShuffleManagerClient(String host, int port) {
+    // Host can be inferred from `spark.driver.bindAddress`, which would be set when SparkContext is
+    // constructed.
+    return ShuffleManagerClientFactory.getInstance()
+        .createShuffleManagerClient(ClientType.GRPC, host, port);
+  }
+
+  /**
+   * Get the ShuffleServer list from the Driver based on the shuffleId
+   *
+   * @param shuffleId shuffleId
+   * @return ShuffleHandleInfo
+   */
+  private ShuffleHandleInfo getRemoteShuffleHandleInfo(int shuffleId) {
+    ShuffleHandleInfo shuffleHandleInfo;
+    RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
+    String driver = rssConf.getString("driver.host", "");
+    int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);
+    if (shuffleManagerClient == null) {
+      shuffleManagerClient = createShuffleManagerClient(driver, port);
+    }
+    RssPartitionToShuffleServerRequest rssPartitionToShuffleServerRequest =
+        new RssPartitionToShuffleServerRequest(shuffleId);
+    RssPartitionToShuffleServerResponse rpcPartitionToShufflerServer =
+        shuffleManagerClient.getPartitionToShufflerServer(rssPartitionToShuffleServerRequest);
+    shuffleHandleInfo =
+        new ShuffleHandleInfo(
+            shuffleId,
+            rpcPartitionToShufflerServer.getPartitionToServers(),
+            rpcPartitionToShufflerServer.getRemoteStorageInfo());
+    return shuffleHandleInfo;
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -95,7 +95,8 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       Roaring64NavigableMap taskIdBitmap,
       ShuffleReadMetrics readMetrics,
       RssConf rssConf,
-      ShuffleDataDistributionType dataDistributionType) {
+      ShuffleDataDistributionType dataDistributionType,
+      Map<Integer, List<ShuffleServerInfo>> allPartitionToServers) {
     this.appId = rssShuffleHandle.getAppId();
     this.startPartition = startPartition;
     this.endPartition = endPartition;
@@ -113,7 +114,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     this.taskIdBitmap = taskIdBitmap;
     this.hadoopConf = hadoopConf;
     this.readMetrics = readMetrics;
-    this.partitionToShuffleServers = rssShuffleHandle.getPartitionToServers();
+    this.partitionToShuffleServers = allPartitionToServers;
     this.rssConf = rssConf;
     this.dataDistributionType = dataDistributionType;
   }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -109,7 +109,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                partitionToServers));
     validateResult(rssShuffleReaderSpy.read(), expectedData, 10);
 
     writeTestData(
@@ -131,7 +132,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                partitionToServers));
     validateResult(rssShuffleReaderSpy1.read(), expectedData, 18);
 
     RssShuffleReader<String, String> rssShuffleReaderSpy2 =
@@ -150,7 +152,8 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 Roaring64NavigableMap.bitmapOf(),
                 new ShuffleReadMetrics(),
                 rssConf,
-                ShuffleDataDistributionType.NORMAL));
+                ShuffleDataDistributionType.NORMAL,
+                partitionToServers));
     validateResult(rssShuffleReaderSpy2.read(), Maps.newHashMap(), 0);
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -18,6 +18,10 @@
 package org.apache.uniffle.common;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.uniffle.proto.RssProtos;
 
 public class ShuffleServerInfo implements Serializable {
 
@@ -107,5 +111,38 @@ public class ShuffleServerInfo implements Serializable {
           + grpcPort
           + "]}";
     }
+  }
+
+  private static ShuffleServerInfo convertToShuffleServerId(
+      RssProtos.ShuffleServerId shuffleServerId) {
+    ShuffleServerInfo shuffleServerInfo =
+        new ShuffleServerInfo(
+            shuffleServerId.getId(), shuffleServerId.getIp(), shuffleServerId.getPort(), 0);
+    return shuffleServerInfo;
+  }
+
+  private static RssProtos.ShuffleServerId convertToShuffleServerId(
+      ShuffleServerInfo shuffleServerInfo) {
+    RssProtos.ShuffleServerId shuffleServerId =
+        RssProtos.ShuffleServerId.newBuilder()
+            .setId(shuffleServerInfo.getId())
+            .setIp(shuffleServerInfo.getHost())
+            .setPort(shuffleServerInfo.grpcPort)
+            .setNettyPort(shuffleServerInfo.nettyPort)
+            .build();
+    return shuffleServerId;
+  }
+
+  public static List<ShuffleServerInfo> fromProto(List<RssProtos.ShuffleServerId> servers) {
+    return servers.stream()
+        .map(server -> convertToShuffleServerId(server))
+        .collect(Collectors.toList());
+  }
+
+  public static List<RssProtos.ShuffleServerId> toProto(
+      List<ShuffleServerInfo> shuffleServerInfos) {
+    return shuffleServerInfos.stream()
+        .map(server -> convertToShuffleServerId(server))
+        .collect(Collectors.toList());
   }
 }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
@@ -47,6 +47,7 @@ public class RSSStageResubmitTest extends SparkIntegrationTestBase {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     dynamicConf.put(
         RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_RESUBMIT_STAGE, "true");
+    dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();
@@ -81,6 +82,8 @@ public class RSSStageResubmitTest extends SparkIntegrationTestBase {
 
   @Override
   public void updateSparkConfCustomer(SparkConf sparkConf) {
+    sparkConf.set(
+        RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_RESUBMIT_STAGE, "true");
     sparkConf.set("spark.task.maxFailures", String.valueOf(maxTaskFailures));
   }
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
@@ -19,10 +19,21 @@ package org.apache.uniffle.client.api;
 
 import java.io.Closeable;
 
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 
 public interface ShuffleManagerClient extends Closeable {
   RssReportShuffleFetchFailureResponse reportShuffleFetchFailure(
       RssReportShuffleFetchFailureRequest request);
+
+  /**
+   * Gets the mapping between partitions and ShuffleServer from the ShuffleManager server
+   *
+   * @param req request
+   * @return RssPartitionToShuffleServerResponse
+   */
+  RssPartitionToShuffleServerResponse getPartitionToShufflerServer(
+      RssPartitionToShuffleServerRequest req);
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -23,10 +23,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleManagerClient;
+import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
+import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureRequest;
 import org.apache.uniffle.proto.RssProtos.ReportShuffleFetchFailureResponse;
 import org.apache.uniffle.proto.ShuffleManagerGrpc;
@@ -73,5 +76,16 @@ public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManag
       LOG.warn(msg, e);
       throw new RssException(msg, e);
     }
+  }
+
+  @Override
+  public RssPartitionToShuffleServerResponse getPartitionToShufflerServer(
+      RssPartitionToShuffleServerRequest req) {
+    RssProtos.PartitionToShuffleServerRequest protoRequest = req.toProto();
+    RssProtos.PartitionToShuffleServerResponse partitionToShufflerServer =
+        getBlockingStub().getPartitionToShufflerServer(protoRequest);
+    RssPartitionToShuffleServerResponse rssPartitionToShuffleServerResponse =
+        RssPartitionToShuffleServerResponse.fromProto(partitionToShufflerServer);
+    return rssPartitionToShuffleServerResponse;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssPartitionToShuffleServerRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssPartitionToShuffleServerRequest.java
@@ -15,43 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.shuffle.manager;
+package org.apache.uniffle.client.request;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import org.apache.uniffle.proto.RssProtos;
 
-import org.apache.spark.shuffle.ShuffleHandleInfo;
+public class RssPartitionToShuffleServerRequest {
+  private int shuffleId;
 
-public class DummyRssShuffleManager implements RssShuffleManagerInterface {
-  public Set<Integer> unregisteredShuffleIds = new LinkedHashSet<>();
-
-  @Override
-  public String getAppId() {
-    return "testAppId";
+  public RssPartitionToShuffleServerRequest(int shuffleId) {
+    this.shuffleId = shuffleId;
   }
 
-  @Override
-  public int getMaxFetchFailures() {
-    return 2;
+  public int getShuffleId() {
+    return shuffleId;
   }
 
-  @Override
-  public int getPartitionNum(int shuffleId) {
-    return 16;
-  }
-
-  @Override
-  public int getNumMaps(int shuffleId) {
-    return 8;
-  }
-
-  @Override
-  public void unregisterAllMapOutput(int shuffleId) {
-    unregisteredShuffleIds.add(shuffleId);
-  }
-
-  @Override
-  public ShuffleHandleInfo getShuffleHandleInfoByShuffleId(int shuffleId) {
-    return null;
+  public RssProtos.PartitionToShuffleServerRequest toProto() {
+    RssProtos.PartitionToShuffleServerRequest.Builder builder =
+        RssProtos.PartitionToShuffleServerRequest.newBuilder();
+    builder.setShuffleId(shuffleId);
+    return builder.build();
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssPartitionToShuffleServerResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssPartitionToShuffleServerResponse.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
+
+public class RssPartitionToShuffleServerResponse extends ClientResponse {
+
+  private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+  private Set<ShuffleServerInfo> shuffleServersForData;
+  private RemoteStorageInfo remoteStorageInfo;
+
+  public RssPartitionToShuffleServerResponse(
+      StatusCode statusCode,
+      String message,
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      Set<ShuffleServerInfo> shuffleServersForData,
+      RemoteStorageInfo remoteStorageInfo) {
+    super(statusCode, message);
+    this.partitionToServers = partitionToServers;
+    this.remoteStorageInfo = remoteStorageInfo;
+    this.shuffleServersForData = shuffleServersForData;
+  }
+
+  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+    return partitionToServers;
+  }
+
+  public Set<ShuffleServerInfo> getShuffleServersForData() {
+    return shuffleServersForData;
+  }
+
+  public RemoteStorageInfo getRemoteStorageInfo() {
+    return remoteStorageInfo;
+  }
+
+  public static RssPartitionToShuffleServerResponse fromProto(
+      RssProtos.PartitionToShuffleServerResponse response) {
+    Map<Integer, RssProtos.GetShuffleServerListResponse> partitionToShuffleServerMap =
+        response.getPartitionToShuffleServerMap();
+    Map<Integer, List<ShuffleServerInfo>> rpcPartitionToShuffleServerInfos = Maps.newHashMap();
+    Set<Map.Entry<Integer, RssProtos.GetShuffleServerListResponse>> entries =
+        partitionToShuffleServerMap.entrySet();
+    for (Map.Entry<Integer, RssProtos.GetShuffleServerListResponse> entry : entries) {
+      Integer partitionId = entry.getKey();
+      List<ShuffleServerInfo> shuffleServerInfos = Lists.newArrayList();
+      List<? extends RssProtos.ShuffleServerIdOrBuilder> serversOrBuilderList =
+          entry.getValue().getServersOrBuilderList();
+      for (RssProtos.ShuffleServerIdOrBuilder shuffleServerIdOrBuilder : serversOrBuilderList) {
+        shuffleServerInfos.add(
+            new ShuffleServerInfo(
+                shuffleServerIdOrBuilder.getId(),
+                shuffleServerIdOrBuilder.getIp(),
+                shuffleServerIdOrBuilder.getPort(),
+                shuffleServerIdOrBuilder.getNettyPort()));
+      }
+
+      rpcPartitionToShuffleServerInfos.put(partitionId, shuffleServerInfos);
+    }
+    Set<ShuffleServerInfo> rpcShuffleServersForData = Sets.newHashSet();
+    for (List<ShuffleServerInfo> ssis : rpcPartitionToShuffleServerInfos.values()) {
+      rpcShuffleServersForData.addAll(ssis);
+    }
+    RssProtos.RemoteStorageInfo protoRemoteStorageInfo = response.getRemoteStorageInfo();
+    RemoteStorageInfo rpcRemoteStorageInfo =
+        new RemoteStorageInfo(
+            protoRemoteStorageInfo.getPath(), protoRemoteStorageInfo.getConfItemsMap());
+    return new RssPartitionToShuffleServerResponse(
+        StatusCode.valueOf(response.getStatus().name()),
+        response.getMsg(),
+        rpcPartitionToShuffleServerInfos,
+        rpcShuffleServersForData,
+        rpcRemoteStorageInfo);
+  }
+}

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -497,6 +497,8 @@ message CancelDecommissionResponse {
 // per application.
 service ShuffleManager {
   rpc reportShuffleFetchFailure (ReportShuffleFetchFailureRequest) returns (ReportShuffleFetchFailureResponse);
+  // Gets the mapping between partitions and ShuffleServer from the ShuffleManager server
+  rpc getPartitionToShufflerServer(PartitionToShuffleServerRequest) returns (PartitionToShuffleServerResponse);
 }
 
 message ReportShuffleFetchFailureRequest {
@@ -515,4 +517,20 @@ message ReportShuffleFetchFailureResponse {
   StatusCode status = 1;
   bool reSubmitWholeStage = 2;
   string msg = 3;
+}
+
+message PartitionToShuffleServerRequest {
+  int32 shuffleId = 2;
+}
+
+message PartitionToShuffleServerResponse {
+  StatusCode status = 1;
+  map<int32,GetShuffleServerListResponse> partitionToShuffleServer = 2;
+  RemoteStorageInfo remote_storage_info = 3;
+  string msg = 4;
+}
+
+message RemoteStorageInfo{
+  string path = 1;
+  map<string, string> confItems = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

ShuffleReader and ShuffleWriter get the ShuffleServer corresponding to the partition from ShuffleManager

Ⅰ. Overall objective:

1. During the shuffle write phase, the ShuffleServer reports faulty nodes and reallocates the ShuffleServer list;
2. Triggers a Stage level retry of SPARK. The shuffleServer node is excluded and reallocated before the retry.

Ⅱ. Implementation logic diagram:

![image](https://github.com/apache/incubator-uniffle/assets/33595968/866c8292-e0ff-4532-b519-02f424f4c2fc)

Ⅲ. As shown in the picture above:

1. During Shuffle registration, obtain the ShuffleServer list to be written through the RPC interface of a Coordinator Client by following the solid blue line step. The list is bound using ShuffleID.
2, the Task of Stage starts, solid steps, in accordance with the green by ShuffleManager Client RPC interface gets to be written for shuffleIdToShuffleHandleInfo ShuffleServer list;
3. In the Stage, if Task fails to write blocks to the ShuffleServer, press the steps in red to report ShuffleServer to FailedShuffleServerList in RSSShuffleManager through the RPC interface.
4. FailedShuffleServerList records the number of ShuffleServer failures. After the number of failures reaches the maximum number of retries of the Task level, follow the steps in dotted orange lines. Through the RPC interface of a Coordinator Client, obtain the list of ShuffleServer files to be written (the ShuffleServer files that fail to be written are excluded). After obtaining the list, go to Step 5 of the dotted orange line. Throwing a FetchFailed Exception triggers a stage-level retry for SPARK;
5. Attempt 1 is generated by the SPARK Stage level again. Pull the corresponding ShuffleServer list according to the green dotted line.

### Why are the changes needed?

Fix: #825 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT.
