### PR TITLE
[#1356] improvement: add metric of total expired pre-allocated buffers

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -71,7 +71,8 @@ public class ShuffleServerMetrics {
   private static final String ALLOCATED_BUFFER_SIZE = "allocated_buffer_size";
   private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE =
       "expired_pre_allocated_buffer_size";
-  private static final String EXPIRED_REQUIRE_BUFFER_IDS = "expired_require_buffer_ids";
+  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_ID_CNT =
+      "expired_pre_allocated_buffer_id_cnt";
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
@@ -164,7 +165,7 @@ public class ShuffleServerMetrics {
   public static Gauge.Child gaugeIsHealthy;
   public static Gauge.Child gaugePreAllocatedBufferSize;
   public static Gauge.Child gaugeExpiredPreAllocatedBufferSize;
-  public static Gauge gaugeExpiredRequireBufferIds;
+  public static Gauge.Child gaugeExpiredPreAllocatedBufferIdCnt;
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
@@ -257,12 +258,6 @@ public class ShuffleServerMetrics {
     counterTotalHadoopWriteDataSize.labels(tags, STORAGE_HOST_LABEL_ALL).inc(size);
   }
 
-  public static void updateExpiredRequireBufferId(String expiredRequireBufferIds) {
-    metricsManager.getCollectorRegistry().unregister(gaugeExpiredRequireBufferIds);
-    gaugeExpiredRequireBufferIds =
-        metricsManager.addGauge(EXPIRED_REQUIRE_BUFFER_IDS, expiredRequireBufferIds);
-  }
-
   private static void setUpMetrics() {
     counterTotalReceivedDataSize = metricsManager.addLabeledCounter(TOTAL_RECEIVED_DATA);
     counterTotalWriteDataSize = metricsManager.addLabeledCounter(TOTAL_WRITE_DATA);
@@ -338,7 +333,8 @@ public class ShuffleServerMetrics {
     gaugePreAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
     gaugeExpiredPreAllocatedBufferSize =
         metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE);
-    gaugeExpiredRequireBufferIds = metricsManager.addGauge(EXPIRED_REQUIRE_BUFFER_IDS);
+    gaugeExpiredPreAllocatedBufferIdCnt =
+        metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_ID_CNT);
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -69,10 +69,10 @@ public class ShuffleServerMetrics {
 
   private static final String IS_HEALTHY = "is_healthy";
   private static final String ALLOCATED_BUFFER_SIZE = "allocated_buffer_size";
-  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE =
-      "expired_pre_allocated_buffer_size";
-  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_ID_CNT =
-      "expired_pre_allocated_buffer_id_cnt";
+  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE_TOTAL =
+      "expired_pre_allocated_buffer_size_total";
+  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_ID_TOTAL =
+      "expired_pre_allocated_buffer_id_total";
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
@@ -164,8 +164,6 @@ public class ShuffleServerMetrics {
 
   public static Gauge.Child gaugeIsHealthy;
   public static Gauge.Child gaugePreAllocatedBufferSize;
-  public static Gauge.Child gaugeExpiredPreAllocatedBufferSize;
-  public static Gauge.Child gaugeExpiredPreAllocatedBufferIdCnt;
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
@@ -180,6 +178,8 @@ public class ShuffleServerMetrics {
   public static Counter counterRemoteStorageSuccessWrite;
   public static Counter counterTotalHadoopWriteDataSize;
   public static Counter counterTotalLocalFileWriteDataSize;
+  public static Counter counterExpiredPreAllocatedBufferSizeTotal;
+  public static Counter counterExpiredPreAllocatedBufferIdTotal;
 
   private static String tags;
   public static Counter counterLocalFileEventFlush;
@@ -331,10 +331,10 @@ public class ShuffleServerMetrics {
 
     gaugeIsHealthy = metricsManager.addLabeledGauge(IS_HEALTHY);
     gaugePreAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
-    gaugeExpiredPreAllocatedBufferSize =
-        metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE);
-    gaugeExpiredPreAllocatedBufferIdCnt =
-        metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_ID_CNT);
+    counterExpiredPreAllocatedBufferSizeTotal =
+        metricsManager.addCounter(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE_TOTAL);
+    counterExpiredPreAllocatedBufferIdTotal =
+        metricsManager.addCounter(EXPIRED_PRE_ALLOCATED_BUFFER_ID_TOTAL);
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -69,7 +69,9 @@ public class ShuffleServerMetrics {
 
   private static final String IS_HEALTHY = "is_healthy";
   private static final String ALLOCATED_BUFFER_SIZE = "allocated_buffer_size";
-  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE = "expired_pre_allocated_buffer_size";
+  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE =
+      "expired_pre_allocated_buffer_size";
+  private static final String EXPIRED_REQUIRE_BUFFER_IDS = "expired_require_buffer_ids";
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
@@ -162,6 +164,7 @@ public class ShuffleServerMetrics {
   public static Gauge.Child gaugeIsHealthy;
   public static Gauge.Child gaugePreAllocatedBufferSize;
   public static Gauge.Child gaugeExpiredPreAllocatedBufferSize;
+  public static Gauge gaugeExpiredRequireBufferIds;
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
@@ -254,6 +257,12 @@ public class ShuffleServerMetrics {
     counterTotalHadoopWriteDataSize.labels(tags, STORAGE_HOST_LABEL_ALL).inc(size);
   }
 
+  public static void updateExpiredRequireBufferId(String expiredRequireBufferIds) {
+    metricsManager.getCollectorRegistry().unregister(gaugeExpiredRequireBufferIds);
+    gaugeExpiredRequireBufferIds =
+        metricsManager.addGauge(EXPIRED_REQUIRE_BUFFER_IDS, expiredRequireBufferIds);
+  }
+
   private static void setUpMetrics() {
     counterTotalReceivedDataSize = metricsManager.addLabeledCounter(TOTAL_RECEIVED_DATA);
     counterTotalWriteDataSize = metricsManager.addLabeledCounter(TOTAL_WRITE_DATA);
@@ -327,7 +336,9 @@ public class ShuffleServerMetrics {
 
     gaugeIsHealthy = metricsManager.addLabeledGauge(IS_HEALTHY);
     gaugePreAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
-    gaugeExpiredPreAllocatedBufferSize = metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE);
+    gaugeExpiredPreAllocatedBufferSize =
+        metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE);
+    gaugeExpiredRequireBufferIds = metricsManager.addGauge(EXPIRED_REQUIRE_BUFFER_IDS);
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -69,6 +69,7 @@ public class ShuffleServerMetrics {
 
   private static final String IS_HEALTHY = "is_healthy";
   private static final String ALLOCATED_BUFFER_SIZE = "allocated_buffer_size";
+  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE = "expired_pre_allocated_buffer_size";
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
@@ -159,7 +160,8 @@ public class ShuffleServerMetrics {
   public static Gauge.Child gaugeLocalStorageUsedSpaceRatio;
 
   public static Gauge.Child gaugeIsHealthy;
-  public static Gauge.Child gaugeAllocatedBufferSize;
+  public static Gauge.Child gaugePreAllocatedBufferSize;
+  public static Gauge.Child gaugeExpiredPreAllocatedBufferSize;
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
@@ -324,7 +326,8 @@ public class ShuffleServerMetrics {
         metricsManager.addLabeledGauge(LOCAL_STORAGE_USED_SPACE_RATIO);
 
     gaugeIsHealthy = metricsManager.addLabeledGauge(IS_HEALTHY);
-    gaugeAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
+    gaugePreAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
+    gaugeExpiredPreAllocatedBufferSize = metricsManager.addLabeledGauge(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE);
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -163,7 +163,7 @@ public class ShuffleServerMetrics {
   public static Gauge.Child gaugeLocalStorageUsedSpaceRatio;
 
   public static Gauge.Child gaugeIsHealthy;
-  public static Gauge.Child gaugePreAllocatedBufferSize;
+  public static Gauge.Child gaugeAllocatedBufferSize;
   public static Gauge.Child gaugeInFlushBufferSize;
   public static Gauge.Child gaugeUsedBufferSize;
   public static Gauge.Child gaugeReadBufferUsedSize;
@@ -330,7 +330,7 @@ public class ShuffleServerMetrics {
         metricsManager.addLabeledGauge(LOCAL_STORAGE_USED_SPACE_RATIO);
 
     gaugeIsHealthy = metricsManager.addLabeledGauge(IS_HEALTHY);
-    gaugePreAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
+    gaugeAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
     counterExpiredPreAllocatedBufferSizeTotal =
         metricsManager.addCounter(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE_TOTAL);
     counterExpiredPreAllocatedBufferIdTotal =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -781,7 +781,6 @@ public class ShuffleTaskManager {
         }
       }
       ShuffleServerMetrics.gaugeExpiredPreAllocatedBufferIdCnt.set(expiredBufferIdsCnt);
-
     } catch (Exception e) {
       LOG.warn("Error happened in preAllocatedBufferCheck", e);
     }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -773,14 +773,14 @@ public class ShuffleTaskManager {
           // move release memory code down to here as the requiredBuffer could be consumed during
           // removing processing.
           shuffleBufferManager.releaseMemory(info.getRequireSize(), false, true);
-          ShuffleServerMetrics.gaugeExpiredPreAllocatedBufferSize.inc(info.getRequireSize());
+          ShuffleServerMetrics.counterExpiredPreAllocatedBufferSizeTotal.inc(info.getRequireSize());
           expiredBufferIdsCnt++;
           LOG.info("Remove expired preAllocatedBuffer " + requireId);
         } else {
           LOG.info("PreAllocatedBuffer[id={}] has already been removed", requireId);
         }
       }
-      ShuffleServerMetrics.gaugeExpiredPreAllocatedBufferIdCnt.set(expiredBufferIdsCnt);
+      ShuffleServerMetrics.counterExpiredPreAllocatedBufferIdTotal.inc(expiredBufferIdsCnt);
     } catch (Exception e) {
       LOG.warn("Error happened in preAllocatedBufferCheck", e);
     }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -772,6 +772,7 @@ public class ShuffleTaskManager {
           // move release memory code down to here as the requiredBuffer could be consumed during
           // removing processing.
           shuffleBufferManager.releaseMemory(info.getRequireSize(), false, true);
+          ShuffleServerMetrics.gaugeExpiredPreAllocatedBufferSize.inc(info.getRequireSize());
           LOG.info("Remove expired preAllocatedBuffer " + requireId);
         } else {
           LOG.info("PreAllocatedBuffer[id={}] has already been removed", requireId);

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -461,12 +461,12 @@ public class ShuffleBufferManager {
 
   void requirePreAllocatedSize(long delta) {
     preAllocatedSize.addAndGet(delta);
-    ShuffleServerMetrics.gaugeAllocatedBufferSize.set(preAllocatedSize.get());
+    ShuffleServerMetrics.gaugePreAllocatedBufferSize.set(preAllocatedSize.get());
   }
 
   public void releasePreAllocatedSize(long delta) {
     preAllocatedSize.addAndGet(-delta);
-    ShuffleServerMetrics.gaugeAllocatedBufferSize.set(preAllocatedSize.get());
+    ShuffleServerMetrics.gaugePreAllocatedBufferSize.set(preAllocatedSize.get());
   }
 
   boolean isFull() {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -461,12 +461,12 @@ public class ShuffleBufferManager {
 
   void requirePreAllocatedSize(long delta) {
     preAllocatedSize.addAndGet(delta);
-    ShuffleServerMetrics.gaugePreAllocatedBufferSize.set(preAllocatedSize.get());
+    ShuffleServerMetrics.gaugeAllocatedBufferSize.set(preAllocatedSize.get());
   }
 
   public void releasePreAllocatedSize(long delta) {
     preAllocatedSize.addAndGet(-delta);
-    ShuffleServerMetrics.gaugePreAllocatedBufferSize.set(preAllocatedSize.get());
+    ShuffleServerMetrics.gaugeAllocatedBufferSize.set(preAllocatedSize.get());
   }
 
   boolean isFull() {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add metrics of expired pre-allocated buffer size

### Why are the changes needed?


Fix: https://github.com/apache/incubator-uniffle/issues/1356

### Does this PR introduce _any_ user-facing change?


No.

### How was this patch tested?

test on PRD
