### PR TITLE
[#1290] improvement(operator): Avoid accidentally deleting data of other services when misconfiguring the mounting directory

### DIFF
--- a/deploy/kubernetes/operator/pkg/controller/constants/constants.go
+++ b/deploy/kubernetes/operator/pkg/controller/constants/constants.go
@@ -58,6 +58,9 @@ const (
 
 	// ConfigurationVolumeName is the name of configMap volume records configuration of coordinators or shuffle servers.
 	ConfigurationVolumeName = "configuration"
+
+	//RssDataDir is the directory name for RSS data as the local storage.
+	RssDataDir = "rssdata"
 )
 
 // PropertyKey defines property key in configuration of coordinators or shuffle servers.

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
@@ -236,7 +236,7 @@ func generateStorageBasePath(rss *unifflev1alpha1.RemoteShuffleService) string {
 		if k == rss.Spec.ShuffleServer.LogHostPath {
 			continue
 		}
-		paths = append(paths, strings.TrimSuffix(v, "/")+"/rssdata")
+		paths = append(paths, strings.TrimSuffix(v, "/")+"/"+controllerconstants.RssDataDir)
 	}
 	sort.Strings(paths)
 	return strings.Join(paths, ",")

--- a/deploy/kubernetes/operator/pkg/controller/util/util.go
+++ b/deploy/kubernetes/operator/pkg/controller/util/util.go
@@ -86,7 +86,8 @@ func addVolumeMountsOfMainContainer(mainContainer *corev1.Container,
 	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts,
 		GenerateHostPathVolumeMounts(hostPathMounts)...)
 	for _, mountPath := range hostPathMounts {
-		clearPathCMDs = append(clearPathCMDs, fmt.Sprintf("rm -rf %v/*", strings.TrimSuffix(mountPath, "/")))
+		clearPathCMDs = append(clearPathCMDs, fmt.Sprintf("rm -rf %v/%v/*",
+			strings.TrimSuffix(mountPath, "/"), controllerconstants.RssDataDir))
 	}
 	if len(clearPathCMDs) > 0 {
 		mainContainer.Lifecycle = &corev1.Lifecycle{


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Only delete `rssdata` directory.

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #1290

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)

Tested in our cluster.

1. mount `/data/hdfs1/rssdata1/rssdata` dir for shuffle server
```
touch /data/hdfs1/rssdata1/a.txt
touch /data/hdfs1/rssdata1/rssdata/b.txt
```
2. update crd to terminate this shuffle server.
3. without this pr, both `a.txt` and `b.txt` are deleted
4. 