### PR TITLE
[#1358] fix(spark): pre-check bytebuffer whether is direct before uncompress

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -150,6 +150,18 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
     return recordsIterator.hasNext();
   }
 
+  private boolean isSameMemoryType(ByteBuffer left, ByteBuffer right) {
+    if (left.isDirect() && right.isDirect()) {
+      return true;
+    }
+
+    if (!left.isDirect() && !right.isDirect()) {
+      return true;
+    }
+
+    return false;
+  }
+
   private int uncompress(CompressedShuffleBlock rawBlock, ByteBuffer rawData) {
     long rawDataLength = rawData.limit() - rawData.position();
     totalRawBytesLength += rawDataLength;
@@ -157,7 +169,9 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
 
     int uncompressedLen = rawBlock.getUncompressLength();
     if (codec != null) {
-      if (uncompressedData == null || uncompressedData.capacity() < uncompressedLen) {
+      if (uncompressedData == null
+          || uncompressedData.capacity() < uncompressedLen
+          || !isSameMemoryType(uncompressedData, rawData)) {
         if (uncompressedData != null) {
           RssUtils.releaseByteBuffer(uncompressedData);
         }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -151,15 +151,7 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
   }
 
   private boolean isSameMemoryType(ByteBuffer left, ByteBuffer right) {
-    if (left.isDirect() && right.isDirect()) {
-      return true;
-    }
-
-    if (!left.isDirect() && !right.isDirect()) {
-      return true;
-    }
-
-    return false;
+    return left.isDirect() == right.isDirect();
   }
 
   private int uncompress(CompressedShuffleBlock rawBlock, ByteBuffer rawData) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -172,6 +172,17 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
       if (uncompressedData == null
           || uncompressedData.capacity() < uncompressedLen
           || !isSameMemoryType(uncompressedData, rawData)) {
+
+        if (LOG.isDebugEnabled()) {
+          if (!isSameMemoryType(uncompressedData, rawData)) {
+            LOG.debug(
+                "This should not happen that the temporary uncompressed data's memory type(isDirect:{}) "
+                    + "is not same with fetched data buffer(isDirect:{})",
+                uncompressedData.isDirect(),
+                rawData.isDirect());
+          }
+        }
+
         if (uncompressedData != null) {
           RssUtils.releaseByteBuffer(uncompressedData);
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

precheck bytebuffer whether is direct before uncompress, and rebuild the temp bytebuffer.

### Why are the changes needed?

For #1358 . But this PR is not the fundamental solution

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
