### PR TITLE
[#1309] fix(spark): WriteBufferManager in Spark2 does not use a reassigned shuffle server.

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -208,7 +208,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             taskAttemptId,
             bufferOptions,
             rssHandle.getDependency().serializer(),
-            rssHandle.getPartitionToServers(),
+            shuffleHandleInfo.getPartitionToServers(),
             context.taskMemoryManager(),
             shuffleWriteMetrics,
             RssSparkConfig.toRssConf(sparkConf),


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Spark2, after a write failure, ShuffleBlockInfo is not built using the new shuffle server after the shuffle server is reassigned.

### Why are the changes needed?

Fix: #1309

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT.
