### PR TITLE
[MINOR] Specify name for dataTransferPool

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -139,7 +139,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.replicaRead = builder.getReplicaRead();
     this.replicaSkipEnabled = builder.isReplicaSkipEnabled();
     this.dataTransferPool =
-        ThreadUtils.getDaemonFixedThreadPool(builder.getDataTransferPoolSize(), "client-data-transfer");
+        ThreadUtils.getDaemonFixedThreadPool(
+            builder.getDataTransferPoolSize(), "client-data-transfer");
     this.dataCommitPoolSize = builder.getDataCommitPoolSize();
     this.unregisterThreadPoolSize = builder.getUnregisterThreadPoolSize();
     this.unregisterRequestTimeSec = builder.getUnregisterRequestTimeSec();

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -139,7 +139,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.replicaWrite = builder.getReplicaWrite();
     this.replicaRead = builder.getReplicaRead();
     this.replicaSkipEnabled = builder.isReplicaSkipEnabled();
-    this.dataTransferPool = Executors.newFixedThreadPool(builder.getDataTransferPoolSize());
+    this.dataTransferPool =
+        ThreadUtils.getDaemonFixedThreadPool(builder.getDataTransferPoolSize(), "client-data-transfer");
     this.dataCommitPoolSize = builder.getDataCommitPoolSize();
     this.unregisterThreadPoolSize = builder.getUnregisterThreadPoolSize();
     this.unregisterRequestTimeSec = builder.getUnregisterRequestTimeSec();

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -27,7 +27,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Specify name for dataTransferPool


### Why are the changes needed?

`dataTransferPool` thread pool did not specify name.

![image](https://github.com/apache/incubator-uniffle/assets/17894939/3baca266-f95b-4af0-a613-a2aa582c8e2b)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

minor fix
