### PR TITLE
[#1261] fix(spark): Throw out InterruptedException for sleep in requestExecutorMemory

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -372,7 +372,7 @@ public class WriteBufferManager extends MemoryConsumer {
       try {
         Thread.sleep(requireMemoryInterval);
       } catch (InterruptedException ie) {
-        LOG.warn("Exception happened when waiting for memory.", ie);
+        throw new RssException("Interrupted when waiting for memory.", ie);
       }
       gotMem = acquireMemory(askExecutorMemory);
       allocatedBytes.addAndGet(gotMem);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Pass InterruptedException in requestExecutorMemory.

### Why are the changes needed?



Fix:  #1261

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?


