### PR TITLE
[#825][part-5] feat(spark): Adds the RPC interface to reassign the ShuffleServer list.

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
@@ -70,4 +70,6 @@ public interface RssShuffleManagerInterface {
    * @param shuffleServerId
    */
   void addFailuresShuffleServerInfos(String shuffleServerId);
+
+  boolean reassignShuffleServers(int stageId, int stageAttemptNumber, int shuffleId, int numMaps);
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -230,6 +230,27 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
     responseObserver.onCompleted();
   }
 
+  @Override
+  public void reassignShuffleServers(
+      RssProtos.ReassignServersRequest request,
+      StreamObserver<RssProtos.ReassignServersReponse> responseObserver) {
+    int stageId = request.getStageId();
+    int stageAttemptNumber = request.getStageAttemptNumber();
+    int shuffleId = request.getShuffleId();
+    int numPartitions = request.getNumPartitions();
+    boolean needReassign =
+        shuffleManager.reassignShuffleServers(
+            stageId, stageAttemptNumber, shuffleId, numPartitions);
+    RssProtos.StatusCode code = RssProtos.StatusCode.SUCCESS;
+    RssProtos.ReassignServersReponse reply =
+        RssProtos.ReassignServersReponse.newBuilder()
+            .setStatus(code)
+            .setNeedReassign(needReassign)
+            .build();
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+
   /**
    * Remove the no longer used shuffle id's rss shuffle status. This is called when ShuffleManager
    * unregisters the corresponding shuffle id.

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
@@ -57,4 +57,10 @@ public class DummyRssShuffleManager implements RssShuffleManagerInterface {
 
   @Override
   public void addFailuresShuffleServerInfos(String shuffleServerId) {}
+
+  @Override
+  public boolean reassignShuffleServers(
+      int stageId, int stageAttemptNumber, int shuffleId, int numMaps) {
+    return false;
+  }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -43,6 +43,7 @@ import org.apache.spark.MapOutputTracker;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
+import org.apache.spark.SparkException;
 import org.apache.spark.TaskContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.executor.ShuffleReadMetrics;
@@ -136,6 +137,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private boolean rssResubmitStage;
   /** A list of shuffleServer for Write failures */
   private Set<String> failuresShuffleServerIds;
+  /**
+   * Prevent multiple tasks from reporting FetchFailed, resulting in multiple ShuffleServer
+   * assignments, stageID, Attemptnumber Whether to reassign the combination flag;
+   */
+  private Map<String, Boolean> serverAssignedInfos;
 
   public RssShuffleManager(SparkConf conf, boolean isDriver) {
     this.sparkConf = conf;
@@ -263,6 +269,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             poolSize,
             keepAliveTime);
     this.shuffleIdToShuffleHandleInfo = JavaUtils.newConcurrentMap();
+    this.failuresShuffleServerIds = Sets.newHashSet();
+    this.serverAssignedInfos = JavaUtils.newConcurrentMap();
   }
 
   public CompletableFuture<Long> sendData(AddBlockEvent event) {
@@ -1103,5 +1111,80 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   @Override
   public void addFailuresShuffleServerInfos(String shuffleServerId) {
     failuresShuffleServerIds.add(shuffleServerId);
+  }
+
+  /**
+   * Reassign the ShuffleServer list for ShuffleId
+   *
+   * @param shuffleId
+   * @param numPartitions
+   */
+  @Override
+  public synchronized boolean reassignShuffleServers(
+      int stageId, int stageAttemptNumber, int shuffleId, int numPartitions) {
+    String stageIdAndAttempt = stageId + "_" + stageAttemptNumber;
+    Boolean needReassgin = serverAssignedInfos.computeIfAbsent(stageIdAndAttempt, id -> false);
+    if (!needReassgin) {
+      String storageType = sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key());
+      RemoteStorageInfo defaultRemoteStorage =
+          new RemoteStorageInfo(sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""));
+      RemoteStorageInfo remoteStorage =
+          ClientUtils.fetchRemoteStorage(
+              id.get(), defaultRemoteStorage, dynamicConfEnabled, storageType, shuffleWriteClient);
+      Set<String> assignmentTags = RssSparkShuffleUtils.getAssignmentTags(sparkConf);
+      int requiredShuffleServerNumber =
+          RssSparkShuffleUtils.getRequiredShuffleServerNumber(sparkConf);
+      long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL);
+      int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES);
+      int estimateTaskConcurrency = RssSparkShuffleUtils.estimateTaskConcurrency(sparkConf);
+      /** Before reassigning ShuffleServer, clear the ShuffleServer list in ShuffleWriteClient. */
+      shuffleWriteClient.unregisterShuffle(id.get(), shuffleId);
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+      try {
+        partitionToServers =
+            RetryUtils.retry(
+                () -> {
+                  ShuffleAssignmentsInfo response =
+                      shuffleWriteClient.getShuffleAssignments(
+                          id.get(),
+                          shuffleId,
+                          numPartitions,
+                          1,
+                          assignmentTags,
+                          requiredShuffleServerNumber,
+                          estimateTaskConcurrency,
+                          failuresShuffleServerIds);
+                  registerShuffleServers(
+                      id.get(), shuffleId, response.getServerToPartitionRanges(), remoteStorage);
+                  return response.getPartitionToServers();
+                },
+                retryInterval,
+                retryTimes);
+
+      } catch (Throwable throwable) {
+        throw new RssException("registerShuffle failed!", throwable);
+      }
+      /**
+       * we need to clear the metadata of the completed task, otherwise some of the stage's data
+       * will be lost
+       */
+      try {
+        unregisterAllMapOutput(shuffleId);
+      } catch (SparkException e) {
+        LOG.error("Clear MapoutTracker Meta failed!");
+        throw new RssException("Clear MapoutTracker Meta failed!", e);
+      }
+      ShuffleHandleInfo handleInfo =
+          new ShuffleHandleInfo(shuffleId, partitionToServers, remoteStorage);
+      shuffleIdToShuffleHandleInfo.put(shuffleId, handleInfo);
+      serverAssignedInfos.put(stageIdAndAttempt, true);
+      return true;
+    } else {
+      LOG.info(
+          "The Stage:{} has been reassigned in an Attempt{},Return without performing any operation",
+          stageId,
+          stageAttemptNumber);
+      return false;
+    }
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
@@ -20,9 +20,11 @@ package org.apache.uniffle.client.api;
 import java.io.Closeable;
 
 import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.request.RssReassignServersRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.request.RssReportShuffleWriteFailureRequest;
 import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
