### PR TITLE
[#901] fix(server): respect disk real usage when checking whether local storage reaches watermark limit

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
@@ -65,7 +65,7 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
                 .getWarmStorageManager();
     for (Storage storage : warmStorageManager.getStorages()) {
       LocalStorage localStorage = (LocalStorage) storage;
-      localStorage.markSpaceFull();
+      localStorage.setWatermarkLimitTriggered(true);
     }
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -190,7 +190,8 @@ public class LocalStorageChecker extends Checker {
   // only for tests
   @VisibleForTesting
   public void resetStorages(LocalStorage... storages) {
-    this.storageInfos = Arrays.stream(storages).map(x -> new StorageInfo(x)).collect(Collectors.toList());
+    this.storageInfos =
+        Arrays.stream(storages).map(x -> new StorageInfo(x)).collect(Collectors.toList());
   }
 
   // todo: This function will be integrated to MultiStorageManager, currently we only support disk
@@ -234,13 +235,15 @@ public class LocalStorageChecker extends Checker {
       if (isWatermarkLimitTriggered) {
         if (Double.compare(usagePercent, lowWaterMarkOfWrite) <= 0) {
           isWatermarkLimitTriggered = false;
-          LOG.info("storage {} has recovered to write, its usage has been below than the low watermark.",
+          LOG.info(
+              "storage {} has recovered to write, its usage has been below than the low watermark.",
               storageDir.getAbsolutePath());
         }
       } else {
         if (Double.compare(usagePercent, highWaterMarkOfWrite) >= 0) {
           isWatermarkLimitTriggered = true;
-          LOG.info("storage {} has reached the high watermark. It will be limited to write!",
+          LOG.info(
+              "storage {} has reached the high watermark. It will be limited to write!",
               storageDir.getAbsolutePath());
         }
       }

--- a/server/src/test/java/org/apache/uniffle/server/LocalStorageCheckerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/LocalStorageCheckerTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.uniffle.common.StorageType;
 import org.apache.uniffle.storage.common.LocalStorage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,9 +46,7 @@ public class LocalStorageCheckerTest {
 
   @Test
   public void testWatermarkLimit(@TempDir File tempDir) throws Exception {
-    LocalStorage storage = LocalStorage.newBuilder()
-        .basePath(tempDir.getAbsolutePath())
-        .build();
+    LocalStorage storage = LocalStorage.newBuilder().basePath(tempDir.getAbsolutePath()).build();
 
     ShuffleServerConf conf = new ShuffleServerConf();
     conf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 80.0);
@@ -57,10 +54,7 @@ public class LocalStorageCheckerTest {
     conf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH.key(), tempDir.getAbsolutePath());
     conf.setString(ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
 
-    LocalStorageChecker checker = new LocalStorageChecker(
-        conf,
-        Arrays.asList(storage)
-    );
+    LocalStorageChecker checker = new LocalStorageChecker(conf, Arrays.asList(storage));
 
     checker = spy(checker);
     checker.resetStorages(storage);

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -672,9 +672,8 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ((HybridStorageManager) storageManager).getWarmStorageManager().selectStorage(event));
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
-    ((LocalStorageManager)(((HybridStorageManager) storageManager).getWarmStorageManager())).getStorages()
-        .stream()
-        .forEach(x -> x.setWatermarkLimitTriggered(true));
+    ((LocalStorageManager) (((HybridStorageManager) storageManager).getWarmStorageManager()))
+        .getStorages().stream().forEach(x -> x.setWatermarkLimitTriggered(true));
 
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
@@ -731,7 +730,8 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
-    ((LocalStorageManager)((HybridStorageManager) storageManager).getWarmStorageManager()).getStorages()
+    ((LocalStorageManager) ((HybridStorageManager) storageManager).getWarmStorageManager())
+        .getStorages()
         .forEach(x -> x.setWatermarkLimitTriggered(true));
 
     flushManager.addToFlushQueue(event);

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -52,8 +52,8 @@ public class LocalStorage extends AbstractStorage {
   private final double lowWaterMarkOfWrite;
   private final LocalStorageMeta metaData = new LocalStorageMeta();
   private final StorageMedia media;
-  private boolean isSpaceEnough = true;
   private volatile boolean isCorrupted = false;
+  private volatile boolean isWatermarkLimitTriggered = false;
 
   private LocalStorage(Builder builder) {
     this.basePath = builder.basePath;
@@ -144,12 +144,7 @@ public class LocalStorage extends AbstractStorage {
 
   @Override
   public boolean canWrite() {
-    if (isSpaceEnough) {
-      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < highWaterMarkOfWrite;
-    } else {
-      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < lowWaterMarkOfWrite;
-    }
-    return isSpaceEnough && !isCorrupted;
+    return !isWatermarkLimitTriggered && !isCorrupted;
   }
 
   public String getBasePath() {
@@ -237,10 +232,12 @@ public class LocalStorage extends AbstractStorage {
     return appIds;
   }
 
-  // Only for test
-  @VisibleForTesting
-  public void markSpaceFull() {
-    isSpaceEnough = false;
+  public void setWatermarkLimitTriggered(boolean watermarkLimitTriggered) {
+    isWatermarkLimitTriggered = watermarkLimitTriggered;
+  }
+
+  public boolean isWatermarkLimitTriggered() {
+    return isWatermarkLimitTriggered;
   }
 
   public static class Builder {

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -75,17 +75,14 @@ public class LocalStorageTest {
   @Test
   public void canWriteTest() {
     LocalStorage item = createTestStorage(testBaseDir);
+    assertTrue(item.canWrite());
 
-    item.getMetaData().updateDiskSize(20);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(65);
-    assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(10);
+    item.setWatermarkLimitTriggered(true);
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
+
+    item.setWatermarkLimitTriggered(false);
+    item.markCorrupted();
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
-    assertTrue(item.canWrite());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Respect disk real usage when checking whether local storage reaches watermark limit


### Why are the changes needed?

Fix: #901

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. UTs
