### PR TITLE
[#1165] improvement(tez): Unregister shuffle data after completing the execution of a DAG. 

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
@@ -267,6 +267,15 @@ public class RssTezUtils {
     return shuffleId;
   }
 
+  public static int parseDagId(int shuffleId) {
+    Preconditions.checkArgument(shuffleId > 0, "shuffleId should be positive.");
+    int dagId = shuffleId / (SHUFFLE_ID_MAGIC * SHUFFLE_ID_MAGIC);
+    if (dagId == 0) {
+      throw new RssException("Illegal shuffleId: " + shuffleId);
+    }
+    return dagId;
+  }
+
   /**
    * @param vertexName: vertex name, like "Map 1" or "Reducer 2"
    * @return Map vertex name of String type to int type. Split vertex name, get vertex type and

--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -269,6 +269,11 @@ public class RssDAGAppMaster extends DAGAppMaster {
 
   @Override
   protected DAG createDAG(DAGProtos.DAGPlan dagPB) {
+    // Generally, one application will execute multiple DAGs,
+    // and there is no correlation between the DAGs.
+    // Therefore, after completing the execution of a DAG,
+    // you can unregister the relevant shuffle data.
+    tezRemoteShuffleManager.unregisterShuffle();
     DAGImpl dag = createDAG(dagPB, null);
     registerStateEnteredCallback(dag, this);
     return dag;

--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -632,7 +632,8 @@ public class RssDAGAppMaster extends DAGAppMaster {
         return;
       }
 
-      if (event.getType() == DAGAppMasterEventType.DAG_FINISHED) {
+      if (event.getType() == DAGAppMasterEventType.DAG_FINISHED
+          && event instanceof DAGAppMasterEventDAGFinished) {
         DAGAppMasterEventDAGFinished finishEvt = (DAGAppMasterEventDAGFinished) event;
         LOG.info(
             "Receive a DAG_FINISHED event, dagId={}, dagState={}",

--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -620,11 +620,7 @@ public class RssDAGAppMaster extends DAGAppMaster {
 
     private TezRemoteShuffleManager tezRemoteShuffleManager;
 
-    public RssDAGAppMasterEventHandler() {}
-
-    public RssDAGAppMasterEventHandler(TezRemoteShuffleManager tezRemoteShuffleManager) {
-      this.tezRemoteShuffleManager = tezRemoteShuffleManager;
-    }
+    RssDAGAppMasterEventHandler() {}
 
     public void setTezRemoteShuffleManager(TezRemoteShuffleManager tezRemoteShuffleManager) {
       this.tezRemoteShuffleManager = tezRemoteShuffleManager;

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
@@ -153,7 +153,8 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
   }
 
   private class TezRemoteShuffleUmbilicalProtocolImpl implements TezRemoteShuffleUmbilicalProtocol {
-    private Map<Integer, ShuffleAssignmentsInfo> shuffleIdToShuffleAssignsInfo = new HashMap<>();
+    private Map<Integer, ShuffleAssignmentsInfo> shuffleIdToShuffleAssignsInfo =
+        new ConcurrentHashMap<>();
 
     @Override
     public long getProtocolVersion(String s, long l) throws IOException {

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -109,15 +109,16 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
 
   @Override
   public void shutdown() throws Exception {
+    unregisterShuffle();
+    server.stop();
+  }
+
+  public void unregisterShuffle() {
+    tezRemoteShuffleUmbilical.clearShuffleInfo();
     if (rssClient != null) {
       LOG.info("unregister all shuffle for appid {}", appId);
-      Map<Integer, ShuffleAssignmentsInfo> infos =
-          tezRemoteShuffleUmbilical.getShuffleIdToShuffleAssignsInfo();
-      for (Map.Entry<Integer, ShuffleAssignmentsInfo> entry : infos.entrySet()) {
-        rssClient.unregisterShuffle(appId, entry.getKey());
-      }
+      rssClient.unregisterShuffle(appId);
     }
-    server.stop();
   }
 
   public InetSocketAddress getAddress() {
@@ -182,8 +183,8 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
       return response;
     }
 
-    Map<Integer, ShuffleAssignmentsInfo> getShuffleIdToShuffleAssignsInfo() {
-      return shuffleIdToShuffleAssignsInfo;
+    void clearShuffleInfo() {
+      this.shuffleIdToShuffleAssignsInfo.clear();
     }
   }
 

--- a/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
+++ b/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
@@ -29,7 +29,6 @@ import org.apache.tez.dag.records.TezDAGID;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -40,6 +39,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.apache.tez.common.RssTezConfig.RSS_STORAGE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssTezUtilsTest {
@@ -207,9 +207,9 @@ public class RssTezUtilsTest {
     dynamic.put(RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
     dynamic.put("config2", "value2");
     RssTezUtils.applyDynamicClientConf(conf, dynamic);
-    Assertions.assertEquals("value1", conf.get("tez.config1"));
-    Assertions.assertEquals("value2", conf.get("tez.config2"));
-    Assertions.assertEquals(StorageType.LOCALFILE.name(), conf.get(RSS_STORAGE_TYPE));
+    assertEquals("value1", conf.get("tez.config1"));
+    assertEquals("value2", conf.get("tez.config2"));
+    assertEquals(StorageType.LOCALFILE.name(), conf.get(RSS_STORAGE_TYPE));
   }
 
   @Test
@@ -218,7 +218,15 @@ public class RssTezUtilsTest {
     conf1.set("tez.config1", "value1");
     conf1.set("config2", "value2");
     Configuration conf2 = RssTezUtils.filterRssConf(conf1);
-    Assertions.assertEquals("value1", conf2.get("tez.config1"));
-    Assertions.assertNull(conf2.get("config2"));
+    assertEquals("value1", conf2.get("tez.config1"));
+    assertNull(conf2.get("config2"));
+  }
+
+  @Test
+  public void testParseDagId() {
+    int shuffleId = RssTezUtils.computeShuffleId(1, 2, 3);
+    assertEquals(1, RssTezUtils.parseDagId(shuffleId));
+    assertThrows(IllegalArgumentException.class, () -> RssTezUtils.parseDagId(-1));
+    assertThrows(RssException.class, () -> RssTezUtils.parseDagId(100));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Generally, one application will execute multiple DAGs, and there is no correlation between the DAGs. Therefore, after completing the execution of a DAG, you can unregister the relevant shuffle data. Otherwise, when there are many DAGs, an application will occupy a large amount of resources for a long period of time.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/1165

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test cases.
