### PR TITLE
[1387] improvement: compatibility with jdk8 when call JavaUtils.newConcurrentMap

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -46,8 +46,10 @@ public class JavaUtils {
   public static <K, V> ConcurrentHashMap<K, V> newConcurrentMap() {
     if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
         && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      logger.info("Jdk version is jdk9");
       return new ConcurrentHashMap<>();
     } else {
+      logger.info("Jdk version is jdk8");
       return new ConcurrentHashMapForJDK8<>();
     }
   }

--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -32,6 +32,17 @@ public class JavaUtils {
   private static final Logger logger = LoggerFactory.getLogger(JavaUtils.class);
   private static final String JAVA_9 = "JAVA_9";
 
+  public static boolean isJavaVersionAtLeastJava9() {
+    if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
+        && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      logger.info("Jdk version is jdk9");
+      return true;
+    } else {
+      logger.info("Jdk version is jdk8");
+      return false;
+    }
+  }
+
   /** Closes the given object, ignoring IOExceptions. */
   public static void closeQuietly(Closeable closeable) {
     try {
@@ -44,12 +55,9 @@ public class JavaUtils {
   }
 
   public static <K, V> ConcurrentHashMap<K, V> newConcurrentMap() {
-    if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
-        && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
-      logger.info("Jdk version is jdk9");
+    if (isJavaVersionAtLeastJava9()) {
       return new ConcurrentHashMap<>();
     } else {
-      logger.info("Jdk version is jdk8");
       return new ConcurrentHashMapForJDK8<>();
     }
   }

--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -35,10 +35,8 @@ public class JavaUtils {
   public static boolean isJavaVersionAtLeastJava9() {
     if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
         && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
-      logger.info("Jdk version is at least jdk9");
       return true;
     } else {
-      logger.info("Jdk version is jdk8");
       return false;
     }
   }

--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -35,7 +35,7 @@ public class JavaUtils {
   public static boolean isJavaVersionAtLeastJava9() {
     if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
         && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
-      logger.info("Jdk version is jdk9");
+      logger.info("Jdk version is at least jdk9");
       return true;
     } else {
       logger.info("Jdk version is jdk8");

--- a/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/JavaUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Enums;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class JavaUtils {
   private static final Logger logger = LoggerFactory.getLogger(JavaUtils.class);
+  private static final String JAVA_9 = "JAVA_9";
 
   /** Closes the given object, ignoring IOExceptions. */
   public static void closeQuietly(Closeable closeable) {
@@ -42,7 +44,8 @@ public class JavaUtils {
   }
 
   public static <K, V> ConcurrentHashMap<K, V> newConcurrentMap() {
-    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+    if (Enums.getIfPresent(JavaVersion.class, JAVA_9).isPresent()
+        && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
       return new ConcurrentHashMap<>();
     } else {
       return new ConcurrentHashMapForJDK8<>();


### PR DESCRIPTION
What changes were proposed in this pull request?
compatibility with jdk8 when call JavaUtils.newConcurrentMap

Why are the changes needed?
Fix: https://github.com/apache/incubator-uniffle/issues/1387

Does this PR introduce any user-facing change?
No.

How was this patch tested?