### PR TITLE
[#1256] refactor: optimize collections contruction

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -18,11 +18,7 @@
 package org.apache.hadoop.mapred;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -201,7 +197,7 @@ public class SortWriteBufferManager<K, V> {
   }
 
   private void sendBufferToServers(SortWriteBuffer<K, V> buffer) {
-    List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
+    List<ShuffleBlockInfo> shuffleBlocks = new ArrayList<>(1);
     prepareBufferForSend(shuffleBlocks, buffer);
     sendShuffleBlocks(shuffleBlocks);
   }

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -18,7 +18,12 @@
 package org.apache.hadoop.mapred;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EventFetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EventFetcherTest.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.mapreduce.task.reduce;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -78,7 +79,11 @@ public class EventFetcherTest {
             any(JobID.class), eq(0), eq(MAX_EVENTS_TO_FETCH), eq(tid)))
         .thenReturn(
             getMockedCompletionEventsUpdate(
-                0, mapTaskNum, Sets.newHashSet(70, 80, 90), Sets.newHashSet(), Sets.newHashSet()));
+                0,
+                mapTaskNum,
+                Sets.newHashSet(70, 80, 90),
+                Collections.EMPTY_SET,
+                Collections.EMPTY_SET));
 
     RssEventFetcher ef = new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
@@ -135,7 +140,7 @@ public class EventFetcherTest {
             any(JobID.class), eq(0), eq(MAX_EVENTS_TO_FETCH), eq(tid)))
         .thenReturn(
             getInconsistentCompletionEventsUpdate(
-                0, mapTaskNum, Sets.newHashSet(45, 67), Sets.newHashSet()));
+                0, mapTaskNum, Sets.newHashSet(45, 67), Collections.EMPTY_SET));
 
     RssEventFetcher ef = new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -17,7 +17,11 @@
 
 package org.apache.spark.shuffle.writer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -585,7 +585,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getFailedBlockIds(String taskId) {
     Set<Long> result = taskToFailedBlockIds.get(taskId);
     if (result == null) {
-      result = Sets.newHashSet();
+      result = Collections.emptySet();
     }
     return result;
   }
@@ -593,7 +593,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getSuccessBlockIds(String taskId) {
     Set<Long> result = taskToSuccessBlockIds.get(taskId);
     if (result == null) {
-      result = Sets.newHashSet();
+      result = Collections.emptySet();
     }
     return result;
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -875,7 +875,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getFailedBlockIds(String taskId) {
     Set<Long> result = taskToFailedBlockIds.get(taskId);
     if (result == null) {
-      Collections.emptySet();
+      result = Collections.emptySet();
     }
     return result;
   }
@@ -883,7 +883,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getSuccessBlockIds(String taskId) {
     Set<Long> result = taskToSuccessBlockIds.get(taskId);
     if (result == null) {
-      Collections.emptySet();
+      result = Collections.emptySet();
     }
     return result;
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -875,7 +875,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getFailedBlockIds(String taskId) {
     Set<Long> result = taskToFailedBlockIds.get(taskId);
     if (result == null) {
-      result = Sets.newHashSet();
+      Collections.emptySet();
     }
     return result;
   }
@@ -883,7 +883,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public Set<Long> getSuccessBlockIds(String taskId) {
     Set<Long> result = taskToSuccessBlockIds.get(taskId);
     if (result == null) {
-      result = Sets.newHashSet();
+      Collections.emptySet();
     }
     return result;
   }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
@@ -18,7 +18,12 @@
 package org.apache.tez.runtime.library.common.sort.buffer;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
@@ -18,11 +18,7 @@
 package org.apache.tez.runtime.library.common.sort.buffer;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -208,7 +204,7 @@ public class WriteBufferManager<K, V> {
   }
 
   private void sendBufferToServers(WriteBuffer<K, V> buffer) {
-    List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
+    List<ShuffleBlockInfo> shuffleBlocks = new ArrayList<>(1);
     prepareBufferForSend(shuffleBlocks, buffer);
     sendShuffleBlocks(shuffleBlocks);
   }

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -19,7 +19,13 @@ package org.apache.tez.runtime.library.common.sort.buffer;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -19,12 +19,7 @@ package org.apache.tez.runtime.library.common.sort.buffer;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -556,7 +551,7 @@ public class WriteBufferManagerTest {
         for (ShuffleBlockInfo blockInfo : shuffleBlockInfoList) {
           successBlockIds.add(blockInfo.getBlockId());
         }
-        return new SendShuffleDataResult(successBlockIds, Sets.newHashSet());
+        return new SendShuffleDataResult(successBlockIds, Collections.EMPTY_SET);
       }
     }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.file.Files;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -85,8 +84,8 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     for (ShuffleServer shuffleServer : shuffleServers) {
       shuffleServer.stopServer();
     }
-    shuffleServers = Collections.emptyList();
-    coordinators = Collections.emptyList();
+    shuffleServers = Lists.newArrayList();
+    coordinators = Lists.newArrayList();
     ShuffleServerMetrics.clear();
     CoordinatorMetrics.clear();
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -84,8 +85,8 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     for (ShuffleServer shuffleServer : shuffleServers) {
       shuffleServer.stopServer();
     }
-    shuffleServers = Lists.newArrayList();
-    coordinators = Lists.newArrayList();
+    shuffleServers = Collections.emptyList();
+    coordinators = Collections.emptyList();
     ShuffleServerMetrics.clear();
     CoordinatorMetrics.clear();
   }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetShuffleAssignmentsRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssGetShuffleAssignmentsRequest.java
@@ -17,10 +17,10 @@
 
 package org.apache.uniffle.client.request;
 
+import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
 
 public class RssGetShuffleAssignmentsRequest {
 
@@ -51,7 +51,7 @@ public class RssGetShuffleAssignmentsRequest {
         requiredTags,
         -1,
         -1,
-        Sets.newHashSet());
+        Collections.emptySet());
   }
 
   public RssGetShuffleAssignmentsRequest(

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -18,7 +18,13 @@
 package org.apache.uniffle.server;
 
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -18,12 +18,7 @@
 package org.apache.uniffle.server;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -576,7 +571,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     shuffleTaskManager.checkResourceStatus();
     // wait resource delete
     Thread.sleep(3000);
-    assertEquals(Sets.newHashSet(), shuffleTaskManager.getAppIds());
+    assertEquals(Collections.EMPTY_SET, shuffleTaskManager.getAppIds());
     assertTrue(shuffleTaskManager.getCachedBlockIds("clearTest1", shuffleId).isEmpty());
   }
 
@@ -627,7 +622,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
           .start();
     }
     countDownLatch.await();
-    assertEquals(Sets.newHashSet(), shuffleTaskManager.getAppIds());
+    assertEquals(Collections.EMPTY_SET, shuffleTaskManager.getAppIds());
     assertTrue(shuffleTaskManager.getCachedBlockIds(appId, shuffleId).isEmpty());
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Some empty collections are only for read, so replace it with Collections.emptyList(), Collections.emptySet(), Collections.emptyMap().
2. In spark, writer client construct a new List prepared for shuffleBlockInfos per record, But in most case there is no blocks produced.
3. Set proper initial value.

### Why are the changes needed?
https://github.com/apache/incubator-uniffle/issues/1256

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
unit test
