### PR TITLE
[MINOR] improvement: use mvn wrapper in CI builds.

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -84,11 +84,11 @@ jobs:
         restore-keys: |
           mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
           mvn-${{ inputs.java-version }}-package-
-    - name: Execute `mvn ${{ inputs.maven-args }} -P${{ matrix.profile }}`
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -P${{ matrix.profile }}`
       run: |
         PROFILES="${{ matrix.profile }}"
         PROFILES=${PROFILES/-/,}
-        mvn -B -fae ${{ inputs.maven-args }} -P${PROFILES} | tee /tmp/maven.log
+        ./mvnw -B -fae ${{ inputs.maven-args }} -P${PROFILES} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -68,20 +68,20 @@ jobs:
         key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark3`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pspark2`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark2`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pmr,hadoop2.8`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop2.8`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `mvn ${{ inputs.maven-args }} -Pmr,hadoop3.2`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop3.2`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `mvn ${{ inputs.maven-args }} -Ptez`
-      run: mvn -B -fae ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Ptez`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
-    - name: Execute `mvn ${{ inputs.maven-args }}`
-      run: mvn -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
+    - name: Execute `./mvnw ${{ inputs.maven-args }}`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}


### PR DESCRIPTION

### What changes were proposed in this pull request?

This is a follow-up to eef0134. The change will (hopefully) invoke `./mvnw` (wrapper) instead of the `mvn` command in CI builds, making the local development builds and CI builds equivalent to the applied `maven` version. 

### Why are the changes needed?

It's prudent to have the development builds as close to the ones executed by CI/CD system as possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I believe having a PR builder pass should suffice.
