### PR TITLE
[MINOR] chore: add scripts for publishing tarballs to svn

### DIFF
--- a/release/create-package.sh
+++ b/release/create-package.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail
+set -e
+set -x
+
+SKIP_GPG=${SKIP_GPG:-false}
+
+exit_with_usage() {
+  local NAME=$(basename $0)
+  cat << EOF
+Usage: $NAME <source|binary>
+
+Top level targets are:
+  source: Create source release tarball
+  binary: Create binary release tarball
+
+All other inputs are environment variables:
+
+SKIP_GPG        - (optional) Default false
+EOF
+  exit 1
+}
+
+PROJECT_DIR="$(cd "$(dirname "$0")"/..; pwd)"
+RELEASE_DIR="${PROJECT_DIR}/tmp"
+
+RELEASE_VERSION=$(grep 'uniffle-parent' "${PROJECT_DIR}/pom.xml" -C 3 |grep 'version' \
+                | head -n 1 \
+                | sed 's/<\/*version>//g' \
+                | sed 's/ //g')
+
+SHASUM="sha512sum"
+if [ "$(uname)" == "Darwin" ]; then
+    SHASUM="shasum -a 512"
+fi
+
+package_source() {
+  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-src.tar.gz"
+  SRC_TGZ="${RELEASE_DIR}/${SRC_TGZ_FILE}"
+
+  mkdir -p "${RELEASE_DIR}"
+  rm -f "${SRC_TGZ}*"
+
+  echo "Creating source release tarball ${SRC_TGZ_FILE}"
+
+  git archive --prefix="apache-uniffle-${RELEASE_VERSION}-incubating-src/" -o "${SRC_TGZ}" HEAD
+
+  if [ "$SKIP_GPG" == "false" ] ; then
+    gpg --armor --detach-sig "${SRC_TGZ}"
+  fi
+  (cd "${RELEASE_DIR}" && $SHASUM "${SRC_TGZ_FILE}" > "${SRC_TGZ_FILE}.sha512")
+}
+
+package_binary() {
+  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-bin.tar.gz"
+  BIN_TGZ="${RELEASE_DIR}/${BIN_TGZ_FILE}"
+
+  mkdir -p "${RELEASE_DIR}"
+  rm -f "${BIN_TGZ}*"
+
+  echo "Creating binary release tarball ${BIN_TGZ_FILE}"
+
+  ${PROJECT_DIR}/build_distribution.sh
+
+  BIN_ORIGIN_NAME="rss-${RELEASE_VERSION}-hadoop2.8.tgz"
+  BIN_DIR_NAME="rss-${RELEASE_VERSION}-hadoop2.8"
+  tar -zxf $BIN_ORIGIN_NAME
+  cp "${PROJECT_DIR}/LICENSE-binary" "${BIN_DIR_NAME}/LICENSE"
+  cp "${PROJECT_DIR}/NOTICE-binary" "${BIN_DIR_NAME}/NOTICE"
+  cp "${PROJECT_DIR}/DISCLAIMER-WIP" ${BIN_DIR_NAME}
+  cp -r "${PROJECT_DIR}/licenses-binary" "${BIN_DIR_NAME}/licenses"
+  tar -zcf $BIN_TGZ_FILE $BIN_DIR_NAME
+
+  cp $BIN_TGZ_FILE $RELEASE_DIR
+
+  if [ "$SKIP_GPG" == "false" ] ; then
+    gpg --armor --detach-sig "${BIN_TGZ}"
+  fi
+  (cd "${RELEASE_DIR}" && $SHASUM "${BIN_TGZ_FILE}" > "${BIN_TGZ_FILE}.sha512")
+}
+
+if [[ "$1" == "source" ]]; then
+  package_source
+  exit 0
+fi
+
+if [[ "$1" == "binary" ]]; then
+  package_binary
+  exit 0
+fi
+
+exit_with_usage

