### PR TITLE
[#1342] improvement(server): dump appId when clearing resource fails

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -187,7 +187,8 @@ public class ShuffleTaskManager {
               }
             } catch (Exception e) {
               StringBuilder diagnosticMessageBuilder =
-                  new StringBuilder("Exception happened when clearing resource for expired application");
+                  new StringBuilder(
+                      "Exception happened when clearing resource for expired application");
               if (event != null) {
                 diagnosticMessageBuilder.append(" for appId: ");
                 diagnosticMessageBuilder.append(event.getAppId());

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -169,8 +169,9 @@ public class ShuffleTaskManager {
     clearResourceThread =
         () -> {
           while (true) {
+            PurgeEvent event = null;
             try {
-              PurgeEvent event = expiredAppIdQueue.take();
+              event = expiredAppIdQueue.take();
               long startTime = System.currentTimeMillis();
               if (event instanceof AppPurgeEvent) {
                 removeResources(event.getAppId(), true);
@@ -185,7 +186,18 @@ public class ShuffleTaskManager {
                 ShuffleServerMetrics.summaryTotalRemoveResourceByShuffleIdsTime.observe(usedTime);
               }
             } catch (Exception e) {
-              LOG.error("Exception happened when clear resource for expired application", e);
+              StringBuilder diagnosticMessageBuilder =
+                  new StringBuilder("Exception happened when clearing resource for expired application");
+              if (event != null) {
+                diagnosticMessageBuilder.append(" for appId: ");
+                diagnosticMessageBuilder.append(event.getAppId());
+
+                if (CollectionUtils.isNotEmpty(event.getShuffleIds())) {
+                  diagnosticMessageBuilder.append(", shuffleIds: ");
+                  diagnosticMessageBuilder.append(event.getShuffleIds());
+                }
+              }
+              LOG.error("{}", diagnosticMessageBuilder, e);
             }
           }
         };


### PR DESCRIPTION
### What changes were proposed in this pull request?

record the appId and shuffleIds in the log when clearing resource fail

### Why are the changes needed?

Fix: #1342

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't
