### PR TITLE
[#1192] improvement: Add RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE conf for storing shuffle data

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The following security configurations are introduced.
 |rss.security.hadoop.kerberos.keytab.file|-|The kerberos keytab file path. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.principal|-|The kerberos keytab principal. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.relogin.interval.sec|60|The kerberos authentication relogin interval. unit: sec|
-|rss.security.hadoop.kerberos.proxy.user.enable|true|Whether using proxy user for spark job user to access secured Hadoop cluster.|
+|rss.security.hadoop.kerberos.proxy.user.enable|true|Whether using proxy user for job user to access secured Hadoop cluster.|
 
 * The proxy user mechanism is used to keep the data isolation in uniffle, which means the shuffle-data written by 
   shuffle-servers is owned by spark app's user. To achieve the this, the login user specified by above config should 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The following security configurations are introduced.
 |rss.security.hadoop.kerberos.keytab.file|-|The kerberos keytab file path. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.principal|-|The kerberos keytab principal. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.relogin.interval.sec|60|The kerberos authentication relogin interval. unit: sec|
-|rss.security.hadoop.kerberos.proxy.user.enable|true|Whether create proxy user for spark job user to visiting secured hadoop cluster.|
+|rss.security.hadoop.kerberos.proxy.user.enable|true|Whether using proxy user for spark job user to access secured Hadoop cluster.|
 
 * The proxy user mechanism is used to keep the data isolation in uniffle, which means the shuffle-data written by 
   shuffle-servers is owned by spark app's user. To achieve the this, the login user specified by above config should 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The following security configurations are introduced.
 |rss.security.hadoop.kerberos.keytab.file|-|The kerberos keytab file path. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.principal|-|The kerberos keytab principal. And only when rss.security.hadoop.kerberos.enable is enabled, the option will be valid|
 |rss.security.hadoop.kerberos.relogin.interval.sec|60|The kerberos authentication relogin interval. unit: sec|
+|rss.security.hadoop.kerberos.proxy.user.enable|true|Whether create proxy user for spark job user to visiting secured hadoop cluster.|
 
 * The proxy user mechanism is used to keep the data isolation in uniffle, which means the shuffle-data written by 
   shuffle-servers is owned by spark app's user. To achieve the this, the login user specified by above config should 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -180,7 +180,7 @@ public class RssBaseConf extends RssConf {
           .booleanType()
           .defaultValue(true)
           .withDescription(
-              "Whether using proxy user for spark job user to access secured Hadoop cluster.");
+              "Whether using proxy user for job user to access secured Hadoop cluster.");
 
   public static final ConfigOption<String> RSS_SECURITY_HADOOP_KRB5_CONF_FILE =
       ConfigOptions.key("rss.security.hadoop.kerberos.krb5-conf.file")

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -175,6 +175,13 @@ public class RssBaseConf extends RssConf {
           .defaultValue(false)
           .withDescription("Whether enable visiting secured hadoop cluster.");
 
+  public static final ConfigOption<Boolean> RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE =
+      ConfigOptions.key("rss.security.hadoop.kerberos.proxy.user.enable")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription(
+              "Whether create proxy user for spark job user to visiting secured hadoop cluster.");
+
   public static final ConfigOption<String> RSS_SECURITY_HADOOP_KRB5_CONF_FILE =
       ConfigOptions.key("rss.security.hadoop.kerberos.krb5-conf.file")
           .stringType()

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -180,7 +180,7 @@ public class RssBaseConf extends RssConf {
           .booleanType()
           .defaultValue(true)
           .withDescription(
-              "Whether create proxy user for spark job user to visiting secured hadoop cluster.");
+              "Whether using proxy user for spark job user to access secured Hadoop cluster.");
 
   public static final ConfigOption<String> RSS_SECURITY_HADOOP_KRB5_CONF_FILE =
       ConfigOptions.key("rss.security.hadoop.kerberos.krb5-conf.file")

--- a/common/src/main/java/org/apache/uniffle/common/security/SecurityConfig.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
   private String keytabFilePath;
   private String principal;
   private long reloginIntervalSec;
+  private boolean enableProxyUser;
 
   private SecurityConfig() {
     // ignore.
@@ -41,6 +42,10 @@ public class SecurityConfig {
 
   public long getReloginIntervalSec() {
     return reloginIntervalSec;
+  }
+
+  public boolean isEnableProxyUser() {
+    return enableProxyUser;
   }
 
   public static class Builder {
@@ -67,6 +72,11 @@ public class SecurityConfig {
 
     public SecurityConfig.Builder krb5ConfPath(String krb5ConfPath) {
       info.krb5ConfPath = krb5ConfPath;
+      return this;
+    }
+
+    public SecurityConfig.Builder enableProxyUser(boolean enableProxyUser) {
+      info.enableProxyUser = enableProxyUser;
       return this;
     }
 

--- a/common/src/main/java/org/apache/uniffle/common/security/SecurityContextFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/security/SecurityContextFactory.java
@@ -46,7 +46,8 @@ public class SecurityContextFactory {
             securityConfig.getKrb5ConfPath(),
             securityConfig.getKeytabFilePath(),
             securityConfig.getPrincipal(),
-            securityConfig.getReloginIntervalSec());
+            securityConfig.getReloginIntervalSec(),
+            securityConfig.isEnableProxyUser());
     LOGGER.info("Initialized security context: {}", securityContext.getClass().getSimpleName());
   }
 

--- a/common/src/test/java/org/apache/uniffle/common/KerberizedHadoopBase.java
+++ b/common/src/test/java/org/apache/uniffle/common/KerberizedHadoopBase.java
@@ -49,6 +49,7 @@ public class KerberizedHadoopBase {
             .keytabFilePath(kerberizedHadoop.getHdfsKeytab())
             .principal(kerberizedHadoop.getHdfsPrincipal())
             .reloginIntervalSec(1000)
+            .enableProxyUser(true)
             .build();
     SecurityContextFactory.get().init(securityConfig);
 

--- a/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
@@ -104,6 +104,28 @@ public class HadoopSecurityContextTest extends KerberizedHadoopBase {
   }
 
   @Test
+  public void testSecuredDisableProxyUser() throws Exception {
+    try (HadoopSecurityContext context =
+        new HadoopSecurityContext(
+            null,
+            kerberizedHadoop.getHdfsKeytab(),
+            kerberizedHadoop.getHdfsPrincipal(),
+            1000,
+            false)) {
+      Path pathWithHdfsUser = new Path("/alex/HadoopSecurityDisableProxyUserWithUser");
+      context.runSecured(
+          "alex",
+          (Callable<Void>)
+              () -> {
+                kerberizedHadoop.getFileSystem().mkdirs(pathWithHdfsUser);
+                return null;
+              });
+      FileStatus fileStatus = kerberizedHadoop.getFileSystem().getFileStatus(pathWithHdfsUser);
+      assertEquals("hdfs", fileStatus.getOwner());
+    }
+  }
+
+  @Test
   public void testCreateIllegalContext() throws Exception {
     System.setProperty("sun.security.krb5.debug", "true");
 

--- a/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/security/HadoopSecurityContextTest.java
@@ -112,7 +112,7 @@ public class HadoopSecurityContextTest extends KerberizedHadoopBase {
             kerberizedHadoop.getHdfsPrincipal(),
             1000,
             false)) {
-      Path pathWithHdfsUser = new Path("/alex/HadoopSecurityDisableProxyUserWithUser");
+      Path pathWithHdfsUser = new Path("/alex/HadoopSecurityDisableProxyUser");
       context.runSecured(
           "alex",
           (Callable<Void>)

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -61,6 +61,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_ENABLE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_KEYTAB_FILE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_PRINCIPAL;
+import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KERBEROS_RELOGIN_INTERVAL_SEC;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_SECURITY_HADOOP_KRB5_CONF_FILE;
 import static org.apache.uniffle.common.config.RssBaseConf.RSS_STORAGE_TYPE;
@@ -237,6 +238,8 @@ public class ShuffleServer {
               .principal(shuffleServerConf.getString(RSS_SECURITY_HADOOP_KERBEROS_PRINCIPAL))
               .reloginIntervalSec(
                   shuffleServerConf.getLong(RSS_SECURITY_HADOOP_KERBEROS_RELOGIN_INTERVAL_SEC))
+              .enableProxyUser(
+                  shuffleServerConf.getBoolean(RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE))
               .build();
     }
     SecurityContextFactory.get().init(securityConfig);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

add `RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE` with default true,
if set false, shuffle data storing in security hdfs use UGI user.

### Why are the changes needed?

Fix:  #1192

### Does this PR introduce _any_ user-facing change?

add `RSS_SECURITY_HADOOP_KERBEROS_PROXY_USER_ENABLE` with default true

### How was this patch tested?

add `HadoopSecurityContextTest.testSecuredDisableProxyUser()`  test case
