### PR TITLE
[#1127] fix(netty): incorrect bytebuf release for ShuffleBlockInfo data in client side

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -408,15 +408,15 @@ public class WriteBufferManager extends MemoryConsumer {
                 + totalSize
                 + " bytes");
         // Use final temporary variables for closures
-        final long _memoryUsed = memoryUsed;
-        final List<ShuffleBlockInfo> _blocks = shuffleBlockInfosPerEvent;
+        final long memoryUsedTemp = memoryUsed;
+        final List<ShuffleBlockInfo> shuffleBlocksTemp = shuffleBlockInfosPerEvent;
         events.add(
             new AddBlockEvent(
                 taskId,
                 shuffleBlockInfosPerEvent,
                 () -> {
-                  freeAllocatedMemory(_memoryUsed);
-                  _blocks.stream().forEach(x -> x.getData().release());
+                  freeAllocatedMemory(memoryUsedTemp);
+                  shuffleBlocksTemp.stream().forEach(x -> x.getData().release());
                 }));
         shuffleBlockInfosPerEvent = Lists.newArrayList();
         totalSize = 0;
@@ -431,15 +431,15 @@ public class WriteBufferManager extends MemoryConsumer {
               + totalSize
               + " bytes");
       // Use final temporary variables for closures
-      final long _memoryUsed = memoryUsed;
-      final List<ShuffleBlockInfo> _blocks = shuffleBlockInfosPerEvent;
+      final long memoryUsedTemp = memoryUsed;
+      final List<ShuffleBlockInfo> shuffleBlocksTemp = shuffleBlockInfosPerEvent;
       events.add(
           new AddBlockEvent(
               taskId,
               shuffleBlockInfosPerEvent,
               () -> {
-                freeAllocatedMemory(_memoryUsed);
-                _blocks.stream().forEach(x -> x.getData().release());
+                freeAllocatedMemory(memoryUsedTemp);
+                shuffleBlocksTemp.stream().forEach(x -> x.getData().release());
               }));
     }
     return events;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -409,7 +409,7 @@ public class WriteBufferManager extends MemoryConsumer {
                 + " bytes");
         // Use final temporary variables for closures
         final long _memoryUsed = memoryUsed;
-        List<ShuffleBlockInfo> _blocks = shuffleBlockInfosPerEvent;
+        final List<ShuffleBlockInfo> _blocks = shuffleBlockInfosPerEvent;
         events.add(
             new AddBlockEvent(
                 taskId,


### PR DESCRIPTION
### What changes were proposed in this pull request?

The principle of data being released is that the data has been sent. 
However, under the current implementation, all blocks will be released in the last event. 
Once executed out of order, the unsent block data will be released prematurely, which is wrong.

### Why are the changes needed?

Fix: #1127 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. existing UTs