### PR TITLE
[MINOR] test: flaky test GrpcServerTest.testGrpcExecutorPool

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -179,6 +179,11 @@ public class GrpcServer implements ServerInterface {
           GRPCMetrics.GRPC_SERVER_EXECUTOR_BLOCKING_QUEUE_SIZE_KEY, getQueue().size());
       super.afterExecute(r, t);
     }
+
+    protected void correctMetrics() {
+      grpcMetrics.setGauge(
+          GRPCMetrics.GRPC_SERVER_EXECUTOR_BLOCKING_QUEUE_SIZE_KEY, getQueue().size());
+    }
   }
 
   @Override

--- a/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/rpc/GrpcServerTest.java
@@ -77,6 +77,7 @@ public class GrpcServerTest {
       Thread.yield();
     }
     Thread.sleep(120);
+    executor.correctMetrics();
     double activeThreads =
         grpcMetrics.getGaugeMap().get(GRPC_SERVER_EXECUTOR_ACTIVE_THREADS_KEY).get();
     assertEquals(2, activeThreads);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
 
fix flaky test GrpcServerTest.testGrpcExecutorPool

### Why are the changes needed?

*GrpcServerTest.testGrpcExecutorPool:83 expected: <1.0> but was: <0.0>*


The cause of the problem:
The metric `GRPC_SERVER_EXECUTOR_BLOCKING_QUEUE_SIZE_KEY` is updated only when there is thread be executed. So if the first two threads have already started executing, and then the third thread is submitted, this metric will not be updated.
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Repeat it for 100 times in my development enviroment.
