### PR TITLE
[Improvement] Using the configOption in RssTezConfig #1303

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezConfig.java
@@ -26,57 +26,107 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.config.RssConf;
 
+import org.apache.uniffle.common.config.ConfigOption;
+import org.apache.uniffle.common.config.ConfigOptions;
+
 public class RssTezConfig {
 
   public static final String TEZ_RSS_CONFIG_PREFIX = "tez.";
   public static final String RSS_CLIENT_HEARTBEAT_THREAD_NUM =
           TEZ_RSS_CONFIG_PREFIX + "rss.client.heartBeat.threadNum";
+
+
   public static final int RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE = 4;
-  public static final String RSS_CLIENT_TYPE = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_TYPE;
-  public static final String RSS_CLIENT_TYPE_DEFAULT_VALUE = RssClientConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE;
-  public static final String RSS_CLIENT_RETRY_MAX = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_RETRY_MAX;
-  public static final int RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE = RssClientConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE;
-  public static final String RSS_CLIENT_RETRY_INTERVAL_MAX =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX;
-  public static final long RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE =
-          RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE;
+
+
+  public static final ConfigOption<String> RSS_CLIENT_TYPE =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_TYPE)
+        .stringType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE)
+        .withDescription("");
+
+  public static final ConfigOption<Integer> RSS_CLIENT_RETRY_MAX =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_RETRY_MAX)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE)
+        .withDescription("");
+
+
+
+  public static final ConfigOption<Long> RSS_CLIENT_RETRY_INTERVAL_MAX =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX)
+        .longType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE)
+        .withDescription("");
+
+
   public static final String RSS_COORDINATOR_QUORUM =
           TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_COORDINATOR_QUORUM;
-  public static final String RSS_DATA_REPLICA = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA;
-  public static final int RSS_DATA_REPLICA_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_WRITE =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_WRITE;
-  public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE =
-          RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_READ =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
-  public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE =
-          RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_SKIP_ENABLED =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
-  public static final String RSS_DATA_TRANSFER_POOL_SIZE =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_TRANSFER_POOL_SIZE;
-  public static final int RSS_DATA_TRANSFER_POOL_SIZE_DEFAULT_VALUE =
-          RssClientConfig.RSS_DATA_TRANFER_POOL_SIZE_DEFAULT_VALUE;
-  public static final String RSS_DATA_COMMIT_POOL_SIZE =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_COMMIT_POOL_SIZE;
-  public static final int RSS_DATA_COMMIT_POOL_SIZE_DEFAULT_VALUE =
-          RssClientConfig.RSS_DATA_COMMIT_POOL_SIZE_DEFAULT_VALUE;
 
-  public static final boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE =
-          RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
-  public static final String RSS_HEARTBEAT_INTERVAL =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_HEARTBEAT_INTERVAL;
-  public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE =
-          RssClientConfig.RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE;
+
+  public static final ConfigOption<Integer> RSS_DATA_REPLICA =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_DATA_REPLICA_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<Integer> RSS_DATA_REPLICA_WRITE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_WRITE)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<Integer> RSS_DATA_REPLICA_READ =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE)
+        .withDescription("");
+
+
+
+  public static final ConfigOption<Integer> RSS_DATA_TRANSFER_POOL_SIZE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_TRANSFER_POOL_SIZE)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_DATA_TRANFER_POOL_SIZE_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<Integer> RSS_DATA_COMMIT_POOL_SIZE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_COMMIT_POOL_SIZE)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_DATA_COMMIT_POOL_SIZE_DEFAULT_VALUE)
+        .withDescription("");
+
+  public static final ConfigOption<Boolean> RSS_DATA_REPLICA_SKIP_ENABLED =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED)
+        .booleanType()
+        .defaultValue(RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<Long> RSS_HEARTBEAT_INTERVAL =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_HEARTBEAT_INTERVAL)
+        .longType()
+        .defaultValue(RssClientConfig.RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE)
+        .withDescription("");
+
+
+
   public static final String RSS_HEARTBEAT_TIMEOUT =
           TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_HEARTBEAT_TIMEOUT;
