### PR TITLE
[#1164] refactor: Exposing the getDataLen method for ShuffleDataResult

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -78,7 +78,7 @@ public class ShuffleDataResult {
     if (buffer.nioByteBuffer().hasArray()) {
       return buffer.nioByteBuffer().array().length;
     }
-    return buffer.byteBuf().array().length;
+    return buffer.nioByteBuffer().remaining();
   }
 
   public ByteBuf getDataBuf() {

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -71,6 +71,16 @@ public class ShuffleDataResult {
     return ByteBufUtils.readBytes(buffer.byteBuf());
   }
 
+  public int getDataLength() {
+    if (buffer == null) {
+      return 0;
+    }
+    if (buffer.nioByteBuffer().hasArray()) {
+      return buffer.nioByteBuffer().array().length;
+    }
+    return buffer.byteBuf().array().length;
+  }
+
   public ByteBuf getDataBuf() {
     return buffer.byteBuf();
   }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -633,8 +633,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                     length);
         long readTime = System.currentTimeMillis() - start;
         ShuffleServerMetrics.counterTotalReadTime.inc(readTime);
-        ShuffleServerMetrics.counterTotalReadDataSize.inc(sdr.getData().length);
-        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(sdr.getData().length);
+        ShuffleServerMetrics.counterTotalReadDataSize.inc(sdr.getDataLength());
+        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(sdr.getDataLength());
         shuffleServer
             .getGrpcMetrics()
             .recordProcessTime(ShuffleServerGrpcMetrics.GET_SHUFFLE_DATA_METHOD, readTime);

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -442,9 +442,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                     length);
         long readTime = System.currentTimeMillis() - start;
         ShuffleServerMetrics.counterTotalReadTime.inc(readTime);
-        int dataLength = sdr.getDataBuffer().remaining();
-        ShuffleServerMetrics.counterTotalReadDataSize.inc(dataLength);
-        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(dataLength);
+        ShuffleServerMetrics.counterTotalReadDataSize.inc(sdr.getDataLength());
+        ShuffleServerMetrics.counterTotalReadLocalDataFileSize.inc(sdr.getDataLength());
         shuffleServer
             .getNettyMetrics()
             .recordProcessTime(GetLocalShuffleDataRequest.class.getName(), readTime);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -199,10 +199,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     bufferPool.get(appId).get(3).get(0).getInFlushBlockMap().clear();
     // empty data return
     sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, Constants.INVALID_BLOCK_ID, 60);
-    assertEquals(0, sdr.getData().length);
+    assertEquals(0, sdr.getDataLength());
     lastBlockId = spd2.getBlockList()[0].getBlockId();
     sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, lastBlockId, 100);
-    assertEquals(0, sdr.getData().length);
+    assertEquals(0, sdr.getDataLength());
   }
 
   @Test

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferTest.java
@@ -310,7 +310,7 @@ public class ShuffleBufferTest extends BufferTestBase {
     shuffleBuffer = new ShuffleBuffer(200);
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 10);
     assertEquals(0, sdr.getBufferSegments().size());
-    assertEquals(0, sdr.getData().length);
+    assertEquals(0, sdr.getDataLength());
 
     // case7: get data with multiple flush buffer and cached buffer
     shuffleBuffer = new ShuffleBuffer(200);

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
@@ -135,7 +135,7 @@ public class LocalFileHandlerTest {
     targetDataFile.delete();
     shuffleDataResults = LocalFileHandlerTestBase.readData(readHandler1, shuffleIndexResult);
     for (ShuffleDataResult shuffleData : shuffleDataResults) {
-      assertEquals(0, shuffleData.getData().length);
+      assertEquals(0, shuffleData.getDataLength());
       assertTrue(shuffleData.isEmpty());
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exposing `ShuffleDataResult.getDataLen` method for being invoked by metrics and tests.

### Why are the changes needed?

Exposing `ShuffleDataResult.getDataLen` method for being invoked by metrics and tests.

Fix: #1164 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
