### PR TITLE
[#1161] improvement: Reduce the data copy

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -442,8 +442,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                     length);
         long readTime = System.currentTimeMillis() - start;
         ShuffleServerMetrics.counterTotalReadTime.inc(readTime);
-        ShuffleServerMetrics.counterTotalReadDataSize.inc(sdr.getData().length);
-        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(sdr.getData().length);
+        int dataLength = sdr.getDataBuffer().remaining();
+        ShuffleServerMetrics.counterTotalReadDataSize.inc(dataLength);
+        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(dataLength);
         shuffleServer
             .getNettyMetrics()
             .recordProcessTime(GetLocalShuffleDataRequest.class.getName(), readTime);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileClientReadHandler.java
@@ -153,10 +153,10 @@ public class LocalFileClientReadHandler extends DataSkippableReadHandler {
               + " due to "
               + e.getMessage());
     }
-    if (result.getData().length != expectedLength) {
+    if (result.getDataBuffer().remaining() != expectedLength) {
       throw new RssException(
           "Wrong data length expect "
-              + result.getData().length
+              + result.getDataBuffer().remaining()
               + " but actual is "
               + expectedLength);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

If we use the off heap memory and then we use the method `getData`, we will copy the off heap memory to heap data memory. So we should avoid using it in the Netty mode.

### Why are the changes needed?

Fix: #1161

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Code Review