-  public static final long RSS_CLIENT_SEND_CHECK_TIMEOUT_MS_DEFAULT_VALUE =
-          RssClientConfig.RSS_CLIENT_SEND_CHECK_TIMEOUT_MS_DEFAULT_VALUE;
+
+  public static final ConfigOption<Long> RSS_CLIENT_SEND_CHECK_TIMEOUT_MS =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + "rss.client.send.check.timeout.ms")
+        .longType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_SEND_CHECK_TIMEOUT_MS_DEFAULT_VALUE)
+        .withDescription("");
 
   // output:
   public static final String RSS_RUNTIME_IO_SORT_MB = TEZ_RSS_CONFIG_PREFIX + "rss.runtime.io.sort.mb";
   public static final int RSS_DEFAULT_RUNTIME_IO_SORT_MB = 100;
+
   public static final String RSS_CLIENT_SORT_MEMORY_USE_THRESHOLD = TEZ_RSS_CONFIG_PREFIX
           + "rss.client.sort.memory.use.threshold";
   public static final double RSS_CLIENT_DEFAULT_SORT_MEMORY_USE_THRESHOLD = 0.9f;
@@ -94,8 +144,7 @@ public class RssTezConfig {
   public static final String RSS_CLIENT_SEND_CHECK_INTERVAL_MS = TEZ_RSS_CONFIG_PREFIX
           + "rss.client.send.check.interval.ms";
   public static final long RSS_CLIENT_DEFAULT_SEND_CHECK_INTERVAL_MS = 500L;
-  public static final String RSS_CLIENT_SEND_CHECK_TIMEOUT_MS = TEZ_RSS_CONFIG_PREFIX
-          + "rss.client.send.check.timeout.ms";
+
   public static final long RSS_CLIENT_DEFAULT_SEND_CHECK_TIMEOUT_MS = 60 * 1000 * 10L;
   public static final String RSS_CLIENT_BITMAP_NUM = TEZ_RSS_CONFIG_PREFIX + "rss.client.bitmap.num";
   public static final int RSS_CLIENT_DEFAULT_BITMAP_NUM = 1;
@@ -106,54 +155,68 @@ public class RssTezConfig {
   public static final String RSS_STORAGE_TYPE = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_STORAGE_TYPE;
   public static final String RSS_STORAGE_TYPE_DEFAULT_VALUE = "MEMORY_LOCALFILE";
 
-
-  public static final String RSS_DYNAMIC_CLIENT_CONF_ENABLED =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED;
-  public static final boolean RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE =
-          RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE;
+  public static final ConfigOption<Boolean> RSS_DYNAMIC_CLIENT_CONF_ENABLED =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED)
+        .booleanType()
+        .defaultValue(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE)
+        .withDescription("");
 
   public static final String RSS_CLIENT_ASSIGNMENT_TAGS =
           TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_TAGS;
 
-  public static final String RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER =
-          RssClientConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER;
-  public static final int RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER_DEFAULT_VALUE =
-          RssClientConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER_DEFAULT_VALUE;
+  public static final ConfigOption<Integer> RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER_DEFAULT_VALUE)
+        .withDescription("");
 
-  public static final String RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL;
-  public static final long RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL_DEFAULT_VALUE =
-          RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL_DEFAULT_VALUE;
-  public static final String RSS_CLIENT_ASSIGNMENT_RETRY_TIMES =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES;
-  public static final int RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE =
-          RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE;
+  public static final ConfigOption<Long> RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL)
+        .longType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL_DEFAULT_VALUE)
+        .withDescription("");
 
-  public static final String RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED;
-  public static final boolean RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED_DEFAULT_VALUE =
-          RssClientConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED_DEFAULT_VALUE;
+  public static final ConfigOption<Integer> RSS_CLIENT_ASSIGNMENT_RETRY_TIMES =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES)
+          .intType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE)
+        .withDescription("");
 
