### PR TITLE
[#1403] fix(client): RSS client configurations are not working.

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -116,7 +116,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
   public ShuffleWriteClientImpl(ShuffleClientFactory.WriteClientBuilder builder) {
     // set default value
-    if (builder.getRssConf() != null) {
+    if (builder.getRssConf() == null) {
       builder.rssConf(new RssConf());
     }
     if (builder.getUnregisterThreadPoolSize() == 0) {

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -35,6 +35,9 @@ import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.netty.IOMode;
 import org.apache.uniffle.common.rpc.StatusCode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -288,5 +291,30 @@ public class ShuffleWriteClientImplTest {
     assertEquals(2, excludeServers.size());
     assertEquals(ssi3, excludeServers.get(0));
     assertEquals(ssi1, excludeServers.get(1));
+  }
+
+  @Test
+  public void testSettingRssClientConfigs() {
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.NETTY_IO_MODE, IOMode.EPOLL);
+    ShuffleClientFactory.WriteClientBuilder writeClientBuilder =
+        ShuffleClientFactory.newWriteBuilder()
+            .clientType(ClientType.GRPC_NETTY.name())
+            .retryMax(3)
+            .retryIntervalMax(2000)
+            .heartBeatThreadNum(4)
+            .replica(1)
+            .replicaWrite(1)
+            .replicaRead(1)
+            .replicaSkipEnabled(true)
+            .dataTransferPoolSize(1)
+            .dataCommitPoolSize(1)
+            .unregisterThreadPoolSize(10)
+            .unregisterRequestTimeSec(10)
+            .rssConf(rssConf);
+    ShuffleWriteClientImpl client = writeClientBuilder.build();
+    IOMode ioMode = writeClientBuilder.getRssConf().get(RssClientConf.NETTY_IO_MODE);
+    client.close();
+    assertEquals(IOMode.EPOLL, ioMode);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a bug that was introduced from [#1228](https://github.com/apache/incubator-uniffle/pull/1228).
When the RssConf variable is not null, it gets overridden by a new RssConf, resulting in the loss of existing parameters within RssConf.

### Why are the changes needed?

For [#1403](https://github.com/apache/incubator-uniffle/issues/1403)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By setting RSS client configs successfully.
