### PR TITLE
[MINOR] docs: Fix spark.serializer in README and client_guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Deploy Steps:
    ```
    # Uniffle transmits serialized shuffle data over network, therefore a serializer that supports relocation of
    # serialized object should be used. 
-   spark.serialier org.apache.spark.serializer.KryoSerializer # this could also be in the spark-defaults.conf
+   spark.serializer org.apache.spark.serializer.KryoSerializer # this could also be in the spark-defaults.conf
    spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
    spark.rss.coordinator.quorum <coordinatorIp1>:19999,<coordinatorIp2>:19999
    # Note: For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -40,7 +40,7 @@ This document will introduce how to deploy Uniffle client plugins with Spark and
    ```
    # Uniffle transmits serialized shuffle data over network, therefore a serializer that supports relocation of
    # serialized object should be used. 
-   spark.serialier org.apache.spark.serializer.KryoSerializer # this could also be in the spark-defaults.conf
+   spark.serializer org.apache.spark.serializer.KryoSerializer # this could also be in the spark-defaults.conf
    spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
    spark.rss.coordinator.quorum <coordinatorIp1>:19999,<coordinatorIp2>:19999
    # Note: For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

before:
<img width="973" alt="企业微信截图_59b6f770-e0c8-4274-86ef-4a0527d530cf" src="https://github.com/apache/incubator-uniffle/assets/70899573/b7e5eb68-b553-406a-bee5-2dede504abbb">
<img width="1005" alt="企业微信截图_ad7abd72-09e7-4b57-905f-a77f04428836" src="https://github.com/apache/incubator-uniffle/assets/70899573/2559bc7e-6446-48d9-b97b-873fc263e2fb">

after:
<img width="959" alt="image" src="https://github.com/apache/incubator-uniffle/assets/70899573/16de72f9-b064-49aa-8a23-e130eeaf4ae8">
<img width="1037" alt="image" src="https://github.com/apache/incubator-uniffle/assets/70899573/882029f5-706b-481c-82db-414c10f03662">


### Why are the changes needed?

![image](https://github.com/apache/incubator-uniffle/assets/70899573/0613f5a0-9a9b-4e91-8fe0-ff20f1dbf507)

If the wrong `spark.serialier` is set, the above error will be reported in registerShuffle, and `spark.serializer` should actually be used.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Screenshots attached.
