### PR TITLE
[#1157] fix(tez): Container not exit because shuffle client is not closed

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
@@ -436,5 +436,6 @@ public class WriteBufferManager<K, V> {
 
   public void freeAllResources() {
     sendExecutorService.shutdownNow();
+    shuffleWriteClient.close();
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

The container does not exit because shuffleclient is not closed
### Why are the changes needed?

The container does not exit because shuffleclient is not closed.

Fix: https://github.com/apache/incubator-uniffle/issues/1157

### Does this PR introduce _any_ user-facing change?



No.

### How was this patch tested?
unit test and prd runs.