### PR TITLE
[#1314] fix: used_buffer leak after ShuffleServer restart. 

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -276,7 +276,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       // removed, then after
       // cacheShuffleData finishes, the preAllocatedSize should be updated accordingly.
       if (info.getRequireSize() > alreadyReleasedSize) {
-        manager.releasePreAllocatedSize(info.getRequireSize() - alreadyReleasedSize);
+        manager.releasePreAllocatedAndUsedMemory(info.getRequireSize() - alreadyReleasedSize);
       }
       reply =
           SendShuffleDataResponse.newBuilder()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -283,6 +283,10 @@ public class ShuffleTaskManager {
     shuffleBufferManager.releasePreAllocatedSize(requireSize);
   }
 
+  public void releasePreAllocatedAndUsedMemory(long requireSize) {
+    shuffleBufferManager.releaseMemory(requireSize, false, true);
+  }
+
   @VisibleForTesting
   void removeAndReleasePreAllocatedBuffer(long requireBufferId) {
     PreAllocatedBufferInfo info = getAndRemovePreAllocatedBuffer(requireBufferId);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix used_buffer leak.

### Why are the changes needed?

When an app is writing data and restarting ShuffleServer, used_buffer cannot be released, because a NO_REGISTER exception will be thrown when sendingShuffleData. At this time, only preAllocated is released, but used_buffer is not released.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
