### PR TITLE
[#825][part-2][followup] fix(writer): Apply a thread safety way to track the blocks sending result

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -56,7 +57,8 @@ public class DataPusher implements Closeable {
   private final Map<String, Set<Long>> taskToSuccessBlockIds;
   // Must be thread safe
   private final Map<String, Set<Long>> taskToFailedBlockIds;
-  private final Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer;
+  private final Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>>
+      taskToFailedBlockIdsAndServer;
   private String rssAppId;
   // Must be thread safe
   private final Set<String> failedTaskIds;
@@ -65,7 +67,7 @@ public class DataPusher implements Closeable {
       ShuffleWriteClient shuffleWriteClient,
       Map<String, Set<Long>> taskToSuccessBlockIds,
       Map<String, Set<Long>> taskToFailedBlockIds,
-      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
+      Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
       Set<String> failedTaskIds,
       int threadPoolSize,
       int threadKeepAliveTime) {
@@ -126,9 +128,9 @@ public class DataPusher implements Closeable {
   }
 
   private synchronized void putSendFailedBlockIdAndShuffleServer(
-      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
+      Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
       String taskAttemptId,
-      Map<Long, List<ShuffleServerInfo>> blockIdsAndServer) {
+      Map<Long, BlockingQueue<ShuffleServerInfo>> blockIdsAndServer) {
     if (blockIdsAndServer == null || blockIdsAndServer.isEmpty()) {
       return;
     }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/DataPusherTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
@@ -81,7 +82,7 @@ public class DataPusherTest {
 
     Map<String, Set<Long>> taskToSuccessBlockIds = Maps.newConcurrentMap();
     Map<String, Set<Long>> taskToFailedBlockIds = Maps.newConcurrentMap();
-    Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
+    Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
         JavaUtils.newConcurrentMap();
     Set<String> failedTaskIds = new HashSet<>();
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -87,8 +88,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private Map<String, Set<Long>> taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
   private Map<String, Set<Long>> taskToFailedBlockIds = JavaUtils.newConcurrentMap();
   // Record both the block that failed to be sent and the ShuffleServer
-  private final Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
-      JavaUtils.newConcurrentMap();
+  private final Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>>
+      taskToFailedBlockIdsAndServer = JavaUtils.newConcurrentMap();
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
@@ -703,10 +704,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
    * @param taskId Shuffle taskId
    * @return List of failed ShuffleServer blocks
    */
-  public Map<Long, List<ShuffleServerInfo>> getFailedBlockIdsWithShuffleServer(String taskId) {
-    Map<Long, List<ShuffleServerInfo>> result = taskToFailedBlockIdsAndServer.get(taskId);
+  public Map<Long, BlockingQueue<ShuffleServerInfo>> getFailedBlockIdsWithShuffleServer(
+      String taskId) {
+    Map<Long, BlockingQueue<ShuffleServerInfo>> result = taskToFailedBlockIdsAndServer.get(taskId);
     if (result == null) {
-      result = JavaUtils.newConcurrentMap();
+      result = Collections.emptyMap();
     }
     return result;
   }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -162,7 +163,7 @@ public class RssShuffleWriterTest {
         ShuffleWriteClient shuffleWriteClient,
         Map<String, Set<Long>> taskToSuccessBlockIds,
         Map<String, Set<Long>> taskToFailedBlockIds,
-        Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
+        Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
         Set<String> failedTaskIds,
         int threadPoolSize,
         int threadKeepAliveTime,

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.shuffle;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.spark.SparkConf;
@@ -37,7 +37,7 @@ public class TestUtils {
       DataPusher dataPusher,
       Map<String, Set<Long>> successBlockIds,
       Map<String, Set<Long>> failBlockIds,
-      Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer) {
+      Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer) {
     return new RssShuffleManager(
         conf, isDriver, dataPusher, successBlockIds, failBlockIds, taskToFailedBlockIdsAndServer);
   }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -82,12 +83,10 @@ public class RssShuffleWriterTest {
         .set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "127.0.0.1:12345,127.0.0.1:12346");
     Map<String, Set<Long>> failBlocks = JavaUtils.newConcurrentMap();
     Map<String, Set<Long>> successBlocks = JavaUtils.newConcurrentMap();
-    Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer =
-        JavaUtils.newConcurrentMap();
     Serializer kryoSerializer = new KryoSerializer(conf);
     RssShuffleManager manager =
         TestUtils.createShuffleManager(
-            conf, false, null, successBlocks, failBlocks, taskToFailedBlockIdsAndServer);
+            conf, false, null, successBlocks, failBlocks, JavaUtils.newConcurrentMap());
 
     ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
     Partitioner mockPartitioner = mock(Partitioner.class);
@@ -164,7 +163,7 @@ public class RssShuffleWriterTest {
         ShuffleWriteClient shuffleWriteClient,
         Map<String, Set<Long>> taskToSuccessBlockIds,
         Map<String, Set<Long>> taskToFailedBlockIds,
-        Map<String, Map<Long, List<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
+        Map<String, Map<Long, BlockingQueue<ShuffleServerInfo>>> taskToFailedBlockIdsAndServer,
         Set<String> failedTaskIds,
         int threadPoolSize,
         int threadKeepAliveTime,

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -363,13 +363,17 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         .forEach(
             blockList ->
                 blockList.forEach(
-                    block -> blockIdsSendSuccessTracker.put(block, new AtomicInteger(0))));
+                    block ->
+                        blockIdsSendSuccessTracker.computeIfAbsent(
+                            block, id -> new AtomicInteger(0))));
     secondaryServerToBlockIds
         .values()
         .forEach(
             blockList ->
                 blockList.forEach(
-                    block -> blockIdsSendSuccessTracker.put(block, new AtomicInteger(0))));
+                    block ->
+                        blockIdsSendSuccessTracker.computeIfAbsent(
+                            block, id -> new AtomicInteger(0))));
     Map<Long, BlockingQueue<ShuffleServerInfo>> blockIdsSendFailTracker =
         JavaUtils.newConcurrentMap();
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -401,14 +401,13 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           needCancelRequest);
     }
 
+    Set<Long> blockIdsSendSuccessSet = Sets.newHashSet();
     blockIdsSendSuccessTracker
         .entrySet()
         .forEach(
             successBlockId -> {
-              if (successBlockId.getValue().get() < replicaWrite) {
-                // Removes blocks that do not reach replicaWrite from the success queue
-                blockIdsSendSuccessTracker.remove(successBlockId.getKey());
-              } else {
+              if (successBlockId.getValue().get() >= replicaWrite) {
+                blockIdsSendSuccessSet.add(successBlockId.getKey());
                 // If the replicaWrite to be sent is reached,
                 // no matter whether the block fails to be sent or not,
                 // the block is considered to have been sent successfully and is removed from the
@@ -417,9 +416,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               }
             });
     return new SendShuffleDataResult(
-        blockIdsSendSuccessTracker.keySet(),
-        blockIdsSendFailTracker.keySet(),
-        blockIdsSendFailTracker);
+        blockIdsSendSuccessSet, blockIdsSendFailTracker.keySet(), blockIdsSendFailTracker);
   }
 
   /**

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -17,9 +17,9 @@
 
 package org.apache.uniffle.client.response;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.JavaUtils;
@@ -28,7 +28,7 @@ public class SendShuffleDataResult {
 
   private Set<Long> successBlockIds;
   private Set<Long> failedBlockIds;
-  private Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds;
+  private Map<Long, BlockingQueue<ShuffleServerInfo>> sendFailedBlockIds;
 
   public SendShuffleDataResult(Set<Long> successBlockIds, Set<Long> failedBlockIds) {
     this.successBlockIds = successBlockIds;
@@ -39,7 +39,7 @@ public class SendShuffleDataResult {
   public SendShuffleDataResult(
       Set<Long> successBlockIds,
       Set<Long> failedBlockIds,
-      Map<Long, List<ShuffleServerInfo>> sendFailedBlockIds) {
+      Map<Long, BlockingQueue<ShuffleServerInfo>> sendFailedBlockIds) {
     this.successBlockIds = successBlockIds;
     this.failedBlockIds = failedBlockIds;
     this.sendFailedBlockIds = sendFailedBlockIds;
@@ -53,7 +53,7 @@ public class SendShuffleDataResult {
     return failedBlockIds;
   }
 
-  public Map<Long, List<ShuffleServerInfo>> getSendFailedBlockIds() {
+  public Map<Long, BlockingQueue<ShuffleServerInfo>> getSendFailedBlockIds() {
     return sendFailedBlockIds;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
As title

### Why are the changes needed?
```
[INFO] Running org.apache.uniffle.test.ContinuousSelectPartitionStrategyTest
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 59.195 s <<< FAILURE! - in org.apache.uniffle.test.ContinuousSelectPartitionStrategyTest
Error:  resultCompareTest  Time elapsed: 55.751 s  <<< ERROR!
org.apache.spark.SparkException: 
Job aborted due to stage failure: Task 6 in stage 1.0 failed 1 times, most recent failure: Lost task 6.0 in stage 1.0 (TID 16) (fv-az391-410.nf14wd45lyte3l5gjbhk121dmd.jx.internal.cloudapp.net executor driver): org.apache.uniffle.common.exception.RssException: Timeout: Task[16_0] failed because 9 blocks can't be sent to shuffle server in 30000 ms.
	at org.apache.spark.shuffle.writer.RssShuffleWriter.checkBlockSendResult(RssShuffleWriter.java:350)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.writeImpl(RssShuffleWriter.java:246)
	at org.apache.spark.shuffle.writer.RssShuffleWriter.write(RssShuffleWriter.java:209)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
```
[ActionLink](https://github.com/apache/incubator-uniffle/actions/runs/6611324517/job/17954967498?pr=1257)
I debug the local test and find that all blocks are successfully send, but some blocks are not in the block tracker

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Integration test
Especially run below test in a loop of many times without a fail
```
mvn -B -fae test -Dtest=org.apache.uniffle.test.ContinuousSelectPartitionStrategyTest -Pspark3
```