--- a/release/publish_to_svn.sh
+++ b/release/publish_to_svn.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail
+set -e
+set -x
+
+PROJECT_DIR="$(cd "$(dirname "$0")"/..; pwd)"
+
+ASF_USERNAME=${ASF_USERNAME:?"ASF_USERNAME is required"}
+ASF_PASSWORD=${ASF_PASSWORD:?"ASF_PASSWORD is required"}
+RELEASE_RC_NO=${RELEASE_RC_NO:?"RELEASE_RC_NO is required, e.g. 0"}
+
+RELEASE_VERSION=$(grep 'uniffle-parent' "${PROJECT_DIR}/pom.xml" -C 3 |grep 'version' \
+                | head -n 1 \
+                | sed 's/<\/*version>//g' \
+                | sed 's/ //g')
+
+if [[ ${RELEASE_VERSION} =~ .*-SNAPSHOT ]]; then
+  echo "Can not release a SNAPSHOT version: ${RELEASE_VERSION}"
+  exit 1
+fi
+
+RELEASE_TAG="${RELEASE_VERSION}-rc${RELEASE_RC_NO}"
+
+SVN_STAGING_REPO="https://dist.apache.org/repos/dist/dev/incubator/uniffle"
+
+RELEASE_DIR="${PROJECT_DIR}/tmp"
+SVN_STAGING_DIR="${PROJECT_DIR}/tmp/dev/uniffle"
+
+package() {
+  SKIP_GPG="false" $PROJECT_DIR/release/create-package.sh source
+  SKIP_GPG="false" $PROJECT_DIR/release/create-package.sh binary
+}
+
+upload_svn_staging() {
+  svn checkout --depth=empty "${SVN_STAGING_REPO}" "${SVN_STAGING_DIR}"
+  mkdir -p "${SVN_STAGING_DIR}/${RELEASE_TAG}"
+  rm -f "${SVN_STAGING_DIR}/${RELEASE_TAG}/*"
+
+  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-src.tar.gz"
+  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-bin.tar.gz"
+
+  echo "Copying release tarballs"
+  cp "${RELEASE_DIR}/${SRC_TGZ_FILE}"        "${SVN_STAGING_DIR}/${RELEASE_TAG}/${SRC_TGZ_FILE}"
+  cp "${RELEASE_DIR}/${SRC_TGZ_FILE}.asc"    "${SVN_STAGING_DIR}/${RELEASE_TAG}/${SRC_TGZ_FILE}.asc"
+  cp "${RELEASE_DIR}/${SRC_TGZ_FILE}.sha512" "${SVN_STAGING_DIR}/${RELEASE_TAG}/${SRC_TGZ_FILE}.sha512"
+  cp "${RELEASE_DIR}/${BIN_TGZ_FILE}"        "${SVN_STAGING_DIR}/${RELEASE_TAG}/${BIN_TGZ_FILE}"
+  cp "${RELEASE_DIR}/${BIN_TGZ_FILE}.asc"    "${SVN_STAGING_DIR}/${RELEASE_TAG}/${BIN_TGZ_FILE}.asc"
+  cp "${RELEASE_DIR}/${BIN_TGZ_FILE}.sha512" "${SVN_STAGING_DIR}/${RELEASE_TAG}/${BIN_TGZ_FILE}.sha512"
+
+  svn add "${SVN_STAGING_DIR}/${RELEASE_TAG}"
+
+  echo "Uploading release tarballs to ${SVN_STAGING_DIR}/${RELEASE_TAG}"
+  (
+    cd "${SVN_STAGING_DIR}" && \
+    svn commit --username "${ASF_USERNAME}" --password "${ASF_PASSWORD}" --message "prepare for ${RELEASE_TAG}"
+  )
+  echo "Uniffle tarballs uploaded"
+}
+
+package
+upload_svn_staging


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

add scripts for publishing tarballs to svn

### Why are the changes needed?

Publishing is more convenient

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually testing while publishing 0.8.0-rc2.
