### PR TITLE
[#1143] docs: Correct sequence number text by reducing paragraph indentation by 1 space

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Depending on different situations, Uniffle supports Memory & Local, Memory & Rem
 * Spark driver ask coordinator to get shuffle server for shuffle process
 * Spark task write shuffle data to shuffle server with following step:
 ![Rss Shuffle_Write](docs/asset/rss_shuffle_write.png)
-   1. Send KV data to buffer
-   2. Flush buffer to queue when buffer is full or buffer manager is full
-   3. Thread pool get data from queue
-   4. Request memory from shuffle server first and send the shuffle data
-   5. Shuffle server cache data in memory first and flush to queue when buffer manager is full
-   6. Thread pool get data from queue
-   7. Write data to storage with index file and data file
-   8. After write data, task report all blockId to shuffle server, this step is used for data validation later
-   9. Store taskAttemptId in MapStatus to support Spark speculation
+ 1. Send KV data to buffer
+ 2. Flush buffer to queue when buffer is full or buffer manager is full
+ 3. Thread pool get data from queue
+ 4. Request memory from shuffle server first and send the shuffle data
+ 5. Shuffle server cache data in memory first and flush to queue when buffer manager is full
+ 6. Thread pool get data from queue
+ 7. Write data to storage with index file and data file
+ 8. After write data, task report all blockId to shuffle server, this step is used for data validation later
+ 9. Store taskAttemptId in MapStatus to support Spark speculation
 
 * Depending on different storage types, the spark task will read shuffle data from shuffle server or remote storage or both of them.
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

Fix: #1143

Before:
![image](https://github.com/apache/incubator-uniffle/assets/1935105/e4b1740d-8adb-4a4f-9dba-00a138380aed)

After:
![image](https://github.com/apache/incubator-uniffle/assets/1935105/309a9a52-bdb8-40a0-b205-f1e9a06e0b98)

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

Screenshots attached.