### PR TITLE
[#1189] feat(server): Add netty used direct memory size metric

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/DirectMemoryUsageReporter.java
+++ b/server/src/main/java/org/apache/uniffle/server/DirectMemoryUsageReporter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server;
+
+import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
+import org.apache.uniffle.common.util.ThreadUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class DirectMemoryUsageReporter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DirectMemoryUsageReporter.class);
+
+  private final long reportInitialDelay;
+  private final long reportInterval;
+  private final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(
+    ThreadUtils.getThreadFactory("DirectMemoryReporter-%d"));
+
+  public DirectMemoryUsageReporter(ShuffleServerConf conf) {
+    this.reportInitialDelay = conf.getLong(ShuffleServerConf.SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY);
+    this.reportInterval = conf.getLong(ShuffleServerConf.SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL);
+  }
+
+  public void start() {
+    LOG.info("Start report direct memory usage to MetricSystem after {}ms and interval is {}ms",
+      reportInitialDelay, reportInterval);
+
+    service.scheduleAtFixedRate(() -> {
+        try {
+          long usedDirectMemory = PlatformDependent.usedDirectMemory();
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Current direct memory usage: {}", usedDirectMemory);
+          }
+          ShuffleServerMetrics.gaugeUsedDirectMemorySize.set(usedDirectMemory);
+        } catch (Throwable t) {
+          LOG.error("Failed to report direct memory.", t);
+        }
+      },
+      reportInitialDelay,
+      reportInterval,
+      TimeUnit.MILLISECONDS
+    );
+  }
+
+  public void stop() {
+    service.shutdownNow();
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/DirectMemoryUsageReporter.java
+++ b/server/src/main/java/org/apache/uniffle/server/DirectMemoryUsageReporter.java
@@ -35,7 +35,7 @@ public class DirectMemoryUsageReporter {
   private final long reportInterval;
   private final ScheduledExecutorService service =
       Executors.newSingleThreadScheduledExecutor(
-          ThreadUtils.getThreadFactory("DirectMemoryReporter-%d"));
+          ThreadUtils.getThreadFactory("DirectMemoryReporter"));
 
   public DirectMemoryUsageReporter(ShuffleServerConf conf) {
     this.reportInitialDelay =

--- a/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
+++ b/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
@@ -27,9 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.util.ThreadUtils;
 
-public class DirectMemoryUsageReporter {
+public class NettyDirectMemoryTracker {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DirectMemoryUsageReporter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyDirectMemoryTracker.class);
 
   private final long reportInitialDelay;
   private final long reportInterval;
@@ -37,11 +37,11 @@ public class DirectMemoryUsageReporter {
       Executors.newSingleThreadScheduledExecutor(
           ThreadUtils.getThreadFactory("DirectMemoryReporter"));
 
-  public DirectMemoryUsageReporter(ShuffleServerConf conf) {
+  public NettyDirectMemoryTracker(ShuffleServerConf conf) {
     this.reportInitialDelay =
-        conf.getLong(ShuffleServerConf.SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY);
+        conf.getLong(ShuffleServerConf.SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_DELAY);
     this.reportInterval =
-        conf.getLong(ShuffleServerConf.SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL);
+        conf.getLong(ShuffleServerConf.SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_INTERVAL);
   }
 
   public void start() {

--- a/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
+++ b/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
@@ -35,7 +35,7 @@ public class NettyDirectMemoryTracker {
   private final long reportInterval;
   private final ScheduledExecutorService service =
       Executors.newSingleThreadScheduledExecutor(
-          ThreadUtils.getThreadFactory("DirectMemoryReporter"));
+          ThreadUtils.getThreadFactory("NettyDirectMemoryTracker"));
 
   public NettyDirectMemoryTracker(ShuffleServerConf conf) {
     this.reportInitialDelay =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -74,6 +74,7 @@ public class ShuffleServer {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleServer.class);
   private RegisterHeartBeat registerHeartBeat;
+  private DirectMemoryUsageReporter directMemoryUsageReporter;
   private String id;
   private String ip;
   private int grpcPort;
@@ -167,6 +168,10 @@ public class ShuffleServer {
       registerHeartBeat.shutdown();
       LOG.info("HeartBeat Stopped!");
     }
+    if (directMemoryUsageReporter != null) {
+      directMemoryUsageReporter.stop();
+      LOG.info("Direct memory usage reporter Stopped!");
+    }
     if (storageManager != null) {
       storageManager.stop();
       LOG.info("MultiStorage Stopped!");
@@ -256,6 +261,7 @@ public class ShuffleServer {
     }
 
     registerHeartBeat = new RegisterHeartBeat(this);
+    directMemoryUsageReporter = new DirectMemoryUsageReporter(getShuffleServerConf());
     shuffleFlushManager = new ShuffleFlushManager(shuffleServerConf, this, storageManager);
     shuffleBufferManager = new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager);
     shuffleTaskManager =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -261,7 +261,7 @@ public class ShuffleServer {
     }
 
     registerHeartBeat = new RegisterHeartBeat(this);
-    directMemoryUsageReporter = new NettyDirectMemoryTracker(getShuffleServerConf());
+    directMemoryUsageReporter = new NettyDirectMemoryTracker(shuffleServerConf);
     shuffleFlushManager = new ShuffleFlushManager(shuffleServerConf, this, storageManager);
     shuffleBufferManager = new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager);
     shuffleTaskManager =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -74,7 +74,7 @@ public class ShuffleServer {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleServer.class);
   private RegisterHeartBeat registerHeartBeat;
-  private DirectMemoryUsageReporter directMemoryUsageReporter;
+  private NettyDirectMemoryTracker directMemoryUsageReporter;
   private String id;
   private String ip;
   private int grpcPort;
@@ -261,7 +261,7 @@ public class ShuffleServer {
     }
 
     registerHeartBeat = new RegisterHeartBeat(this);
-    directMemoryUsageReporter = new DirectMemoryUsageReporter(getShuffleServerConf());
+    directMemoryUsageReporter = new NettyDirectMemoryTracker(getShuffleServerConf());
     shuffleFlushManager = new ShuffleFlushManager(shuffleServerConf, this, storageManager);
     shuffleBufferManager = new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager);
     shuffleTaskManager =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -170,7 +170,7 @@ public class ShuffleServer {
     }
     if (directMemoryUsageReporter != null) {
       directMemoryUsageReporter.stop();
-      LOG.info("Direct memory usage reporter Stopped!");
+      LOG.info("Direct memory usage tracker Stopped!");
     }
     if (storageManager != null) {
       storageManager.stop();

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -81,13 +81,13 @@ public class ShuffleServerConf extends RssBaseConf {
       ConfigOptions.key("rss.server.netty.direct-memory-tracker.fetch.initial-delay-ms")
           .longType()
           .defaultValue(10 * 1000L)
-          .withDescription("rss direct memory usage report initial delay (ms)");
+          .withDescription("Direct memory usage tracker initial delay (ms)");
 
   public static final ConfigOption<Long> SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_INTERVAL =
       ConfigOptions.key("rss.server.netty.direct-memory-tracker.metrics.update-interval-ms")
           .longType()
           .defaultValue(10 * 1000L)
-          .withDescription("Direct memory usage report interval to MetricSystem (ms)");
+          .withDescription("Direct memory usage tracker interval to MetricSystem (ms)");
 
   public static final ConfigOption<Integer> SERVER_FLUSH_LOCALFILE_THREAD_POOL_SIZE =
       ConfigOptions.key("rss.server.flush.localfile.threadPool.size")

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -77,17 +77,17 @@ public class ShuffleServerConf extends RssBaseConf {
           .defaultValue(10 * 1000L)
           .withDescription("Heartbeat interval to Coordinator (ms)");
 
-  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY = ConfigOptions
-    .key("rss.server.direct.memory.report.delay")
-    .longType()
-    .defaultValue(10 * 1000L)
-    .withDescription("rss direct memory usage report initial delay (ms)");
+  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY =
+      ConfigOptions.key("rss.server.direct.memory.report.delay")
+          .longType()
+          .defaultValue(10 * 1000L)
+          .withDescription("rss direct memory usage report initial delay (ms)");
 
-  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL = ConfigOptions
-    .key("rss.server.direct.memory.usage.report.interval")
-    .longType()
-    .defaultValue(10 * 1000L)
-    .withDescription("Direct memory usage report interval to MetricSystem (ms)");
+  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL =
+      ConfigOptions.key("rss.server.direct.memory.usage.report.interval")
+          .longType()
+          .defaultValue(10 * 1000L)
+          .withDescription("Direct memory usage report interval to MetricSystem (ms)");
 
   public static final ConfigOption<Integer> SERVER_FLUSH_LOCALFILE_THREAD_POOL_SIZE =
       ConfigOptions.key("rss.server.flush.localfile.threadPool.size")

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -77,14 +77,14 @@ public class ShuffleServerConf extends RssBaseConf {
           .defaultValue(10 * 1000L)
           .withDescription("Heartbeat interval to Coordinator (ms)");
 
-  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY =
-      ConfigOptions.key("rss.server.direct.memory.report.delay")
+  public static final ConfigOption<Long> SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_DELAY =
+      ConfigOptions.key("rss.server.netty.direct-memory-tracker.fetch.initial-delay-ms")
           .longType()
           .defaultValue(10 * 1000L)
           .withDescription("rss direct memory usage report initial delay (ms)");
 
-  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL =
-      ConfigOptions.key("rss.server.direct.memory.usage.report.interval")
+  public static final ConfigOption<Long> SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_INTERVAL =
+      ConfigOptions.key("rss.server.netty.direct-memory-tracker.metrics.update-interval-ms")
           .longType()
           .defaultValue(10 * 1000L)
           .withDescription("Direct memory usage report interval to MetricSystem (ms)");

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -77,6 +77,18 @@ public class ShuffleServerConf extends RssBaseConf {
           .defaultValue(10 * 1000L)
           .withDescription("Heartbeat interval to Coordinator (ms)");
 
+  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_DELAY = ConfigOptions
+    .key("rss.server.direct.memory.report.delay")
+    .longType()
+    .defaultValue(10 * 1000L)
+    .withDescription("rss direct memory usage report initial delay (ms)");
+
+  public static final ConfigOption<Long> SERVER_DIRECT_MEMORY_USAGE_REPORT_INTERVAL = ConfigOptions
+    .key("rss.server.direct.memory.usage.report.interval")
+    .longType()
+    .defaultValue(10 * 1000L)
+    .withDescription("Direct memory usage report interval to MetricSystem (ms)");
+
   public static final ConfigOption<Integer> SERVER_FLUSH_LOCALFILE_THREAD_POOL_SIZE =
       ConfigOptions.key("rss.server.flush.localfile.threadPool.size")
           .intType()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -78,13 +78,13 @@ public class ShuffleServerConf extends RssBaseConf {
           .withDescription("Heartbeat interval to Coordinator (ms)");
 
   public static final ConfigOption<Long> SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_DELAY =
-      ConfigOptions.key("rss.server.netty.direct-memory-tracker.fetch.initial-delay-ms")
+      ConfigOptions.key("rss.server.netty.directMemoryTracker.memoryUsage.initialFetchDelayMs")
           .longType()
           .defaultValue(10 * 1000L)
           .withDescription("Direct memory usage tracker initial delay (ms)");
 
   public static final ConfigOption<Long> SERVER_NETTY_DIRECT_MEMORY_USAGE_TRACKER_INTERVAL =
-      ConfigOptions.key("rss.server.netty.direct-memory-tracker.metrics.update-interval-ms")
+      ConfigOptions.key("rss.server.netty.directMemoryTracker.memoryUsage.updateMetricsIntervalMs")
           .longType()
           .defaultValue(10 * 1000L)
           .withDescription("Direct memory usage tracker interval to MetricSystem (ms)");

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -72,6 +72,7 @@ public class ShuffleServerMetrics {
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
+  private static final String USED_DIRECT_MEMORY_SIZE = "used_direct_memory_size";
   private static final String TOTAL_FAILED_WRITTEN_EVENT_NUM = "total_failed_written_event_num";
   private static final String TOTAL_DROPPED_EVENT_NUM = "total_dropped_event_num";
   private static final String TOTAL_HADOOP_WRITE_DATA = "total_hadoop_write_data";
@@ -163,6 +164,7 @@ public class ShuffleServerMetrics {
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
+  public static Gauge.Child gaugeUsedDirectMemorySize;
   public static Gauge.Child gaugeWriteHandler;
   public static Gauge.Child gaugeEventQueueSize;
   public static Gauge.Child gaugeAppNum;
@@ -328,6 +330,7 @@ public class ShuffleServerMetrics {
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);
+    gaugeUsedDirectMemorySize = metricsManager.addLabeledGauge(USED_DIRECT_MEMORY_SIZE);
     gaugeWriteHandler = metricsManager.addLabeledGauge(TOTAL_WRITE_HANDLER);
     gaugeEventQueueSize = metricsManager.addLabeledGauge(EVENT_QUEUE_SIZE);
     gaugeAppNum = metricsManager.addLabeledGauge(APP_NUM_WITH_NODE);


### PR DESCRIPTION
### What changes were proposed in this pull request?

ShuffleServer add Direct Memory Metric for monitor

### Why are the changes needed?


Fix: # (https://github.com/apache/incubator-uniffle/issues/1189)

### Does this PR introduce _any_ user-facing change?



No.

### How was this patch tested?

