### PR TITLE
[#1196] improvement: rss.client.assignment.shuffle.nodes.max should not be less than rss.data.replica

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -89,7 +89,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
-  private final int shuffleServers;
+  private int assignmentShuffleNodesNum;
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
@@ -122,7 +122,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
     this.maxConcurrencyPerPartitionToWrite =
         RssSparkConfig.toRssConf(sparkConf).get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE);
-    this.shuffleServers = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
+    this.assignmentShuffleNodesNum =
+        sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
     LOG.info(
         "Check quorum config ["
             + dataReplica
@@ -133,7 +134,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             + ":"
             + dataReplicaSkipEnabled
             + "]");
-    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead, shuffleServers);
+    RssUtils.checkQuorumSetting(
+        dataReplica, dataReplicaWrite, dataReplicaRead, assignmentShuffleNodesNum);
 
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -89,6 +89,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
+  private final int shuffleServers;
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
@@ -121,6 +122,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
     this.maxConcurrencyPerPartitionToWrite =
         RssSparkConfig.toRssConf(sparkConf).get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE);
+    this.shuffleServers = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
     LOG.info(
         "Check quorum config ["
             + dataReplica
@@ -131,7 +133,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             + ":"
             + dataReplicaSkipEnabled
             + "]");
-    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
+    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead, shuffleServers);
 
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -91,6 +91,7 @@ public class DelegationRssShuffleManagerTest {
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
     assertCreateSortShuffleManager(conf);
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     assertCreateRssShuffleManager(conf);
 
     conf = new SparkConf();
@@ -131,6 +132,7 @@ public class DelegationRssShuffleManagerTest {
 
     // No fall back in executor
     conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     boolean hasException = false;
     try {
       new DelegationRssShuffleManager(conf, false);
@@ -161,6 +163,7 @@ public class DelegationRssShuffleManagerTest {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     assertCreateRssShuffleManager(conf);
 
     CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -77,7 +77,8 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_CLIENT_RETRY_INTERVAL_MAX.key(), "1000")
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
-        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346")
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     // init SparkContext
     final SparkContext sc = SparkContext.getOrCreate(conf);
     RssShuffleManager manager = new RssShuffleManager(conf, false);
@@ -195,7 +196,8 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key(), "128")
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
-        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346")
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     // init SparkContext
     final SparkContext sc = SparkContext.getOrCreate(conf);
     RssShuffleManager manager = new RssShuffleManager(conf, false);
@@ -352,7 +354,8 @@ public class RssShuffleWriterTest {
             RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
                 + RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMITATION.key(),
             "64")
-        .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
+        .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
 
     TaskMemoryManager mockTaskMemoryManager = mock(TaskMemoryManager.class);
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -92,7 +92,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
-  private final int shuffleServers;
+  private int assignmentShuffleNodesNum;
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
@@ -136,7 +136,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.dataReplicaWrite = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_WRITE);
     this.dataReplicaRead = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_READ);
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
-    this.shuffleServers = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
+    this.assignmentShuffleNodesNum =
+        sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
     LOG.info(
         "Check quorum config ["
             + dataReplica
@@ -147,7 +148,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             + ":"
             + dataReplicaSkipEnabled
             + "]");
-    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead, shuffleServers);
+    RssUtils.checkQuorumSetting(
+        dataReplica, dataReplicaWrite, dataReplicaRead, assignmentShuffleNodesNum);
 
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);
     this.heartbeatTimeout =
@@ -280,6 +282,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.dataReplica = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA);
     this.dataReplicaWrite = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_WRITE);
     this.dataReplicaRead = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_READ);
+    this.assignmentShuffleNodesNum =
+        sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
     LOG.info(
         "Check quorum config ["
@@ -291,7 +295,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             + ":"
             + dataReplicaSkipEnabled
             + "]");
-    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
+    RssUtils.checkQuorumSetting(
+        dataReplica, dataReplicaWrite, dataReplicaRead, assignmentShuffleNodesNum);
 
     int retryMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX);
     long retryIntervalMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_INTERVAL_MAX);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -92,6 +92,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
