### PR TITLE
[#1269] fix(tez): uniqueMapId may be not unique when more than one fetcher…

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
@@ -83,7 +83,7 @@ public class RssFetcher<K, V> {
   private long copyTime = 0; // the sum of readTime + decompressTime + serializeTime + waitTime
   private long unCompressionLength = 0;
   private final TaskAttemptID reduceId;
-  private int uniqueMapId = 0;
+  private static int uniqueMapId = 0;
 
   private boolean hasPendingData = false;
   private long startWait;

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcher.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcher.java
@@ -56,7 +56,7 @@ public class RssTezFetcher {
   private long waitTime = 0;
   private long copyTime = 0; // the sum of readTime + decompressTime + serializeTime + waitTime
   private long unCompressionLength = 0;
-  private int uniqueMapId = 0;
+  private static int uniqueMapId = 0;
 
   private boolean hasPendingData = false;
   private long startWait;

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezShuffleDataFetcher.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssTezShuffleDataFetcher.java
@@ -64,7 +64,7 @@ public class RssTezShuffleDataFetcher extends CallableWithNdc<Void> {
   private long copyTime = 0; // the sum of readTime + decompressTime + serializeTime + waitTime
   private long unCompressionLength = 0;
   private final InputAttemptIdentifier inputAttemptIdentifier;
-  private int uniqueMapId = 0;
+  private static int uniqueMapId = 0;
 
   private boolean hasPendingData = false;
   private long startWait;


### PR DESCRIPTION
### What changes were proposed in this pull request?

make uniqueMapId static.

### Why are the changes needed?

Fix: #1269 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

When flush to disk, may produce this bug. Test and verify on cluster. 