### PR TITLE
[#1319] fix(server): Add shaded com.google.guava:failureaccess dependency to prevent NoClassDefFoundError

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -159,6 +159,7 @@
                 <includes>
                   <include>com.google.protobuf:protobuf-java-util</include>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.guava:failureaccess</include>
                   <include>com.fasterxml.jackson.core:jackson-databind</include>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                 </includes>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add shaded com.google.guava:failureaccess dependency in server pom.xml to prevent NoClassDefFoundError

### Why are the changes needed?

For [#1319](https://github.com/apache/incubator-uniffle/issues/1319)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By running server successfully.