+import org.apache.uniffle.client.response.RssReassignServersReponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.response.RssReportShuffleWriteFailureResponse;
 
@@ -41,4 +43,6 @@ public interface ShuffleManagerClient extends Closeable {
 
   RssReportShuffleWriteFailureResponse reportShuffleWriteFailure(
       RssReportShuffleWriteFailureRequest req);
+
+  RssReassignServersReponse reassignShuffleServers(RssReassignServersRequest req);
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -24,9 +24,11 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.request.RssReassignServersRequest;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.request.RssReportShuffleWriteFailureRequest;
 import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
+import org.apache.uniffle.client.response.RssReassignServersReponse;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.response.RssReportShuffleWriteFailureResponse;
 import org.apache.uniffle.common.config.RssBaseConf;
@@ -104,5 +106,13 @@ public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManag
       LOG.warn(msg, e);
       throw new RssException(msg, e);
     }
+  }
+
+  @Override
+  public RssReassignServersReponse reassignShuffleServers(RssReassignServersRequest req) {
+    RssProtos.ReassignServersRequest reassignServersRequest = req.toProto();
+    RssProtos.ReassignServersReponse reassignServersReponse =
+        getBlockingStub().reassignShuffleServers(reassignServersRequest);
+    return RssReassignServersReponse.fromProto(reassignServersReponse);
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReassignServersRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReassignServersRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.request;
+
+import org.apache.uniffle.proto.RssProtos;
+
+public class RssReassignServersRequest {
+  private int stageId;
+  private int stageAttemptNumber;
+  private int shuffleId;
+  private int numPartitions;
+
+  public RssReassignServersRequest(
+      int stageId, int stageAttemptNumber, int shuffleId, int numPartitions) {
+    this.stageId = stageId;
+    this.stageAttemptNumber = stageAttemptNumber;
+    this.shuffleId = shuffleId;
+    this.numPartitions = numPartitions;
+  }
+
+  public RssProtos.ReassignServersRequest toProto() {
+    RssProtos.ReassignServersRequest.Builder builder =
+        RssProtos.ReassignServersRequest.newBuilder()
+            .setStageId(stageId)
+            .setStageAttemptNumber(stageAttemptNumber)
+            .setShuffleId(shuffleId)
+            .setNumPartitions(numPartitions);
+    return builder.build();
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssReassignServersReponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssReassignServersReponse.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.response;
+
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.proto.RssProtos;
+
+public class RssReassignServersReponse extends ClientResponse {
+
+  private boolean needReassign;
+
+  public RssReassignServersReponse(StatusCode statusCode, String message, boolean needReassign) {
+    super(statusCode, message);
+    this.needReassign = needReassign;
+  }
+
+  public boolean isNeedReassign() {
+    return needReassign;
+  }
+
+  public static RssReassignServersReponse fromProto(RssProtos.ReassignServersReponse response) {
+    return new RssReassignServersReponse(
+        // todo: [issue#780] add fromProto for StatusCode issue
+        StatusCode.valueOf(response.getStatus().name()),
+        response.getMsg(),
+        response.getNeedReassign());
+  }
+}

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -501,6 +501,8 @@ service ShuffleManager {
   rpc getPartitionToShufflerServer(PartitionToShuffleServerRequest) returns (PartitionToShuffleServerResponse);
   // Report write failures to ShuffleManager
   rpc reportShuffleWriteFailure (ReportShuffleWriteFailureRequest) returns (ReportShuffleWriteFailureResponse);
+  // Reassign the RPC interface of the ShuffleServer list
+  rpc reassignShuffleServers(ReassignServersRequest) returns (ReassignServersReponse);
 }
 
 message ReportShuffleFetchFailureRequest {
@@ -548,5 +550,18 @@ message ReportShuffleWriteFailureRequest {
 message ReportShuffleWriteFailureResponse {
   StatusCode status = 1;
   bool reSubmitWholeStage = 2;
+  string msg = 3;
+}
+
+message ReassignServersRequest{
+  int32 stageId = 1;
+  int32 stageAttemptNumber = 2;
+  int32 shuffleId = 3;
+  int32 numPartitions = 4;
+}
+
+message ReassignServersReponse{
+  StatusCode status = 1;
+  bool needReassign = 2;
   string msg = 3;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the RPC interface to reassign the ShuffleServer list.

Ⅰ. Overall objective:

1. During the shuffle write phase, the ShuffleServer reports faulty nodes and reallocates the ShuffleServer list;
2. Triggers a Stage level retry of SPARK. The shuffleServer node is excluded and reallocated before the retry.

Ⅱ. Implementation logic diagram:

![image](https://github.com/apache/incubator-uniffle/assets/33595968/866c8292-e0ff-4532-b519-02f424f4c2fc)

Ⅲ. As shown in the picture above:

1. During Shuffle registration, obtain the ShuffleServer list to be written through the RPC interface of a Coordinator Client by following the solid blue line step. The list is bound using ShuffleID.
2, the Task of Stage starts, solid steps, in accordance with the green by ShuffleManager Client RPC interface gets to be written for shuffleIdToShuffleHandleInfo ShuffleServer list;
3. In the Stage, if Task fails to write blocks to the ShuffleServer, press the steps in red to report ShuffleServer to FailedShuffleServerList in RSSShuffleManager through the RPC interface.
4. FailedShuffleServerList records the number of ShuffleServer failures. After the number of failures reaches the maximum number of retries of the Task level, follow the steps in dotted orange lines. Through the RPC interface of a Coordinator Client, obtain the list of ShuffleServer files to be written (the ShuffleServer files that fail to be written are excluded). After obtaining the list, go to Step 5 of the dotted orange line. Throwing a FetchFailed Exception triggers a stage-level retry for SPARK;
5. Attempt 1 is generated by the SPARK Stage level again. Pull the corresponding ShuffleServer list according to the green dotted line.

### Why are the changes needed?

Fix: #825 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT.
