### PR TITLE
[#1243] fix(test): Fix the flaky test `SparkSQLTest` and `Repartition…

### DIFF
--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionTest.java
@@ -32,15 +32,12 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class RepartitionTest extends SparkIntegrationTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepartitionTest.class);
-
-  static @TempDir File tempDir;
 
   @Test
   public void resultCompareTest() throws Exception {

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLTest.java
@@ -30,15 +30,12 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class SparkSQLTest extends SparkIntegrationTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkSQLTest.class);
-
-  static @TempDir File tempDir;
 
   @Test
   public void resultCompareTest() throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove static tmpDir field annotated with `@TempDir` of which their super class has the same field  with the same annotation

### Why are the changes needed?
When both static tmpDir field annotated with `@TempDir` exists, the tmpDir of the super class is not initialized by the junit framework, then NullPointerException occurs when call `IntegrationTestBase.getShuffleServerConf()`

https://github.com/apache/incubator-uniffle/issues/1243

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
mvn -B   package -Dtest=org.apache.uniffle.test.SparkSQLWithDelegationShuffleManagerTest -Pspark3
mvn -B   package -Dtest=org.apache.uniffle.test.RepartitionWithLocalFileRssTest -Pspark3

