### PR TITLE
[#1173] fix: incorrect shuffle server status

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -148,7 +148,7 @@ public class SimpleClusterManager implements ClusterManager {
           if (ServerStatus.LOST.equals(sn.getStatus())) {
             sn.setStatus(ServerStatus.ACTIVE);
             lostNodes.remove(sn);
-          } if (ServerStatus.UNHEALTHY.equals(sn.getStatus())) {
+          } else if (ServerStatus.UNHEALTHY.equals(sn.getStatus())) {
             sn.setStatus(ServerStatus.ACTIVE);
             unhealthyNodes.remove(sn);
           }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -145,9 +145,13 @@ public class SimpleClusterManager implements ClusterManager {
           unhealthyNodes.add(sn);
           lostNodes.remove(sn);
         } else {
-          sn.setStatus(ServerStatus.ACTIVE);
-          lostNodes.remove(sn);
-          unhealthyNodes.remove(sn);
+          if (ServerStatus.LOST.equals(sn.getStatus())) {
+            sn.setStatus(ServerStatus.ACTIVE);
+            lostNodes.remove(sn);
+          } if (ServerStatus.UNHEALTHY.equals(sn.getStatus())) {
+            sn.setStatus(ServerStatus.ACTIVE);
+            unhealthyNodes.remove(sn);
+          }
         }
       }
       for (ServerNode server : lostNodes) {
@@ -248,8 +252,7 @@ public class SimpleClusterManager implements ClusterManager {
         continue;
       }
       if (!excludeNodes.contains(node.getId())
-          && node.getTags().containsAll(requiredTags)
-          && ServerStatus.ACTIVE.equals(node.getStatus())) {
+          && node.getTags().containsAll(requiredTags)) {
         availableNodes.add(node);
       }
     }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -71,7 +71,7 @@ public class ServerResource extends BaseResource {
     } else if (ServerStatus.LOST.name().equalsIgnoreCase(status)) {
       serverList = clusterManager.getLostServerList();
     } else {
-      serverList = clusterManager.getServerList(Collections.emptySet());
+      serverList = clusterManager.list();
     }
     serverList =
         serverList.stream()

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.coordinator.web.resource;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix incorrect shuffle server status.

### Why are the changes needed?

Fix: #1173 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT
