### PR TITLE
[#1335][0.8] fix(server, netty): release bytebuf explicitly when requiredId is expired and cache failed #1357

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -125,8 +125,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       boolean isPreAllocated = info != null;
       if (!isPreAllocated) {
         req.getPartitionToBlocks().values().stream()
-                .flatMap(Collection::stream)
-                .forEach(block -> block.getData().release());
+            .flatMap(Collection::stream)
+            .forEach(block -> block.getData().release());
 
         String errorMsg =
             "Can't find requireBufferId["

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -18,6 +18,8 @@
 package org.apache.uniffle.server.netty;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -122,6 +124,10 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       PreAllocatedBufferInfo info = manager.getAndRemovePreAllocatedBuffer(requireBufferId);
       boolean isPreAllocated = info != null;
       if (!isPreAllocated) {
+        req.getPartitionToBlocks().values().stream()
+                .flatMap(Collection::stream)
+                .forEach(block -> block.getData().release());
+
         String errorMsg =
             "Can't find requireBufferId["
                 + requireBufferId
@@ -140,7 +146,13 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       final long start = System.currentTimeMillis();
       List<ShufflePartitionedData> shufflePartitionedData = toPartitionedData(req);
       long alreadyReleasedSize = 0;
+      boolean isFailureOccurs = false;
       for (ShufflePartitionedData spd : shufflePartitionedData) {
+        // Once the cache failure occurs, we should explicitly release data held by byteBuf
+        if (isFailureOccurs) {
+          Arrays.stream(spd.getBlockList()).forEach(block -> block.getData().release());
+          continue;
+        }
         String shuffleDataInfo =
             "appId["
                 + appId
@@ -159,7 +171,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                     + ret;
             LOG.error(errorMsg);
             responseMessage = errorMsg;
-            break;
+            isFailureOccurs = true;
           } else {
             long toReleasedSize = spd.getTotalBlockSize();
             // after each cacheShuffleData call, the `preAllocatedSize` is updated timely.
@@ -177,7 +189,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
           ret = StatusCode.INTERNAL_ERROR;
           responseMessage = errorMsg;
           LOG.error(errorMsg);
-          break;
+          isFailureOccurs = true;
         }
       }
       // since the required buffer id is only used once, the shuffle client would try to require


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release bytebuf explicitly when `requiredId` is expired and cache failure occurs

### Why are the changes needed?

Fix: #1335

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal production tests.