### PR TITLE
[#1175] fix(netty): Retry failed with StacklessClosedChannelException after channel closed

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -61,7 +61,8 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
     this(rssConf, host, grpcPort, nettyPort, 3);
   }
 
-  public ShuffleServerGrpcNettyClient(RssConf rssConf, String host, int grpcPort, int nettyPort, int maxRetryAttempts) {
+  public ShuffleServerGrpcNettyClient(
+      RssConf rssConf, String host, int grpcPort, int nettyPort, int maxRetryAttempts) {
     super(host, grpcPort, maxRetryAttempts);
     this.nettyPort = nettyPort;
     TransportContext transportContext = new TransportContext(new TransportConf(rssConf));

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -66,7 +66,6 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
 
   @Override
   public RssSendShuffleDataResponse sendShuffleData(RssSendShuffleDataRequest request) {
-    TransportClient transportClient = getTransportClient();
     Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks =
         request.getShuffleIdToBlocks();
     boolean isSuccessful = true;
@@ -88,6 +87,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
       try {
         RetryUtils.retry(
             () -> {
+              TransportClient transportClient = getTransportClient();
               long requireId =
                   requirePreAllocation(
                       request.getAppId(),

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -58,7 +58,11 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
   private TransportClientFactory clientFactory;
 
   public ShuffleServerGrpcNettyClient(RssConf rssConf, String host, int grpcPort, int nettyPort) {
-    super(host, grpcPort);
+    this(rssConf, host, grpcPort, nettyPort, 3);
+  }
+
+  public ShuffleServerGrpcNettyClient(RssConf rssConf, String host, int grpcPort, int nettyPort, int maxRetryAttempts) {
+    super(host, grpcPort, maxRetryAttempts);
     this.nettyPort = nettyPort;
     TransportContext transportContext = new TransportContext(new TransportConf(rssConf));
     this.clientFactory = new TransportClientFactory(transportContext);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1、reget a transportClient in ShuffleServerGrpcNettyClient.sendShuffleData RetryCmd
2、add ShuffleServerGrpcNettyClient construct with maxRetryAttempts (but in this pr init ShuffleServerGrpcNettyClient with default maxRetryAttempts(3))

### Why are the changes needed?
Fix: #1175

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UT.