+  private final int shuffleServers;
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
@@ -135,6 +136,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.dataReplicaWrite = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_WRITE);
     this.dataReplicaRead = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_READ);
     this.dataReplicaSkipEnabled = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED);
+    this.shuffleServers = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
     LOG.info(
         "Check quorum config ["
             + dataReplica
@@ -145,7 +147,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             + ":"
             + dataReplicaSkipEnabled
             + "]");
-    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
+    RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead, shuffleServers);
 
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);
     this.heartbeatTimeout =

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -53,6 +53,7 @@ public class DelegationRssShuffleManagerTest extends RssShuffleManagerTestBase {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     assertCreateRssShuffleManager(conf);
 
     conf = new SparkConf();
@@ -84,6 +85,7 @@ public class DelegationRssShuffleManagerTest extends RssShuffleManagerTestBase {
 
     // No fall back in executor
     conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     boolean hasException = false;
     try {
       new DelegationRssShuffleManager(conf, false);
@@ -105,6 +107,7 @@ public class DelegationRssShuffleManagerTest extends RssShuffleManagerTestBase {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     assertCreateRssShuffleManager(conf);
 
     setupMockedRssShuffleUtils(ACCESS_DENIED);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -93,6 +93,7 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     // enable stage recompute
     conf.set("spark." + RssClientConfig.RSS_RESUBMIT_STAGE, "true");
 
@@ -110,7 +111,7 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
     conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
     conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
-
+    conf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     conf.set("spark.task.maxFailures", "3");
     RssShuffleManager shuffleManager = new RssShuffleManager(conf, true);
     assertEquals(shuffleManager.getMaxFetchFailures(), 2);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -434,21 +434,7 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name())
         .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
 
-    BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
-    WriteBufferManager bufferManager =
-        new WriteBufferManager(
-            0,
-            0,
-            bufferOptions,
-            new KryoSerializer(conf),
-            Maps.newHashMap(),
-            mock(TaskMemoryManager.class),
-            new ShuffleWriteMetrics(),
-            RssSparkConfig.toRssConf(conf));
-    WriteBufferManager bufferManagerSpy = spy(bufferManager);
-
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
-    ShuffleWriteMetrics mockMetrics = mock(ShuffleWriteMetrics.class);
     Partitioner mockPartitioner = mock(Partitioner.class);
     when(mockDependency.partitioner()).thenReturn(mockPartitioner);
     when(mockPartitioner.numPartitions()).thenReturn(2);
@@ -472,6 +458,19 @@ public class RssShuffleWriterTest {
     ShuffleWriteClient mockWriteClient = mock(ShuffleWriteClient.class);
 
     List<ShuffleBlockInfo> shuffleBlockInfoList = createShuffleBlockList(1, 31);
+    BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
+    WriteBufferManager bufferManager =
+            new WriteBufferManager(
+                    0,
+                    0,
+                    bufferOptions,
+                    new KryoSerializer(conf),
+                    Maps.newHashMap(),
+                    mock(TaskMemoryManager.class),
+                    new ShuffleWriteMetrics(),
+                    RssSparkConfig.toRssConf(conf));
+    WriteBufferManager bufferManagerSpy = spy(bufferManager);
+    ShuffleWriteMetrics mockMetrics = mock(ShuffleWriteMetrics.class);
     RssShuffleWriter<String, String, String> writer =
         new RssShuffleWriter<>(
             "appId",

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -79,7 +79,8 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_CLIENT_RETRY_MAX.key(), "10")
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
-        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346")
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     Map<String, Set<Long>> failBlocks = JavaUtils.newConcurrentMap();
     Map<String, Set<Long>> successBlocks = JavaUtils.newConcurrentMap();
     Serializer kryoSerializer = new KryoSerializer(conf);
@@ -196,7 +197,8 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key(), "100000")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY.name())
-        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346")
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
 
     Map<String, Set<Long>> successBlockIds = Maps.newConcurrentMap();
 
@@ -287,7 +289,8 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_CLIENT_SEND_CHECK_INTERVAL_MS.key(), "1000")
         .set(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key(), "128")
         .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name())
