### PR TITLE
[#1178]  improvement: set `rss.coordinator.quota.default.app.num` default -1 to indicate no quota check

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorConf.java
@@ -201,13 +201,15 @@ public class CoordinatorConf extends RssBaseConf {
   public static final ConfigOption<Integer> COORDINATOR_QUOTA_DEFAULT_APP_NUM =
       ConfigOptions.key("rss.coordinator.quota.default.app.num")
           .intType()
-          .defaultValue(5)
-          .withDescription("Default number of apps at user level");
+          .defaultValue(-1)
+          .withDescription("Default number of apps at user level, if set value < 0,then this user app quota "
+              + "check would passed");
   public static final ConfigOption<String> COORDINATOR_QUOTA_DEFAULT_PATH =
       ConfigOptions.key("rss.coordinator.quota.default.path")
           .stringType()
           .noDefaultValue()
-          .withDescription("A configuration file for the number of apps for a user-defined user");
+          .withDescription("A configuration file for the number of apps for a user-defined user, if set value < 0,then this user app quota "
+              + "check would passed.");
   public static final ConfigOption<Long> COORDINATOR_QUOTA_UPDATE_INTERVAL =
       ConfigOptions.key("rss.coordinator.quota.update.interval")
           .longType()

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
@@ -118,10 +118,10 @@ public class QuotaManager {
   public boolean checkQuota(String user, String uuid) {
     Map<String, Long> appAndTimes =
         currentUserAndApp.computeIfAbsent(user, x -> JavaUtils.newConcurrentMap());
-    Integer defaultAppNum = defaultUserApps.computeIfAbsent(user, x -> quotaAppNum);
+    Integer userAppQuotaNum = defaultUserApps.computeIfAbsent(user, x -> quotaAppNum);
     synchronized (this) {
       int currentAppNum = appAndTimes.size();
-      if (currentAppNum >= defaultAppNum) {
+      if (userAppQuotaNum >= 0 && currentAppNum >= userAppQuotaNum) {
         return true;
       } else {
         appAndTimes.put(uuid, System.currentTimeMillis());

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
@@ -116,13 +116,15 @@ public class QuotaManagerTest {
     final boolean icCheck =
         applicationManager.getQuotaManager().checkQuota("user4", String.valueOf(i1));
     registerThread.join();
-    assertTrue(icCheck);
+    assertFalse(icCheck);
     assertEquals(
-        applicationManager.getQuotaManager().getCurrentUserAndApp().get("user4").size(), 5);
+        applicationManager.getQuotaManager().getCurrentUserAndApp().get("user4").size(), 6);
   }
 
   @Test
   public void testCheckQuotaMetrics() {
+    CoordinatorMetrics.clear();
+    CoordinatorMetrics.register();
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_QUOTA_DEFAULT_PATH, quotaFile);
     conf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 1500);


### PR DESCRIPTION


<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1、set `rss.coordinator.quota.default.app.num`  default value as -1 
2、the logic for  quota check is the user app quota value < 0,then this user app quota check would passed

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (#1178 )

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT