### PR TITLE
[ISSUE-1204] chores(ci): Fix the ci pipeline of Kubernetes

### DIFF
--- a/deploy/kubernetes/operator/Makefile
+++ b/deploy/kubernetes/operator/Makefile
@@ -127,7 +127,7 @@ goimports: ## Download goimports locally if necessary.
 REVIVE = $(LOCAL_DIR)/revive
 .PHONY: revive
 revive: ## Download revive locally if necessary.
-	$(call go-get-tool,$(REVIVE),github.com/mgechev/revive@latest)
+	$(call go-get-tool,$(REVIVE),github.com/mgechev/revive@v1.3.3)
 	files=$$(find . -name '*.go' | egrep -v './vendor|zz_generated|./pkg/generated|./api|./hack'); \
     $(REVIVE) -config hack/revive.toml -formatter friendly $$files
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The ci pipeline use the latest revive package. But the version v1.3.4 will cause the failure of CI. So I use the older version package to pass the CI pipeline
https://github.com/apache/incubator-uniffle/actions/runs/6273740844/job/17060784342

### Why are the changes needed?

Fix: #1204

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI passed.
