### PR TITLE
 [WIP][#1264] feat(spark): support cancel async rpc when kill or interrupt task

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -977,10 +977,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return true;
   }
 
-  public boolean isValidTask(String taskId) {
-    return !failedTaskIds.contains(taskId);
-  }
-
   private Roaring64NavigableMap getShuffleResultForMultiPart(
       String clientType,
       Map<ShuffleServerInfo, Set<Integer>> serverToPartitions,

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -243,11 +243,12 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               dataTransferPool);
       futures.add(future);
     }
-
     boolean result = ClientUtils.waitUntilDoneOrFail(futures, allowFastFail);
-    if (!result) {
+    if (!result && Thread.currentThread().isInterrupted()) {
+      LOG.warn("task is interrupt, cancelled rpc size: {}", futures.size());
+    } else if (!result) {
       LOG.error(
-          "Some shuffle data can't be sent to shuffle-server, is fast fail: {}, cancelled task size: {}",
+          "Some shuffle data can't be sent to shuffle-server, is fast fail: {}, cancelled rpc size: {}",
           allowFastFail,
           futures.size());
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Cancel all the runnable that are wait to be executed or blocking in waiting for rpc callback
2. Interrupt checkBlockSendResult immediately

### Why are the changes needed?
https://github.com/apache/incubator-uniffle/issues/1264

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Integration test