-  public static final String RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR;
 
-  public static final double RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR_DEFAULT_VALUE
-          = RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR_DEFAULT_VALUE;
+  public static final ConfigOption<Boolean> RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED =
+     ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED)
+          .booleanType()
+        .defaultValue(RssClientConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED_DEFAULT_VALUE)
+        .withDescription("");
 
-  public static final String RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER =
-          TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER;
-  public static final int RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER_DEFAULT_VALUE =
-          RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER_DEFAULT_VALUE;
 
-  public static final String RSS_CLIENT_READ_BUFFER_SIZE =
-      TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE;
-  public static final String RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE =
-      RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE;
+  public static final ConfigOption<Double> RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR)
+        .doubleType()
+        .defaultValue(RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR_DEFAULT_VALUE)
+        .withDescription("");
 
-  public static final String RSS_PARTITION_NUM_PER_RANGE =
-      TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_PARTITION_NUM_PER_RANGE;
-  public static final int RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE =
-      RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE;
+
+  public static final ConfigOption<Integer> RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<String> RSS_CLIENT_READ_BUFFER_SIZE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE)
+        .stringType()
+        .defaultValue(RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE)
+        .withDescription("");
+
+
+  public static final ConfigOption<Integer> RSS_PARTITION_NUM_PER_RANGE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_PARTITION_NUM_PER_RANGE)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE)
+        .withDescription("");
+
 
   public static final String RSS_REMOTE_STORAGE_PATH =
       TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_REMOTE_STORAGE_PATH;
@@ -164,13 +227,22 @@ public class RssTezConfig {
   public static final String RSS_AM_SHUFFLE_MANAGER_ADDRESS = TEZ_RSS_CONFIG_PREFIX + "rss.am.shuffle.manager.address";
   public static final String RSS_AM_SHUFFLE_MANAGER_PORT = TEZ_RSS_CONFIG_PREFIX + "rss.am.shuffle.manager.port";
   public static final String RSS_AM_SHUFFLE_MANAGER_DEBUG = TEZ_RSS_CONFIG_PREFIX + "rss.am.shuffle.manager.debug";
-  public static final String RSS_AM_SLOW_START_ENABLE = TEZ_RSS_CONFIG_PREFIX + "rss.am.slow.start.enable";
-  public static final Boolean RSS_AM_SLOW_START_ENABLE_DEFAULT = false;
+
+
+  public static final ConfigOption<Boolean> RSS_AM_SLOW_START_ENABLE =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + "rss.am.slow.start.enable")
+        .booleanType()
+        .defaultValue(false)
+        .withDescription("");
 
   public static final String RSS_REDUCE_INITIAL_MEMORY = TEZ_RSS_CONFIG_PREFIX + "rss.reduce.initial.memory";
 
-  public static final String RSS_ACCESS_TIMEOUT_MS = TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ACCESS_TIMEOUT_MS;
-  public static final int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE;
+  public static final ConfigOption<Integer> RSS_ACCESS_TIMEOUT_MS =
+      ConfigOptions.key(TEZ_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ACCESS_TIMEOUT_MS)
+        .intType()
+        .defaultValue(RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE)
+        .withDescription("");
+
 
   public static final Set<String> RSS_MANDATORY_CLUSTER_CONF =
       ImmutableSet.of(RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);

