### PR TITLE
[MINOR] test: flaky test ShuffleTaskManagerTest#checkAndClearLeakShuffleDataTest

### DIFF
--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -937,8 +937,9 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     File hiddenFile = new File(storageDir + "/" + LocalStorageChecker.CHECKER_DIR_NAME);
     hiddenFile.mkdir();
 
-    appIdsOnDisk = getAppIdsOnDisk(localStorageManager);
-    assertFalse(appIdsOnDisk.contains(appId));
+    Awaitility.await()
+        .timeout(10, TimeUnit.SECONDS)
+        .until(() -> !getAppIdsOnDisk(localStorageManager).contains(appId));
     assertFalse(appIdsOnDisk.contains(LocalStorageChecker.CHECKER_DIR_NAME));
 
     // mock leak shuffle data


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

fix flaky test ShuffleTaskManagerTest#checkAndClearLeakShuffleDataTest.

### Why are the changes needed?

*ShuffleTaskManagerTest.checkAndClearLeakShuffleDataTest:940 expected:
\<false\> but was: \<true\>*

The cause of the problem:
Application in `shuffleTaskInfos` is removed first, and then remove the directory in the local disk.
Refer: org.apache.uniffle.server.ShuffleTaskManager#removeResources

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Repeat it for 100 times in my development enviroment.
