### PR TITLE
[#1307] feat(rust): make each thread listen the socket to improve throughput in tonic

### DIFF
--- a/rust/experimental/server/Cargo.lock
+++ b/rust/experimental/server/Cargo.lock
@@ -3197,6 +3197,7 @@ dependencies = [
  "prost-build",
  "serde",
  "signal-hook",
+ "socket2 0.4.9",
  "tempdir",
  "tempfile",
  "thiserror",

--- a/rust/experimental/server/Cargo.toml
+++ b/rust/experimental/server/Cargo.toml
@@ -94,6 +94,7 @@ console-subscriber = "0.1.9"
 pin-project-lite = "0.2.8"
 signal-hook = "0.3.17"
 clap = "3.0.14"
+socket2 = { version="0.4", features = ["all"]}
 
 [dependencies.hdrs]
 version = "0.3.0"

--- a/rust/experimental/server/src/main.rs
+++ b/rust/experimental/server/src/main.rs
@@ -38,7 +38,7 @@ use log::{debug, error, info};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tokio::net::TcpListener;
-use tokio::sync::{broadcast};
+use tokio::sync::broadcast;
 use tonic::transport::{Channel, Server};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::layer::SubscriberExt;
@@ -246,7 +246,11 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-async fn grpc_serve(service: ShuffleServerServer<DefaultShuffleServer>, addr: SocketAddr, mut rx: broadcast::Receiver<()>) {
+async fn grpc_serve(
+    service: ShuffleServerServer<DefaultShuffleServer>,
+    addr: SocketAddr,
+    mut rx: broadcast::Receiver<()>,
+) {
     let sock = socket2::Socket::new(
         match addr {
             SocketAddr::V4(_) => socket2::Domain::IPV4,
@@ -255,7 +259,7 @@ async fn grpc_serve(service: ShuffleServerServer<DefaultShuffleServer>, addr: So
         socket2::Type::STREAM,
         None,
     )
-        .unwrap();
+    .unwrap();
 
     sock.set_reuse_address(true).unwrap();
     sock.set_reuse_port(true).unwrap();

--- a/rust/experimental/server/src/signal.rs
+++ b/rust/experimental/server/src/signal.rs
@@ -31,7 +31,7 @@ pub mod details {
         }
     }
 
-    pub fn graceful_wait_for_signal(tx: tokio::sync::oneshot::Sender<()>) {
+    pub fn graceful_wait_for_signal(tx: tokio::sync::broadcast::Sender<()>) {
         let mut sigs = Signals::new(TERM_SIGNALS).expect("Failed to register signal handlers");
 
         for signal in &mut sigs {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make each grpc service thread listens the socket to improve request throughput.

### Why are the changes needed?

I‘m always digging the way to solve the request throughput when the writing concurrency is 400. And then I found the few people talk about this, which makes me confused until I see this https://github.com/hyperium/tonic/issues/1405#issuecomment-1805099818 .

From this blog https://medium.com/@fujita.tomonori/scalable-server-design-in-rust-with-tokio-4c81a5f350a3,
 I try to do this optimization, and then do some terasort test. I found the peek receive data speed from 1.2G/s -> 2.0G/s, it works ! And the latency becomes low. And the whole processing time reduces from 20min -> 8.5min


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need