-        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
+        .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346")
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     List<ShuffleBlockInfo> shuffleBlockInfos = Lists.newArrayList();
     Map<String, Set<Long>> successBlockIds = Maps.newConcurrentMap();
 
@@ -428,7 +431,8 @@ public class RssShuffleWriterTest {
             RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
                 + RssSparkConfig.RSS_CLIENT_SEND_SIZE_LIMITATION.key(),
             "64")
-        .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
+        .set(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name())
+        .set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
 
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
     WriteBufferManager bufferManager =
@@ -447,7 +451,6 @@ public class RssShuffleWriterTest {
     ShuffleWriteMetrics mockMetrics = mock(ShuffleWriteMetrics.class);
     Partitioner mockPartitioner = mock(Partitioner.class);
     when(mockDependency.partitioner()).thenReturn(mockPartitioner);
-    SparkConf sparkConf = new SparkConf();
     when(mockPartitioner.numPartitions()).thenReturn(2);
     List<AddBlockEvent> events = Lists.newArrayList();
 
@@ -457,7 +460,8 @@ public class RssShuffleWriterTest {
               events.add(event);
               return new CompletableFuture<>();
             });
-
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), "1");
     RssShuffleManager mockShuffleManager =
         spy(
             TestUtils.createShuffleManager(

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -307,7 +307,8 @@ public class RssUtils {
     return extensions;
   }
 
-  public static void checkQuorumSetting(int replica, int replicaWrite, int replicaRead) {
+  public static void checkQuorumSetting(
+      int replica, int replicaWrite, int replicaRead, int shuffleServer) {
     if (replica < 1 || replicaWrite > replica || replicaRead > replica) {
       throw new RssException(
           "Replica config is invalid, recommend replica.write + replica.read > replica");
@@ -315,6 +316,10 @@ public class RssUtils {
     if (replicaWrite + replicaRead <= replica) {
       throw new RssException(
           "Replica config is unsafe, recommend replica.write + replica.read > replica");
+    }
+    if (shuffleServer < replica) {
+      throw new RssException(
+          "Assignment config is unsafe, recommend rss.client.assignment.shuffle.nodes.max > replica");
     }
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -211,7 +211,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
       assertTrue(e.getMessage().startsWith("Replica config is invalid"));
     }
     try {
-      RssUtils.checkQuorumSetting(0, 0, 0, -1);
+      RssUtils.checkQuorumSetting(1, 1, 1, 0);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
       assertTrue(e.getMessage().startsWith("Assignment config is unsafe"));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -193,22 +193,28 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void quorumConfigTest() throws Exception {
     try {
-      RssUtils.checkQuorumSetting(3, 1, 1);
+      RssUtils.checkQuorumSetting(3, 1, 1, 3);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
       assertTrue(e.getMessage().startsWith("Replica config is unsafe"));
     }
     try {
-      RssUtils.checkQuorumSetting(3, 4, 1);
+      RssUtils.checkQuorumSetting(3, 4, 1, 3);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
       assertTrue(e.getMessage().startsWith("Replica config is invalid"));
     }
     try {
-      RssUtils.checkQuorumSetting(0, 0, 0);
+      RssUtils.checkQuorumSetting(0, 0, 0, 3);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
       assertTrue(e.getMessage().startsWith("Replica config is invalid"));
+    }
+    try {
+      RssUtils.checkQuorumSetting(0, 0, 0, -1);
+      fail(EXPECTED_EXCEPTION_MESSAGE);
+    } catch (Exception e) {
+      assertTrue(e.getMessage().startsWith("Assignment config is unsafe"));
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add check for `rss.client.assignment.shuffle.nodes.max` and `rss.data.replica`

### Why are the changes needed?

Fix: #1196 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

current testing
