### PR TITLE
[#1267][followup] improvement(client): The previous exception may be discarded when OOM occurs

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -164,10 +164,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
         return canAccess;
       } catch (Throwable e) {
         LOG.warn(
-            "Fail to access cluster {} using {} for {}",
-            coordinatorClient.getDesc(),
-            accessId,
-            e.getMessage());
+            "Fail to access cluster {} using {} for ", coordinatorClient.getDesc(), accessId, e);
       }
     }
 

--- a/common/src/main/java/org/apache/uniffle/common/util/RetryUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RetryUtils.java
@@ -76,24 +76,29 @@ public class RetryUtils {
       Function<Throwable, Boolean> isRetryFunc)
       throws Throwable {
     int retry = 0;
-    Throwable previousThrowable = null;
     while (true) {
       try {
         return cmd.execute();
       } catch (Throwable t) {
         retry++;
         if (isRetryFunc.apply(t) && retry < retryTimes) {
-          previousThrowable = t;
-          LOG.info("Retry due to Throwable, " + t.getClass().getName() + " " + t.getMessage());
-          LOG.info("Waiting " + intervalMs + " milliseconds before next connection attempt.");
+          if (LOG.isDebugEnabled()) {
+            LOG.error("Retry due to Throwable ", t);
+          } else {
+            LOG.error(
+                "Retry due to Throwable {}. Use DEBUG level to see the full stack: {}",
+                t.getClass().getName(),
+                t.getMessage());
+          }
+          LOG.error(
+              "Will retry {} more time(s) after waiting {} milliseconds.",
+              retryTimes - retry,
+              intervalMs);
           Thread.sleep(intervalMs);
           if (callBack != null) {
             callBack.execute();
           }
         } else {
-          if (previousThrowable != null) {
-            LOG.error("The previous retry failed due to ", previousThrowable);
-          }
           throw t;
         }
       }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -461,7 +461,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             maxRetryAttempts,
             t -> !(t instanceof OutOfMemoryError));
       } catch (Throwable throwable) {
-        LOG.warn(throwable.getMessage());
+        LOG.warn("Failed to send shuffle data due to ", throwable);
         isSuccessful = false;
         break;
       }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -154,7 +154,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
             maxRetryAttempts,
             t -> !(t instanceof OutOfMemoryError));
       } catch (Throwable throwable) {
-        LOG.warn(throwable.getMessage());
+        LOG.warn("Failed to send shuffle data due to ", throwable);
         isSuccessful = false;
         break;
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Save the previous exception in advance to prevent it from being lost during the next retry.

### Why are the changes needed?

This is the follow up pr of  [#1344](https://github.com/apache/incubator-uniffle/pull/1344)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
