### PR TITLE
[#1249] feat(mr): Support to spill large amounts of shuffle data.

### DIFF
--- a/client-mr/core/pom.xml
+++ b/client-mr/core/pom.xml
@@ -115,6 +115,11 @@
             <groupId>org.apache.uniffle</groupId>
             <artifactId>hadoop${hadoop.short.version}-shim</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
@@ -17,12 +17,20 @@
 
 package org.apache.hadoop.mapreduce.task.reduce;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.mapred.IFileOutputStream;
 
 import org.apache.uniffle.common.exception.RssException;
 
@@ -31,7 +39,7 @@ import org.apache.uniffle.common.exception.RssException;
 public class RssBypassWriter {
   private static final Log LOG = LogFactory.getLog(RssBypassWriter.class);
 
-  public static void write(MapOutput mapOutput, byte[] buffer) {
+  public static void write(MapOutput mapOutput, byte[] buffer, CompressionCodec codec) {
     // Write and commit uncompressed data to MapOutput.
     // In the majority of cases, merger allocates memory to accept data,
     // but when data size exceeds the threshold, merger can also allocate disk.
@@ -46,11 +54,7 @@ public class RssBypassWriter {
       CodecPool.returnDecompressor(getDecompressor(inMemoryMapOutput));
       write(inMemoryMapOutput, buffer);
     } else if (mapOutput instanceof OnDiskMapOutput) {
-      // RSS leverages its own compression, it is incompatible with hadoop's disk file compression.
-      // So we should disable this situation.
-      throw new IllegalStateException(
-          "RSS does not support OnDiskMapOutput as shuffle ouput,"
-              + " try to reduce mapreduce.reduce.shuffle.memory.limit.percent");
+      write((OnDiskMapOutput) mapOutput, buffer, codec);
     } else {
       throw new IllegalStateException(
           "Merger reserve unknown type of MapOutput: " + mapOutput.getClass().getCanonicalName());
@@ -60,6 +64,69 @@ public class RssBypassWriter {
   private static void write(InMemoryMapOutput inMemoryMapOutput, byte[] buffer) {
     byte[] memory = inMemoryMapOutput.getMemory();
     System.arraycopy(buffer, 0, memory, 0, buffer.length);
+  }
+
+  // The parameter 'codec' is hadoop codec. RssFetcher will fetch compressed data
+  // (compressed by uiffle), then decompressed to the parameter 'buffer'. Until now
+  // buffer is the decompressed data. But when MergeManagerImpl merge the temporary
+  // shuffle data, will use hadoop compression code. So we should compressed the buffer
+  // for future merge.
+  // For now, it is not recommended to enable "mapreduce.map.output.compress".
+  private static void write(
+      OnDiskMapOutput onDiskMapOutput, byte[] buffer, CompressionCodec codec) {
+    OutputStream disk = null;
+    try {
+      Class clazz = Class.forName(OnDiskMapOutput.class.getName());
+      Field diskField = clazz.getDeclaredField("disk");
+      diskField.setAccessible(true);
+      disk = (OutputStream) diskField.get(onDiskMapOutput);
+    } catch (Exception e) {
+      throw new RssException(
+          "Failed to access OnDiskMapOutput by reflection due to: " + e.getMessage());
+    }
+    if (disk == null) {
+      throw new RssException("OnDiskMapOutput should not contain null disk stream");
+    }
+
+    // Copy data to local-disk
+    FSDataOutputStream out = null;
+    CompressionOutputStream compressedOut = null;
+    IFileOutputStream ifos = null;
+    Compressor compressor = null;
+    try {
+      ifos = new IFileOutputStream(disk);
+      if (codec != null) {
+        compressor = CodecPool.getCompressor(codec);
+        if (compressor != null) {
+          compressor.reset();
+          compressedOut = codec.createOutputStream(ifos, compressor);
+          out = new FSDataOutputStream(compressedOut, null);
+        } else {
+          LOG.warn("Could not obtain compressor from CodecPool");
+          out = new FSDataOutputStream(ifos, null);
+        }
+      } else {
+        out = new FSDataOutputStream(ifos, null);
+      }
+      out.write(buffer, 0, buffer.length);
+      out.close();
+    } catch (IOException ioe) {
+      throw new RssException("Failed to write OnDiskMapOutput due to: " + ioe.getMessage());
+    } finally {
+      // Close the streams
+      if (out != null) {
+        IOUtils.cleanup(LOG, out);
+      } else if (compressedOut != null) {
+        IOUtils.cleanup(LOG, compressedOut);
+      } else if (ifos != null) {
+        IOUtils.cleanup(LOG, ifos);
+      } else {
+        IOUtils.cleanup(LOG, disk);
+      }
+      if (compressor != null) {
+        CodecPool.returnCompressor(compressor);
+      }
+    }
   }
 
   static Decompressor getDecompressor(InMemoryMapOutput inMemoryMapOutput) {

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
@@ -244,7 +244,8 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
               metrics,
               shuffleReadClient,
               blockIdBitmap.getLongCardinality(),
-              RssMRConfig.toRssConf(rssJobConf));
+              RssMRConfig.toRssConf(rssJobConf),
+              context.getCodec());
       fetcher.fetchAllRssBlocks();
       LOG.info(
           "In reduce: " + reduceId + ", Rss MR client fetches blocks from RSS server successfully");

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -127,7 +127,8 @@ public class FetcherTest {
             metrics,
             shuffleReadClient,
             3,
-            new RssConf());
+            new RssConf(),
+            null);
     fetcher.fetchAllRssBlocks();
 
     RawKeyValueIterator iterator = merger.close();
@@ -182,7 +183,8 @@ public class FetcherTest {
             metrics,
             shuffleReadClient,
             3,
-            new RssConf());
+            new RssConf(),
+            null);
     fetcher.fetchAllRssBlocks();
 
     RawKeyValueIterator iterator = merger.close();
@@ -240,7 +242,8 @@ public class FetcherTest {
             metrics,
             shuffleReadClient,
             3,
-            new RssConf());
+            new RssConf(),
+            null);
     fetcher.fetchAllRssBlocks();
 
     RawKeyValueIterator iterator = merger.close();
@@ -290,9 +293,9 @@ public class FetcherTest {
     TaskAttemptID taskAttemptID = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, 1, 1);
     byte[] buffer = new byte[10];
     MapOutput mapOutput1 = merger.reserve(taskAttemptID, 10, 1);
-    RssBypassWriter.write(mapOutput1, buffer);
+    RssBypassWriter.write(mapOutput1, buffer, null);
     MapOutput mapOutput2 = merger.reserve(taskAttemptID, 10, 1);
-    RssBypassWriter.write(mapOutput2, buffer);
+    RssBypassWriter.write(mapOutput2, buffer, null);
     assertEquals(
         RssBypassWriter.getDecompressor((InMemoryMapOutput) mapOutput1),
         RssBypassWriter.getDecompressor((InMemoryMapOutput) mapOutput2));

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImplTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/MergeManagerImplTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce.task.reduce;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalDirAllocator;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.SerializationFactory;
+import org.apache.hadoop.mapred.IFile;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.MROutputFiles;
+import org.apache.hadoop.mapred.RawKeyValueIterator;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.MRConfig;
+import org.apache.hadoop.mapreduce.RssMRUtils;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.util.Progress;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.junit.Assert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.apache.hadoop.mapreduce.MRJobConfig.REDUCE_MEMORY_TOTAL_BYTES;
+import static org.apache.hadoop.mapreduce.MRJobConfig.SHUFFLE_MEMORY_LIMIT_PERCENT;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MergeManagerImplTest {
+
+  private static JobID jobId = new JobID("a", 0);
+  private static TaskAttemptID reduceId1 =
+      new TaskAttemptID(new TaskID(jobId, TaskType.REDUCE, 0), 0);
+  private static LocalDirAllocator lda = new LocalDirAllocator(MRConfig.LOCAL_DIR);
+  private static FileSystem fs;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "org.apache.hadoop.io.compress.BZip2Codec"})
+  public void testMerge(String codecClassName) throws Throwable {
+    fs = FileSystem.getLocal(new JobConf());
+    JobConf jobConf = new JobConf();
+    jobConf.setInt(REDUCE_MEMORY_TOTAL_BYTES, 10240);
+    jobConf.setFloat(SHUFFLE_MEMORY_LIMIT_PERCENT, 0.1F);
+    CompressionCodec codec = getCompressionCodec(jobConf, codecClassName);
+    if (codec instanceof BZip2Codec) {
+      ((BZip2Codec) codec).setConf(jobConf);
+    }
+    MergeManagerImpl merger =
+        new MergeManagerImpl<Text, Text>(
+            reduceId1,
+            jobConf,
+            fs,
+            lda,
+            Reporter.NULL,
+            codec,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new Progress(),
+            new MROutputFiles());
+    int fetcherId = 1;
+    int taskId = 1;
+    int loops = 5;
+    // Add map output in inverted order
+    for (int i = loops - 1; i >= 0; i--) {
+      TaskAttemptID taskAttemptID =
+          RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskId++, 1);
+      byte[] buffer1 = writeMapOutput(jobConf, i * 100, i * 100 + 1);
+      MapOutput mapOutput1 = merger.reserve(taskAttemptID, buffer1.length, fetcherId++);
+      assertTrue(mapOutput1 instanceof InMemoryMapOutput);
+      RssBypassWriter.write(mapOutput1, buffer1, codec);
+      mapOutput1.commit();
+      taskAttemptID = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskId++, 1);
+      byte[] buffer2 = writeMapOutput(jobConf, i * 100 + 1, i * 100 + 100);
+      MapOutput mapOutput2 = merger.reserve(taskAttemptID, buffer2.length, fetcherId++);
+      assertTrue(mapOutput2 instanceof OnDiskMapOutput);
+      RssBypassWriter.write(mapOutput2, buffer2, codec);
+      mapOutput2.commit();
+    }
+    RawKeyValueIterator iterator = merger.close();
+    SerializationFactory serializationFactory = new SerializationFactory(jobConf);
+    Deserializer<Text> deserializer = serializationFactory.getDeserializer(Text.class);
+    BytesWritable currentRaw = new BytesWritable();
+    DataInputBuffer buffer = new DataInputBuffer();
+    deserializer.open(buffer);
+    for (int i = 0; i < loops * 100; i++) {
+      Assert.assertTrue(iterator.next());
+      DataInputBuffer nextBuffer = iterator.getKey();
+      currentRaw.set(
+          nextBuffer.getData(),
+          nextBuffer.getPosition(),
+          nextBuffer.getLength() - nextBuffer.getPosition());
+      buffer.reset(currentRaw.getBytes(), 0, currentRaw.getLength());
+      Text key = new Text();
+      key = deserializer.deserialize(key);
+      Assert.assertEquals(String.format("k%03d", i), key.toString());
+
+      nextBuffer = iterator.getValue();
+      currentRaw.set(
+          nextBuffer.getData(),
+          nextBuffer.getPosition(),
+          nextBuffer.getLength() - nextBuffer.getPosition());
+      buffer.reset(currentRaw.getBytes(), 0, currentRaw.getLength());
+      Text value = new Text();
+      value = deserializer.deserialize(value);
+      Assert.assertEquals(String.format("v%03d", i), value.toString());
+    }
+    Assert.assertFalse(iterator.next());
+  }
+
+  private static byte[] writeMapOutput(Configuration conf, int start, int end) throws IOException {
+    Map<String, String> keysToValues = new TreeMap<>();
+    for (int i = start; i < end; i++) {
+      keysToValues.put(String.format("k%03d", i), String.format("v%03d", i));
+    }
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    FSDataOutputStream fsdos = new FSDataOutputStream(baos, null);
+    IFile.Writer<Text, Text> writer =
+        new IFile.Writer<Text, Text>(conf, fsdos, Text.class, Text.class, null, null);
+    for (String key : keysToValues.keySet()) {
+      String value = keysToValues.get(key);
+      writer.append(new Text(key), new Text(value));
+    }
+    writer.close();
+    return baos.toByteArray();
+  }
+
+  private static CompressionCodec getCompressionCodec(JobConf jobConf, String name)
+      throws ClassNotFoundException {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    Class<? extends CompressionCodec> codecClass =
+        jobConf.getClassByName(name).asSubclass(CompressionCodec.class);
+    return ReflectionUtils.newInstance(codecClass, jobConf);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support to spill large amounts of shuffle data.

### Why are the changes needed?

For large amounts of shuffle data, we should restore into local or remote disk, but not memory.
This PR is proposal (1) which describe in #1249.

Fix: #1249 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

unit test, test mr word count on cluster.