### PR TITLE
[#1364] feat(client): introduce option to control whether to use local hadoop conf for remote storage by default

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -25,7 +25,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.spark.*;
+import org.apache.spark.MapOutputTracker;
+import org.apache.spark.MapOutputTrackerMaster;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.SparkException;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.RssSparkShuffleUtils;
 import org.apache.spark.shuffle.ShuffleManager;

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -19,9 +19,11 @@ package org.apache.uniffle.shuffle.manager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.*;
 import org.apache.spark.shuffle.RssSparkConfig;
@@ -155,13 +157,22 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
     return tracker instanceof MapOutputTrackerMaster ? (MapOutputTrackerMaster) tracker : null;
   }
 
+  private Map<String, String> parseRemoteStorageConf(Configuration conf) {
+    Map<String, String> confItems = Maps.newHashMap();
+    for (Map.Entry<String, String> entry : conf) {
+      confItems.put(entry.getKey(), entry.getValue());
+    }
+    return confItems;
+  }
+
   protected RemoteStorageInfo getRemoteStorageInfo(SparkConf sparkConf) {
+    Map<String, String> confItems = Maps.newHashMap();
     RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
     if (rssConf.getBoolean(RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED)) {
-      return new RemoteStorageInfo(
-          sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""), new Configuration(true));
+      confItems = parseRemoteStorageConf(new Configuration(true));
     }
 
-    return new RemoteStorageInfo(sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""));
+    return new RemoteStorageInfo(
+        sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""), confItems);
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -306,8 +306,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     }
 
     String storageType = sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key());
-    RemoteStorageInfo defaultRemoteStorage =
-        new RemoteStorageInfo(sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""));
+    RemoteStorageInfo defaultRemoteStorage = getRemoteStorageInfo(sparkConf);
     RemoteStorageInfo remoteStorage =
         ClientUtils.fetchRemoteStorage(
             appId, defaultRemoteStorage, dynamicConfEnabled, storageType, shuffleWriteClient);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -410,8 +410,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     }
 
     String storageType = sparkConf.get(RssSparkConfig.RSS_STORAGE_TYPE.key());
-    RemoteStorageInfo defaultRemoteStorage =
-        new RemoteStorageInfo(sparkConf.get(RssSparkConfig.RSS_REMOTE_STORAGE_PATH.key(), ""));
+    RemoteStorageInfo defaultRemoteStorage = getRemoteStorageInfo(sparkConf);
     RemoteStorageInfo remoteStorage =
         ClientUtils.fetchRemoteStorage(
             id.get(), defaultRemoteStorage, dynamicConfEnabled, storageType, shuffleWriteClient);

--- a/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
@@ -26,7 +26,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 
 import org.apache.uniffle.common.util.Constants;
 
@@ -51,19 +50,6 @@ public class RemoteStorageInfo implements Serializable {
   public RemoteStorageInfo(String path, String confString) {
     this.path = path;
     this.confItems = parseRemoteStorageConf(confString);
-  }
-
-  public RemoteStorageInfo(String path, Configuration conf) {
-    this.path = path;
-    this.confItems = parseRemoteStorageConf(conf);
-  }
-
-  private Map<String, String> parseRemoteStorageConf(Configuration conf) {
-    Map<String, String> confItems = Maps.newHashMap();
-    for (Map.Entry<String, String> entry : conf) {
-      confItems.put(entry.getKey(), entry.getValue());
-    }
-    return confItems;
   }
 
   public static Map<String, String> parseRemoteStorageConf(String confString) {

--- a/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
@@ -26,6 +26,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 
 import org.apache.uniffle.common.util.Constants;
 
@@ -50,6 +51,19 @@ public class RemoteStorageInfo implements Serializable {
   public RemoteStorageInfo(String path, String confString) {
     this.path = path;
     this.confItems = parseRemoteStorageConf(confString);
+  }
+
+  public RemoteStorageInfo(String path, Configuration conf) {
+    this.path = path;
+    this.confItems = parseRemoteStorageConf(conf);
+  }
+
+  private Map<String, String> parseRemoteStorageConf(Configuration conf) {
+    Map<String, String> confItems = Maps.newHashMap();
+    for (Map.Entry<String, String> entry : conf) {
+      confItems.put(entry.getKey(), entry.getValue());
+    }
+    return confItems;
   }
 
   public static Map<String, String> parseRemoteStorageConf(String confString) {

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -142,4 +142,12 @@ public class RssClientConf {
           .enumType(ClientType.class)
           .defaultValue(ClientType.GRPC)
           .withDescription("Supports GRPC, GRPC_NETTY");
+
+  public static final ConfigOption<Boolean> RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED =
+      ConfigOptions.key("rss.client.remote.storage.use-local-conf.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "This option is only valid when the remote storage path is specified. If ture, "
+                  + "the remote storage conf will use the client side hadoop configuration loaded from the classpath.");
 }

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -144,7 +144,7 @@ public class RssClientConf {
           .withDescription("Supports GRPC, GRPC_NETTY");
 
   public static final ConfigOption<Boolean> RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED =
-      ConfigOptions.key("rss.client.remote.storage.use-local-conf.enabled")
+      ConfigOptions.key("rss.client.remote.storage.useLocalConfAsDefault")
           .booleanType()
           .defaultValue(false)
           .withDescription(

--- a/docs/client_guide/spark_client_guide.md
+++ b/docs/client_guide/spark_client_guide.md
@@ -78,13 +78,14 @@ Local shuffle reader as its name indicates is suitable and optimized for spark's
 
 The important configuration is listed as following.
 
-|Property Name|Default|Description|
-|---|---|---|
-|spark.rss.writer.buffer.spill.size|128m|Buffer size for total partition data|
-|spark.rss.client.send.size.limit|16m|The max data size sent to shuffle server|
-|spark.rss.client.unregister.thread.pool.size|10|The max size of thread pool of unregistering|
-|spark.rss.client.unregister.request.timeout.sec|10|The max timeout sec when doing unregister to remote shuffle-servers|
-|spark.rss.client.off.heap.memory.enable|false|The client use off heap memory to process data|
+| Property Name                                         | Default | Description                                                                                                                                                                    |
+|-------------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| spark.rss.writer.buffer.spill.size                    | 128m    | Buffer size for total partition data                                                                                                                                           |
+| spark.rss.client.send.size.limit                      | 16m     | The max data size sent to shuffle server                                                                                                                                       |
+| spark.rss.client.unregister.thread.pool.size          | 10      | The max size of thread pool of unregistering                                                                                                                                   |
+| spark.rss.client.unregister.request.timeout.sec       | 10      | The max timeout sec when doing unregister to remote shuffle-servers                                                                                                            |
+| spark.rss.client.off.heap.memory.enable               | false   | The client use off heap memory to process data                                                                                                                                 |
+| spark.rss.client.remote.storage.useLocalConfAsDefault | false   | This option is only valid when the remote storage path is specified. If ture, the remote storage conf will use the client side hadoop configuration loaded from the classpath  |
 
 ### Adaptive Remote Shuffle Enabling 
 Currently, this feature only supports Spark. 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce the config to control whether to use local hadoop conf for remote storage by default

### Why are the changes needed?

I want to deploy one uniffle cluster to serve for spark jobs in multiple hadoop clusters. So I hope the remote storage config could be loaded from the default hdfs-site.xml in the classpath.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Internal tests.
