### PR TITLE
[#1163] improvement(netty): return the direct byte buffer when getting localfile data by using netty

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -454,7 +454,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             requestInfo);
         response =
             new GetLocalShuffleDataResponse(
-                req.getRequestId(), status, msg, sdr.getManagedBuffer());
+                req.getRequestId(), status, msg, new NettyManagedBuffer(Unpooled.wrappedBuffer(sdr.getManagedBuffer().nioByteBuffer())));
       } catch (Exception e) {
         status = StatusCode.INTERNAL_ERROR;
         msg = "Error happened when get shuffle data for " + requestInfo + ", " + e.getMessage();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, the `FileSegmentManagedBuffer` will return the heap bytebuffer when reading data from localfile. It will be better to using the direct byte buffer

### Why are the changes needed?

Fix: [# (issue)](https://github.com/apache/incubator-uniffle/issues/1163)

### Does this PR introduce _any_ user-facing change?

No.

