### PR TITLE
[#1308] improvement(rust): detect whether data has been purged in UT

### DIFF
--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -1071,13 +1071,21 @@ mod test {
         assert_eq!(1, data.from_memory().shuffle_data_block_segments.len());
 
         // get weak reference to ensure purge can successfully free memory
-        let weak_ref_before = store.state.get(&uid)
+        let weak_ref_before = store
+            .state
+            .get(&uid)
             .map(|entry| Arc::downgrade(&entry.value()));
-        assert!(weak_ref_before.is_some(), "Failed to obtain weak reference before purge");
+        assert!(
+            weak_ref_before.is_some(),
+            "Failed to obtain weak reference before purge"
+        );
 
         // purge
         runtime.wait(store.purge(app_id.to_string())).expect("");
-        assert!(weak_ref_before.clone().unwrap().upgrade().is_none(), "Arc should not exist after purge");
+        assert!(
+            weak_ref_before.clone().unwrap().upgrade().is_none(),
+            "Arc should not exist after purge"
+        );
         let snapshot = runtime.wait(store.budget.snapshot());
         assert_eq!(snapshot.used, 0);
         // the remaining allocated will be removed.

--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -1070,8 +1070,14 @@ mod test {
         let data = runtime.wait(store.get(reading_ctx.clone())).expect("");
         assert_eq!(1, data.from_memory().shuffle_data_block_segments.len());
 
+        // get weak reference to ensure purge can successfully free memory
+        let weak_ref_before = store.state.get(&uid)
+            .map(|entry| Arc::downgrade(&entry.value()));
+        assert!(weak_ref_before.is_some(), "Failed to obtain weak reference before purge");
+
         // purge
         runtime.wait(store.purge(app_id.to_string())).expect("");
+        assert!(weak_ref_before.clone().unwrap().upgrade().is_none(), "Arc should not exist after purge");
         let snapshot = runtime.wait(store.budget.snapshot());
         assert_eq!(snapshot.used, 0);
         // the remaining allocated will be removed.


### PR DESCRIPTION
### What changes were proposed in this pull request?

add code to improve purge unit test to detect whether arc reference is 0

### Why are the changes needed?

Fix: #1308 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

1. UT
