### PR TITLE
[#1211] fix: Unexpectedly removing resources even though the App has re-registered shuffle later.

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -188,6 +188,15 @@ public class ShuffleTaskManager {
     thread.start();
   }
 
+  private Lock getAppLock(String appId) {
+    try {
+      return appLocks.get(appId, ReentrantLock::new);
+    } catch (ExecutionException e) {
+      LOG.error("Failed to get App lock.", e);
+      throw new RssException(e);
+    }
+  }
+
   /** Only for test */
   @VisibleForTesting
   public StatusCode registerShuffle(
@@ -204,15 +213,6 @@ public class ShuffleTaskManager {
         user,
         ShuffleDataDistributionType.NORMAL,
         -1);
-  }
-
-  private Lock getAppLock(String appId) {
-    try {
-      return appLocks.get(appId, ReentrantLock::new);
-    } catch (ExecutionException e) {
-      LOG.error("Failed to get App lock.", e);
-      throw new RssException(e);
-    }
   }
 
   public StatusCode registerShuffle(

--- a/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
@@ -158,7 +158,7 @@ public class KerberizedShuffleTaskManagerTest extends KerberizedHadoopBase {
     assertTrue(fs.exists(new Path(appBasePath)));
     assertNull(shuffleBufferManager.getBufferPool().get(appId).get(0));
     assertNotNull(shuffleBufferManager.getBufferPool().get(appId).get(1));
-    shuffleTaskManager.removeResources(appId);
+    shuffleTaskManager.removeResources(appId, false);
     assertFalse(fs.exists(new Path(appBasePath)));
     assertNull(shuffleBufferManager.getBufferPool().get(appId));
   }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
@@ -103,7 +103,7 @@ public class ShuffleServerTest {
     // Shuffle server is decommissioning, but we can also decommission it again.
     shuffleServer.decommission();
     shuffleServer.cancelDecommission();
-    shuffleTaskManager.removeResources(appId);
+    shuffleTaskManager.removeResources(appId, false);
     // Wait for 2 seconds, make sure cancel command is work.
     Thread.sleep(2000);
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -48,6 +48,7 @@ import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.common.util.Constants;
@@ -150,7 +151,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     assertEquals(1, ShuffleServerMetrics.gaugeAppWithHugePartitionNum.get());
 
     // case5
-    shuffleTaskManager.removeResources(appId);
+    shuffleTaskManager.removeResources(appId, false);
     assertEquals(0, ShuffleServerMetrics.gaugeHugePartitionNum.get());
     assertEquals(0, ShuffleServerMetrics.gaugeAppWithHugePartitionNum.get());
   }
@@ -447,7 +448,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     assertTrue(fs.exists(new Path(appBasePath)));
     assertNull(shuffleBufferManager.getBufferPool().get(appId).get(0));
     assertNotNull(shuffleBufferManager.getBufferPool().get(appId).get(1));
-    shuffleTaskManager.removeResources(appId);
+    shuffleTaskManager.removeResources(appId, false);
   }
 
   @Test
@@ -618,7 +619,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
       new Thread(
               () -> {
                 try {
-                  shuffleTaskManager.removeResources(appId);
+                  shuffleTaskManager.removeResources(appId, false);
                 } finally {
                   countDownLatch.countDown();
                 }
@@ -1062,5 +1063,63 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
 
     // case3: client max concurrency exceed 30
     assertEquals(30, ShuffleTaskManager.getMaxConcurrencyWriting(40, conf));
+  }
+
+  @Test
+  public void testRegisterShuffleAfterAppIsExpired() throws Exception {
+    String confFile = ClassLoader.getSystemResource("server.conf").getFile();
+    ShuffleServerConf conf = new ShuffleServerConf(confFile);
+    String storageBasePath = HDFS_URI + "rss/testRegisterShuffleAfterAppIsExpired";
+    conf.set(ShuffleServerConf.RSS_TEST_MODE_ENABLE, true);
+    conf.set(ShuffleServerConf.RPC_SERVER_PORT, 1234);
+    conf.set(ShuffleServerConf.RSS_COORDINATOR_QUORUM, "localhost:9527");
+
+    shuffleServer = new ShuffleServer(conf);
+    ShuffleTaskManager shuffleTaskManager = shuffleServer.getShuffleTaskManager();
+
+    String appId = "appId1";
+    shuffleTaskManager.registerShuffle(
+        appId,
+        1,
+        Lists.newArrayList(new PartitionRange(0, 1)),
+        new RemoteStorageInfo(storageBasePath, Maps.newHashMap()),
+        StringUtils.EMPTY);
+    shuffleTaskManager.refreshAppId(appId);
+    assertEquals(1, shuffleTaskManager.getAppIds().size());
+
+    ShufflePartitionedData partitionedData0 = createPartitionedData(1, 1, 35);
+    shuffleTaskManager.requireBuffer(35);
+    shuffleTaskManager.cacheShuffleData(appId, 0, false, partitionedData0);
+    shuffleTaskManager.updateCachedBlockIds(appId, 0, partitionedData0.getBlockList());
+    shuffleTaskManager.refreshAppId(appId);
+    shuffleTaskManager.checkResourceStatus();
+    assertEquals(1, shuffleTaskManager.getAppIds().size());
+
+    // App is expired due to no heartbeat, so it was added to expired queue and will be removed
+    // resource soon.
+    Thread thread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(1000);
+                shuffleTaskManager.removeResources(appId, true);
+              } catch (InterruptedException e) {
+                throw new RssException(e);
+              }
+            });
+    thread.start();
+
+    // At this moment, this app re-registers shuffle.
+    shuffleTaskManager.registerShuffle(
+        appId,
+        2,
+        Lists.newArrayList(new PartitionRange(0, 1)),
+        new RemoteStorageInfo(storageBasePath, Maps.newHashMap()),
+        StringUtils.EMPTY);
+    Thread.sleep(2000);
+
+    // The NO_REGISTER status code should not appear.
+    assertTrue(shuffleTaskManager.requireBuffer(appId, 2, Arrays.asList(1), 35) != -4);
+    shuffleTaskManager.removeResources(appId, false);
   }
 }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -1069,7 +1069,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
   public void testRegisterShuffleAfterAppIsExpired() throws Exception {
     String confFile = ClassLoader.getSystemResource("server.conf").getFile();
     ShuffleServerConf conf = new ShuffleServerConf(confFile);
-    String storageBasePath = HDFS_URI + "rss/testRegisterShuffleAfterAppIsExpired";
+    final String storageBasePath = HDFS_URI + "rss/testRegisterShuffleAfterAppIsExpired";
     conf.set(ShuffleServerConf.RSS_TEST_MODE_ENABLE, true);
     conf.set(ShuffleServerConf.RPC_SERVER_PORT, 1234);
     conf.set(ShuffleServerConf.RSS_COORDINATOR_QUORUM, "localhost:9527");


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Check again if the App has expired when removing resources.

### Why are the changes needed?


Fix: https://github.com/apache/incubator-uniffle/issues/1211

### Does this PR introduce _any_ user-facing change?


No.

### How was this patch tested?

Add more tests.