--- a/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
+++ b/client-tez/src/main/java/org/apache/tez/common/RssTezUtils.java
@@ -80,24 +80,24 @@ public class RssTezUtils {
   public static ShuffleWriteClient createShuffleClient(Configuration conf) {
     int heartBeatThreadNum = conf.getInt(RssTezConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM,
         RssTezConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE);
-    int retryMax = conf.getInt(RssTezConfig.RSS_CLIENT_RETRY_MAX,
-        RssTezConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE);
-    long retryIntervalMax = conf.getLong(RssTezConfig.RSS_CLIENT_RETRY_INTERVAL_MAX,
-        RssTezConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE);
-    String clientType = conf.get(RssTezConfig.RSS_CLIENT_TYPE,
-        RssTezConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
-    int replicaWrite = conf.getInt(RssTezConfig.RSS_DATA_REPLICA_WRITE,
-        RssTezConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
-    int replicaRead = conf.getInt(RssTezConfig.RSS_DATA_REPLICA_READ,
-        RssTezConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    int replica = conf.getInt(RssTezConfig.RSS_DATA_REPLICA,
-        RssTezConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
-    boolean replicaSkipEnabled = conf.getBoolean(RssTezConfig.RSS_DATA_REPLICA_SKIP_ENABLED,
-        RssTezConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
-    int dataTransferPoolSize = conf.getInt(RssTezConfig.RSS_DATA_TRANSFER_POOL_SIZE,
-        RssTezConfig.RSS_DATA_TRANSFER_POOL_SIZE_DEFAULT_VALUE);
-    int dataCommitPoolSize = conf.getInt(RssTezConfig.RSS_DATA_COMMIT_POOL_SIZE,
-        RssTezConfig.RSS_DATA_COMMIT_POOL_SIZE_DEFAULT_VALUE);
+    int retryMax = conf.getInt(RssTezConfig.RSS_CLIENT_RETRY_MAX.key(),
+        RssTezConfig.RSS_CLIENT_RETRY_MAX.defaultValue());
+    long retryIntervalMax = conf.getLong(RssTezConfig.RSS_CLIENT_RETRY_INTERVAL_MAX.key(),
+        RssTezConfig.RSS_CLIENT_RETRY_INTERVAL_MAX.defaultValue());
+    String clientType = conf.get(RssTezConfig.RSS_CLIENT_TYPE.key(),
+        RssTezConfig.RSS_CLIENT_TYPE.defaultValue());
+    int replicaWrite = conf.getInt(RssTezConfig.RSS_DATA_REPLICA_WRITE.key(),
+        RssTezConfig.RSS_DATA_REPLICA_WRITE.defaultValue());
+    int replicaRead = conf.getInt(RssTezConfig.RSS_DATA_REPLICA_READ.key(),
+        RssTezConfig.RSS_DATA_REPLICA_READ.defaultValue());
+    int replica = conf.getInt(RssTezConfig.RSS_DATA_REPLICA.key(),
+        RssTezConfig.RSS_DATA_REPLICA.defaultValue());
+    boolean replicaSkipEnabled = conf.getBoolean(RssTezConfig.RSS_DATA_REPLICA_SKIP_ENABLED.key(),
+        RssTezConfig.RSS_DATA_REPLICA_SKIP_ENABLED.defaultValue());
+    int dataTransferPoolSize = conf.getInt(RssTezConfig.RSS_DATA_TRANSFER_POOL_SIZE.key(),
+        RssTezConfig.RSS_DATA_TRANSFER_POOL_SIZE.defaultValue());
+    int dataCommitPoolSize = conf.getInt(RssTezConfig.RSS_DATA_COMMIT_POOL_SIZE.key(),
+        RssTezConfig.RSS_DATA_COMMIT_POOL_SIZE.defaultValue());
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax,
@@ -164,8 +164,8 @@ public class RssTezUtils {
   }
 
   public static int estimateTaskConcurrency(Configuration jobConf, int mapNum, int reduceNum) {
-    double dynamicFactor = jobConf.getDouble(RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR,
-        RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR_DEFAULT_VALUE);
+    double dynamicFactor = jobConf.getDouble(RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR.key(),
+        RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_DYNAMIC_FACTOR.defaultValue());
     double slowStart = jobConf.getDouble(Constants.MR_SLOW_START, Constants.MR_SLOW_START_DEFAULT_VALUE);
     int mapLimit = jobConf.getInt(Constants.MR_MAP_LIMIT, Constants.MR_MAP_LIMIT_DEFAULT_VALUE);
     int reduceLimit = jobConf.getInt(Constants.MR_REDUCE_LIMIT, Constants.MR_REDUCE_LIMIT_DEFAULT_VALUE);
@@ -181,19 +181,19 @@ public class RssTezUtils {
 
   public static int getRequiredShuffleServerNumber(Configuration jobConf, int mapNum, int reduceNum) {
     int requiredShuffleServerNumber = jobConf.getInt(
-        RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER,
-        RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER_DEFAULT_VALUE
+        RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(),
+        RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.defaultValue()
     );
     boolean enabledEstimateServer = jobConf.getBoolean(
-        RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED,
-        RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED_DEFAULT_VALUE
+        RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED.key(),
+        RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED.defaultValue()
     );
     if (!enabledEstimateServer || requiredShuffleServerNumber > 0) {
       return requiredShuffleServerNumber;
     }
     int taskConcurrency = estimateTaskConcurrency(jobConf, mapNum, reduceNum);
-    int taskConcurrencyPerServer = jobConf.getInt(RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER,
-        RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER_DEFAULT_VALUE);
+    int taskConcurrencyPerServer = jobConf.getInt(RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER.key(),
+        RssTezConfig.RSS_ESTIMATE_TASK_CONCURRENCY_PER_SERVER.defaultValue());
     return (int) Math.ceil(taskConcurrency * 1.0 / taskConcurrencyPerServer);
   }
 

--- a/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/RssDAGAppMaster.java
@@ -139,8 +139,8 @@ public class RssDAGAppMaster extends DAGAppMaster {
     client.registerCoordinators(coordinators);
 
     String strAppAttemptId = appMaster.getAttemptID().toString();
-    long heartbeatInterval = conf.getLong(RssTezConfig.RSS_HEARTBEAT_INTERVAL,
-            RssTezConfig.RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE);
+    long heartbeatInterval = conf.getLong(RssTezConfig.RSS_HEARTBEAT_INTERVAL.key(),
+            RssTezConfig.RSS_HEARTBEAT_INTERVAL.defaultValue());
     long heartbeatTimeout = conf.getLong(RssTezConfig.RSS_HEARTBEAT_TIMEOUT, heartbeatInterval / 2);
     client.registerApplicationInfo(strAppAttemptId, heartbeatTimeout, "user");
 
@@ -164,11 +164,11 @@ public class RssDAGAppMaster extends DAGAppMaster {
     appMaster.getTezRemoteShuffleManager().start();
 
     // apply dynamic configuration
-    boolean dynamicConfEnabled = conf.getBoolean(RssTezConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
-        RssTezConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE);
+    boolean dynamicConfEnabled = conf.getBoolean(RssTezConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(),
+        RssTezConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.defaultValue());
     if (dynamicConfEnabled) {
       appMaster.clusterClientConf = client.fetchClientConf(
-          conf.getInt(RssTezConfig.RSS_ACCESS_TIMEOUT_MS, RssTezConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
+          conf.getInt(RssTezConfig.RSS_ACCESS_TIMEOUT_MS.key(), RssTezConfig.RSS_ACCESS_TIMEOUT_MS.defaultValue()));
     }
 
     mayCloseTezSlowStart(conf);
@@ -290,7 +290,7 @@ public class RssDAGAppMaster extends DAGAppMaster {
   }
 
   static void mayCloseTezSlowStart(Configuration conf) {
-    if (!conf.getBoolean(RssTezConfig.RSS_AM_SLOW_START_ENABLE, RssTezConfig.RSS_AM_SLOW_START_ENABLE_DEFAULT)) {
+    if (!conf.getBoolean(RssTezConfig.RSS_AM_SLOW_START_ENABLE.key(), RssTezConfig.RSS_AM_SLOW_START_ENABLE.defaultValue())) {
       conf.setFloat(ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION, 1.0f);
       conf.setFloat(ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION, 1.0f);
     }

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -169,10 +169,10 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
     ShuffleAssignmentsInfo shuffleAssignmentsInfo;
     int requiredAssignmentShuffleServersNum = RssTezUtils.getRequiredShuffleServerNumber(conf, 200, partitionNum);
     // retryInterval must bigger than `rss.server.heartbeat.timeout`, or maybe it will return the same result
-    long retryInterval = conf.getLong(RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL,
-            RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL_DEFAULT_VALUE);
-    int retryTimes = conf.getInt(RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES,
-            RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES_DEFAULT_VALUE);
+    long retryInterval = conf.getLong(RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL.key(),
+            RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL.defaultValue());
+    int retryTimes = conf.getInt(RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES.key(),
+            RssTezConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES.defaultValue());
 
     // Get the configured server assignment tags and it will also add default shuffle version tag.
     Set<String> assignmentTags = new HashSet<>();

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
@@ -101,15 +101,15 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
 
     this.reduceId =  this.inputContext.getTaskIndex();
     LOG.info("RssTezFetcherTask, dagIdentifier:{}, vertexIndex:{}, reduceId:{}.", dagIdentifier, vertexIndex, reduceId);
-    clientType = conf.get(RssTezConfig.RSS_CLIENT_TYPE, RssTezConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
+    clientType = conf.get(RssTezConfig.RSS_CLIENT_TYPE.key(), RssTezConfig.RSS_CLIENT_TYPE.defaultValue());
     this.storageType = conf.get(RssTezConfig.RSS_STORAGE_TYPE, RssTezConfig.RSS_STORAGE_TYPE_DEFAULT_VALUE);
     LOG.info("RssTezFetcherTask storageType:{}", storageType);
 
-    String readBufferSize = conf.get(RssTezConfig.RSS_CLIENT_READ_BUFFER_SIZE,
-        RssTezConfig.RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE);
+    String readBufferSize = conf.get(RssTezConfig.RSS_CLIENT_READ_BUFFER_SIZE.key(),
+        RssTezConfig.RSS_CLIENT_READ_BUFFER_SIZE.defaultValue());
     this.readBufferSize = (int) UnitConverter.byteStringAsBytes(readBufferSize);
-    this.partitionNumPerRange = conf.getInt(RssTezConfig.RSS_PARTITION_NUM_PER_RANGE,
-        RssTezConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
+    this.partitionNumPerRange = conf.getInt(RssTezConfig.RSS_PARTITION_NUM_PER_RANGE.key(),
+        RssTezConfig.RSS_PARTITION_NUM_PER_RANGE.defaultValue());
     LOG.info("RssTezFetcherTask fetch partition:{}, with inputs:{}, readBufferSize:{}, partitionNumPerRange:{}.",
         this.partition, inputs, this.readBufferSize, this.partitionNumPerRange);
   }

--- a/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
+++ b/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
@@ -128,11 +128,11 @@ public class RssTezUtilsTest {
     Configuration jobConf = new Configuration();
     int mapNum = 500;
     int reduceNum = 20;
-    jobConf.setInt(RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER, 10);
+    jobConf.setInt(RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key(), 10);
     assertEquals(10, RssTezUtils.getRequiredShuffleServerNumber(jobConf, mapNum, reduceNum));
-    jobConf.setBoolean(RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED, true);
+    jobConf.setBoolean(RssTezConfig.RSS_ESTIMATE_SERVER_ASSIGNMENT_ENABLED.key(), true);
     assertEquals(10, RssTezUtils.getRequiredShuffleServerNumber(jobConf, mapNum, reduceNum));
-    jobConf.unset(RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER);
+    jobConf.unset(RssTezConfig.RSS_CLIENT_ASSIGNMENT_SHUFFLE_SERVER_NUMBER.key());
     assertEquals(7, RssTezUtils.getRequiredShuffleServerNumber(jobConf, mapNum, reduceNum));
     jobConf.setDouble(Constants.MR_SLOW_START, 1.0);
     assertEquals(7, RssTezUtils.getRequiredShuffleServerNumber(jobConf, mapNum, reduceNum));


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Using the ConfigOption to unify all client and server config style.


### Why are the changes needed?
Unify all client and server config style.



### Does this PR introduce _any_ user-facing change?


### How was this patch tested?

