### PR TITLE
[#1373][part-1] add PartitionServerInfo for ShuffleHandleInfo to split partition server

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.broadcast.Broadcast;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
@@ -67,7 +68,7 @@ public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
     return handlerInfoBd.value().getRemoteStorage();
   }
 
-  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+  public Map<Integer, List<PartitionServerInfo>> getPartitionToServers() {
     return handlerInfoBd.value().getPartitionToServers();
   }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -48,8 +48,8 @@ import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.RemoteStorageInfo;
-import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
@@ -263,7 +263,7 @@ public class RssSparkShuffleUtils {
   public static Broadcast<ShuffleHandleInfo> broadcastShuffleHdlInfo(
       SparkContext sc,
       int shuffleId,
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      Map<Integer, List<PartitionServerInfo>> partitionToServers,
       RemoteStorageInfo storageInfo) {
     ShuffleHandleInfo handleInfo =
         new ShuffleHandleInfo(shuffleId, partitionToServers, storageInfo);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/ShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/ShuffleHandleInfo.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
@@ -37,7 +38,7 @@ public class ShuffleHandleInfo implements Serializable {
 
   private int shuffleId;
 
-  private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+  private Map<Integer, List<PartitionServerInfo>> partitionToServers;
   // shuffle servers which is for store shuffle data
   private Set<ShuffleServerInfo> shuffleServersForData;
   // remoteStorage used for this job
@@ -48,18 +49,21 @@ public class ShuffleHandleInfo implements Serializable {
 
   public ShuffleHandleInfo(
       int shuffleId,
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      Map<Integer, List<PartitionServerInfo>> partitionToServers,
       RemoteStorageInfo storageInfo) {
     this.shuffleId = shuffleId;
     this.partitionToServers = partitionToServers;
     this.shuffleServersForData = Sets.newHashSet();
-    for (List<ShuffleServerInfo> ssis : partitionToServers.values()) {
-      this.shuffleServersForData.addAll(ssis);
+    for (List<PartitionServerInfo> ssis : partitionToServers.values()) {
+      ssis.stream()
+          .forEach(
+              partitionServerInfo ->
+                  this.shuffleServersForData.addAll(partitionServerInfo.getSplitServers()));
     }
     this.remoteStorage = storageInfo;
   }
 
-  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+  public Map<Integer, List<PartitionServerInfo>> getPartitionToServers() {
     return partitionToServers;
   }
 

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -31,6 +31,7 @@ import org.apache.spark.shuffle.ShuffleHandleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.JavaUtils;
@@ -193,14 +194,15 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
         shuffleManager.getShuffleHandleInfoByShuffleId(shuffleId);
     if (shuffleHandleInfoByShuffleId != null) {
       code = RssProtos.StatusCode.SUCCESS;
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers =
+      Map<Integer, List<PartitionServerInfo>> partitionToServers =
           shuffleHandleInfoByShuffleId.getPartitionToServers();
       Map<Integer, RssProtos.GetShuffleServerListResponse> protopartitionToServers =
           JavaUtils.newConcurrentMap();
-      for (Map.Entry<Integer, List<ShuffleServerInfo>> integerListEntry :
+      for (Map.Entry<Integer, List<PartitionServerInfo>> integerListEntry :
           partitionToServers.entrySet()) {
+        // @TODO proto
         List<RssProtos.ShuffleServerId> shuffleServerIds =
-            ShuffleServerInfo.toProto(integerListEntry.getValue());
+            ShuffleServerInfo.toProto(integerListEntry.getValue().get(0).getSplitServers());
         RssProtos.GetShuffleServerListResponse getShuffleServerListResponse =
             RssProtos.GetShuffleServerListResponse.newBuilder()
                 .addAllServers(shuffleServerIds)

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -69,6 +69,7 @@ import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
@@ -428,7 +429,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_RETRY_INTERVAL);
     int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ASSIGNMENT_RETRY_TIMES);
     int estimateTaskConcurrency = RssSparkShuffleUtils.estimateTaskConcurrency(sparkConf);
-    Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+    Map<Integer, List<PartitionServerInfo>> partitionToServers;
     try {
       partitionToServers =
           RetryUtils.retry(
@@ -634,9 +635,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
               rssShuffleHandle.getPartitionToServers(),
               rssShuffleHandle.getRemoteStorage());
     }
-    Map<Integer, List<ShuffleServerInfo>> allPartitionToServers =
+    Map<Integer, List<PartitionServerInfo>> allPartitionToServers =
         shuffleHandleInfo.getPartitionToServers();
-    Map<Integer, List<ShuffleServerInfo>> requirePartitionToServers =
+    Map<Integer, List<PartitionServerInfo>> requirePartitionToServers =
         allPartitionToServers.entrySet().stream()
             .filter(x -> x.getKey() >= startPartition && x.getKey() < endPartition)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -1139,7 +1140,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       int estimateTaskConcurrency = RssSparkShuffleUtils.estimateTaskConcurrency(sparkConf);
       /** Before reassigning ShuffleServer, clear the ShuffleServer list in ShuffleWriteClient. */
       shuffleWriteClient.unregisterShuffle(id.get(), shuffleId);
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+      Map<Integer, List<PartitionServerInfo>> partitionToServers;
       try {
         partitionToServers =
             RetryUtils.retry(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -50,8 +50,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
-import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 
@@ -59,7 +59,7 @@ import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
 
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleReader.class);
-  private final Map<Integer, List<ShuffleServerInfo>> partitionToShuffleServers;
+  private final Map<Integer, List<PartitionServerInfo>> partitionToShuffleServers;
 
   private String appId;
   private int shuffleId;
@@ -96,7 +96,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       ShuffleReadMetrics readMetrics,
       RssConf rssConf,
       ShuffleDataDistributionType dataDistributionType,
-      Map<Integer, List<ShuffleServerInfo>> allPartitionToServers) {
+      Map<Integer, List<PartitionServerInfo>> allPartitionToServers) {
     this.appId = rssShuffleHandle.getAppId();
     this.startPartition = startPartition;
     this.endPartition = endPartition;
@@ -240,7 +240,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
           LOG.info("{} partition is empty partition", partition);
           continue;
         }
-        List<ShuffleServerInfo> shuffleServerInfoList = partitionToShuffleServers.get(partition);
+        List<PartitionServerInfo> shuffleServerInfoList = partitionToShuffleServers.get(partition);
         // This mechanism of expectedTaskIdsBitmap filter is to filter out the most of data.
         // especially for AQE skew optimization
         boolean expectedTaskIdsBitmapFilterEnable =
@@ -258,7 +258,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
                         .partitionNum(partitionNum)
                         .blockIdBitmap(partitionToExpectBlocks.get(partition))
                         .taskIdBitmap(taskIdBitmap)
-                        .shuffleServerInfoList(shuffleServerInfoList)
+                        .partitionServerInfoList(shuffleServerInfoList)
                         .hadoopConf(hadoopConf)
                         .shuffleDataDistributionType(dataDistributionType)
                         .expectedTaskIdsBitmapFilterEnable(expectedTaskIdsBitmapFilterEnable)

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.spark.shuffle.RssShuffleHandle;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
@@ -73,9 +74,11 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
     when(handleMock.getDependency()).thenReturn(dependencyMock);
     when(handleMock.getShuffleId()).thenReturn(1);
     when(handleMock.getNumMaps()).thenReturn(1);
-    Map<Integer, List<ShuffleServerInfo>> partitionToServers = new HashMap<>();
-    partitionToServers.put(0, Lists.newArrayList(ssi));
-    partitionToServers.put(1, Lists.newArrayList(ssi));
+    Map<Integer, List<PartitionServerInfo>> partitionToServers = new HashMap<>();
+    partitionToServers.put(
+        0, Lists.newArrayList(new PartitionServerInfo(0, Lists.newArrayList(ssi))));
+    partitionToServers.put(
+        1, Lists.newArrayList(new PartitionServerInfo(1, Lists.newArrayList(ssi))));
     when(handleMock.getPartitionToServers()).thenReturn(partitionToServers);
     when(dependencyMock.serializer()).thenReturn(KRYO_SERIALIZER);
     TaskContext contextMock = mock(TaskContext.class);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -54,6 +54,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.JavaUtils;
@@ -374,13 +375,28 @@ public class RssShuffleWriterTest {
 
     BufferManagerOptions bufferOptions = new BufferManagerOptions(conf);
     ShuffleWriteMetrics shuffleWriteMetrics = new ShuffleWriteMetrics();
+    Map<Integer, List<PartitionServerInfo>> partitionToServerInfos = Maps.newHashMap();
+    partitionToServers.entrySet().stream()
+        .forEach(
+            entry -> {
+              entry
+                  .getValue()
+                  .forEach(
+                      shuffleServerInfo -> {
+                        partitionToServerInfos
+                            .computeIfAbsent(entry.getKey(), k -> Lists.newArrayList())
+                            .add(
+                                new PartitionServerInfo(
+                                    entry.getKey(), Lists.newArrayList(shuffleServerInfo)));
+                      });
+            });
     WriteBufferManager bufferManager =
         new WriteBufferManager(
             0,
             0,
             bufferOptions,
             kryoSerializer,
-            partitionToServers,
+            partitionToServerInfos,
             mockTaskMemoryManager,
             shuffleWriteMetrics,
             RssSparkConfig.toRssConf(conf));

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -35,9 +35,9 @@ import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
 import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
-import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
@@ -51,7 +51,7 @@ import org.apache.uniffle.storage.request.CreateShuffleReadHandlerRequest;
 public class ShuffleReadClientImpl implements ShuffleReadClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleReadClientImpl.class);
-  private List<ShuffleServerInfo> shuffleServerInfoList;
+  private List<PartitionServerInfo> partitionServerInfoList;
   private int shuffleId;
   private int partitionId;
   private ByteBuffer readBuffer;
@@ -121,7 +121,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     this.blockIdBitmap = builder.getBlockIdBitmap();
     this.taskIdBitmap = builder.getTaskIdBitmap();
     this.idHelper = builder.getIdHelper();
-    this.shuffleServerInfoList = builder.getShuffleServerInfoList();
+    this.partitionServerInfoList = builder.getPartitionServerInfoList();
 
     CreateShuffleReadHandlerRequest request = new CreateShuffleReadHandlerRequest();
     request.setStorageType(builder.getStorageType());
@@ -133,7 +133,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     request.setPartitionNum(builder.getPartitionNum());
     request.setReadBufferSize((int) builder.getReadBufferSize());
     request.setStorageBasePath(builder.getBasePath());
-    request.setShuffleServerInfoList(shuffleServerInfoList);
+    request.setPartitionServerInfoList(partitionServerInfoList);
     request.setHadoopConf(builder.getHadoopConf());
     request.setExpectBlockIds(blockIdBitmap);
     request.setProcessBlockIds(processedBlockIds);
@@ -223,7 +223,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
                   + actualCrc;
           // If some blocks of one replica are corrupted,but maybe other replicas are not corrupted,
           // so exception should not be thrown here if blocks have multiple replicas
-          if (shuffleServerInfoList.size() > 1) {
+          if (partitionServerInfoList.size() > 1) {
             LOG.warn(errMsg);
             clientReadHandler.updateConsumedBlockInfo(bs, true);
             continue;

--- a/common/src/main/java/org/apache/uniffle/common/PartitionServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/PartitionServerInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+import java.util.List;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class PartitionServerInfo {
+  private Integer partitionId;
+  private List<ShuffleServerInfo> splitServers;
+
+  public Integer getPartitionId() {
+    return partitionId;
+  }
+
+  public PartitionServerInfo(Integer partitionId, List<ShuffleServerInfo> splitServers) {
+    this.partitionId = partitionId;
+    this.splitServers = splitServers;
+  }
+
+  public List<ShuffleServerInfo> getSplitServers() {
+    return splitServers;
+  }
+
+  public ShuffleServerInfo getFirstSplitServer() {
+    return splitServers != null && splitServers.size() > 0 ? splitServers.get(0) : null;
+  }
+
+  public ShuffleServerInfo getLastSplitServer() {
+    return splitServers != null && splitServers.size() > 0
+        ? splitServers.get(splitServers.size() - 1)
+        : null;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder codeBuilder = new HashCodeBuilder();
+    codeBuilder.append(this.getPartitionId());
+    if (this.getSplitServers() != null) {
+      for (int i = 0; i < this.getSplitServers().size(); i++) {
+        codeBuilder.append(this.getSplitServers().get(i));
+      }
+    }
+    return codeBuilder.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof PartitionServerInfo) {
+      return partitionId.equals(((PartitionServerInfo) obj).getPartitionId())
+          && splitServers.equals(((PartitionServerInfo) obj).getSplitServers());
+    }
+    return false;
+  }
+
+}

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleAssignmentsInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleAssignmentsInfo.java
@@ -22,17 +22,17 @@ import java.util.Map;
 
 public class ShuffleAssignmentsInfo {
 
-  private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+  private Map<Integer, List<PartitionServerInfo>> partitionToServers;
   private Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges;
 
   public ShuffleAssignmentsInfo(
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      Map<Integer, List<PartitionServerInfo>> partitionToServers,
       Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges) {
     this.partitionToServers = partitionToServers;
     this.serverToPartitionRanges = serverToPartitionRanges;
   }
 
-  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+  public Map<Integer, List<PartitionServerInfo>> getPartitionToServers() {
     return partitionToServers;
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -54,6 +54,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.config.RssConf;
@@ -347,15 +348,17 @@ public class RssUtils {
   }
 
   public static Map<ShuffleServerInfo, Set<Integer>> generateServerToPartitions(
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers) {
+      Map<Integer, List<PartitionServerInfo>> partitionToServers) {
     Map<ShuffleServerInfo, Set<Integer>> serverToPartitions = Maps.newHashMap();
-    for (Map.Entry<Integer, List<ShuffleServerInfo>> entry : partitionToServers.entrySet()) {
+    for (Map.Entry<Integer, List<PartitionServerInfo>> entry : partitionToServers.entrySet()) {
       int partitionId = entry.getKey();
-      for (ShuffleServerInfo serverInfo : entry.getValue()) {
-        if (!serverToPartitions.containsKey(serverInfo)) {
-          serverToPartitions.put(serverInfo, Sets.newHashSet(partitionId));
-        } else {
-          serverToPartitions.get(serverInfo).add(partitionId);
+      for (PartitionServerInfo partitionServerInfo : entry.getValue()) {
+        for (ShuffleServerInfo serverInfo : partitionServerInfo.getSplitServers()) {
+          if (!serverToPartitions.containsKey(serverInfo)) {
+            serverToPartitions.put(serverInfo, Sets.newHashSet(partitionId));
+          } else {
+            serverToPartitions.get(serverInfo).add(partitionId);
+          }
         }
       }
     }

--- a/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.config.RssConf;
@@ -246,15 +247,19 @@ public class RssUtilsTest {
 
   @Test
   public void testGenerateServerToPartitions() {
-    Map<Integer, List<ShuffleServerInfo>> partitionToServers = Maps.newHashMap();
+    Map<Integer, List<PartitionServerInfo>> partitionToServers = Maps.newHashMap();
     ShuffleServerInfo server1 = new ShuffleServerInfo("server1", "0.0.0.1", 100);
     ShuffleServerInfo server2 = new ShuffleServerInfo("server2", "0.0.0.2", 200);
     ShuffleServerInfo server3 = new ShuffleServerInfo("server3", "0.0.0.3", 300);
     ShuffleServerInfo server4 = new ShuffleServerInfo("server4", "0.0.0.4", 400);
-    partitionToServers.put(1, Lists.newArrayList(server1, server2));
-    partitionToServers.put(2, Lists.newArrayList(server3, server4));
-    partitionToServers.put(3, Lists.newArrayList(server1, server2));
-    partitionToServers.put(4, Lists.newArrayList(server3, server4));
+    partitionToServers.put(
+        1, Lists.newArrayList(new PartitionServerInfo(1, Lists.newArrayList(server1, server2))));
+    partitionToServers.put(
+        2, Lists.newArrayList(new PartitionServerInfo(1, Lists.newArrayList(server3, server4))));
+    partitionToServers.put(
+        3, Lists.newArrayList(new PartitionServerInfo(1, Lists.newArrayList(server1, server2))));
+    partitionToServers.put(
+        4, Lists.newArrayList(new PartitionServerInfo(1, Lists.newArrayList(server3, server4))));
     Map<ShuffleServerInfo, Set<Integer>> serverToPartitions =
         RssUtils.generateServerToPartitions(partitionToServers);
     assertEquals(4, serverToPartitions.size());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
@@ -176,7 +176,7 @@ public class AssignmentWithTagsTest extends CoordinatorTestBase {
     List<Integer> assignedServerPorts =
         assignmentsInfo.getPartitionToServers().values().stream()
             .flatMap(x -> x.stream())
-            .map(x -> x.getGrpcPort())
+            .map(x -> x.getSplitServers().get(0).getGrpcPort())
             .collect(Collectors.toList());
     assertEquals(1, assignedServerPorts.size());
     assertTrue(
@@ -200,7 +200,7 @@ public class AssignmentWithTagsTest extends CoordinatorTestBase {
     assignedServerPorts =
         assignmentsInfo.getPartitionToServers().values().stream()
             .flatMap(x -> x.stream())
-            .map(x -> x.getGrpcPort())
+            .map(x -> x.getSplitServers().get(0).getGrpcPort())
             .collect(Collectors.toList());
     assertEquals(1, assignedServerPorts.size());
     assertTrue(tagOfShufflePorts.get("fixed").contains(assignedServerPorts.get(0)));
@@ -212,7 +212,7 @@ public class AssignmentWithTagsTest extends CoordinatorTestBase {
     assignedServerPorts =
         assignmentsInfo.getPartitionToServers().values().stream()
             .flatMap(x -> x.stream())
-            .map(x -> x.getGrpcPort())
+            .map(x -> x.getSplitServers().get(0).getGrpcPort())
             .collect(Collectors.toList());
     assertEquals(1, assignedServerPorts.size());
     assertTrue(tagOfShufflePorts.get("fixed").contains(assignedServerPorts.get(0)));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.ReconfigurableBase;
@@ -258,8 +259,8 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
         shuffleWriteClient.getShuffleAssignments(
             "app1", 0, 10, 1, TAGS, SERVER_NUM + 10, -1, excludeServer);
     List<ShuffleServerInfo> resultShuffle = Lists.newArrayList();
-    for (List<ShuffleServerInfo> ssis : shuffleAssignmentsInfo.getPartitionToServers().values()) {
-      resultShuffle.addAll(ssis);
+    for (List<PartitionServerInfo> psis : shuffleAssignmentsInfo.getPartitionToServers().values()) {
+      psis.forEach(psi -> resultShuffle.addAll(psi.getSplitServers()));
     }
 
     List<String> resultShuffleServerId =

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorGrpcTest.java
@@ -35,6 +35,7 @@ import org.apache.uniffle.client.response.RssApplicationInfoResponse;
 import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleRegisterInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
@@ -86,28 +87,36 @@ public class CoordinatorGrpcTest extends CoordinatorTestBase {
   public void testGetPartitionToServers() {
     GetShuffleAssignmentsResponse testResponse = generateShuffleAssignmentsResponse();
 
-    Map<Integer, List<ShuffleServerInfo>> partitionToServers =
+    Map<Integer, List<PartitionServerInfo>> partitionToServers =
         coordinatorClient.getPartitionToServers(testResponse);
 
     assertEquals(
         Arrays.asList(
-            new ShuffleServerInfo("id1", "0.0.0.1", 100),
-            new ShuffleServerInfo("id2", "0.0.0.2", 100)),
+            new PartitionServerInfo(
+                0, Lists.newArrayList(new ShuffleServerInfo("id1", "0.0.0.1", 100))),
+            new PartitionServerInfo(
+                0, Lists.newArrayList(new ShuffleServerInfo("id2", "0.0.0.2", 100)))),
         partitionToServers.get(0));
     assertEquals(
         Arrays.asList(
-            new ShuffleServerInfo("id1", "0.0.0.1", 100),
-            new ShuffleServerInfo("id2", "0.0.0.2", 100)),
+            new PartitionServerInfo(
+                1, Lists.newArrayList(new ShuffleServerInfo("id1", "0.0.0.1", 100))),
+            new PartitionServerInfo(
+                1, Lists.newArrayList(new ShuffleServerInfo("id2", "0.0.0.2", 100)))),
         partitionToServers.get(1));
     assertEquals(
         Arrays.asList(
-            new ShuffleServerInfo("id3", "0.0.0.3", 100),
-            new ShuffleServerInfo("id4", "0.0.0.4", 100)),
+            new PartitionServerInfo(
+                2, Lists.newArrayList(new ShuffleServerInfo("id3", "0.0.0.3", 100))),
+            new PartitionServerInfo(
+                2, Lists.newArrayList(new ShuffleServerInfo("id4", "0.0.0.4", 100)))),
         partitionToServers.get(2));
     assertEquals(
         Arrays.asList(
-            new ShuffleServerInfo("id3", "0.0.0.3", 100),
-            new ShuffleServerInfo("id4", "0.0.0.4", 100)),
+            new PartitionServerInfo(
+                3, Lists.newArrayList(new ShuffleServerInfo("id3", "0.0.0.3", 100))),
+            new PartitionServerInfo(
+                3, Lists.newArrayList(new ShuffleServerInfo("id4", "0.0.0.4", 100)))),
         partitionToServers.get(3));
     assertNull(partitionToServers.get(4));
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/PartitionBalanceCoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/PartitionBalanceCoordinatorGrpcTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.request.RssGetShuffleAssignmentsRequest;
 import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
-import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -63,30 +63,33 @@ public class PartitionBalanceCoordinatorGrpcTest extends CoordinatorTestBase {
             "app1", 1, 1, 1, 1, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     RssGetShuffleAssignmentsResponse response = coordinatorClient.getShuffleAssignments(request);
     assertEquals(1, response.getPartitionToServers().size());
-    for (Map.Entry<Integer, List<ShuffleServerInfo>> entry :
+    for (Map.Entry<Integer, List<PartitionServerInfo>> entry :
         response.getPartitionToServers().entrySet()) {
       assertEquals(1, entry.getValue().size());
-      assertEquals(SHUFFLE_SERVER_PORT + 1, entry.getValue().get(0).getGrpcPort());
+      assertEquals(
+          SHUFFLE_SERVER_PORT + 1, entry.getValue().get(0).getFirstSplitServer().getGrpcPort());
     }
     request =
         new RssGetShuffleAssignmentsRequest(
             "app1", 2, 1, 1, 1, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     response = coordinatorClient.getShuffleAssignments(request);
     assertEquals(1, response.getPartitionToServers().size());
-    for (Map.Entry<Integer, List<ShuffleServerInfo>> entry :
+    for (Map.Entry<Integer, List<PartitionServerInfo>> entry :
         response.getPartitionToServers().entrySet()) {
       assertEquals(1, entry.getValue().size());
-      assertEquals(SHUFFLE_SERVER_PORT + 1, entry.getValue().get(0).getGrpcPort());
+      assertEquals(
+          SHUFFLE_SERVER_PORT + 1, entry.getValue().get(0).getFirstSplitServer().getGrpcPort());
     }
     request =
         new RssGetShuffleAssignmentsRequest(
             "app1", 2, 1, 1, 1, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     response = coordinatorClient.getShuffleAssignments(request);
     assertEquals(1, response.getPartitionToServers().size());
-    for (Map.Entry<Integer, List<ShuffleServerInfo>> entry :
+    for (Map.Entry<Integer, List<PartitionServerInfo>> entry :
         response.getPartitionToServers().entrySet()) {
       assertEquals(1, entry.getValue().size());
-      assertEquals(SHUFFLE_SERVER_PORT, entry.getValue().get(0).getGrpcPort());
+      assertEquals(
+          SHUFFLE_SERVER_PORT, entry.getValue().get(0).getFirstSplitServer().getGrpcPort());
     }
   }
 }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -39,6 +40,7 @@ import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
@@ -224,6 +226,10 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
       List<ShuffleServerInfo> shuffleServerInfoList,
       Roaring64NavigableMap expectBlockIds,
       StorageType storageType) {
+    List<PartitionServerInfo> partitionServerInfos =
+        shuffleServerInfoList.stream()
+            .map(ssi -> new PartitionServerInfo(partitionId, Lists.newArrayList(ssi)))
+            .collect(Collectors.toList());
     CreateShuffleReadHandlerRequest request = new CreateShuffleReadHandlerRequest();
     request.setStorageType(storageType.name());
     request.setAppId(testAppId);
@@ -234,7 +240,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     request.setPartitionNum(1);
     request.setReadBufferSize(14 * 1024 * 1024);
     request.setStorageBasePath(remoteStoragePath);
-    request.setShuffleServerInfoList(shuffleServerInfoList);
+    request.setPartitionServerInfoList(partitionServerInfos);
     request.setHadoopConf(conf);
     request.setExpectBlockIds(expectBlockIds);
     Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.MockedGrpcServer;
@@ -256,7 +256,7 @@ public class GetShuffleReportForMultiPartTest extends SparkIntegrationTestBase {
         Roaring64NavigableMap taskIdBitmap) {
       int shuffleId = handle.shuffleId();
       RssShuffleHandle<?, ?, ?> rssShuffleHandle = (RssShuffleHandle<?, ?, ?>) handle;
-      Map<Integer, List<ShuffleServerInfo>> allPartitionToServers =
+      Map<Integer, List<PartitionServerInfo>> allPartitionToServers =
           rssShuffleHandle.getPartitionToServers();
       int partitionNum =
           (int)

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleAssignmentsResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssGetShuffleAssignmentsResponse.java
@@ -21,12 +21,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.StatusCode;
 
 public class RssGetShuffleAssignmentsResponse extends ClientResponse {
 
-  private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
+  private Map<Integer, List<PartitionServerInfo>> partitionToServers;
   private Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges;
 
   public RssGetShuffleAssignmentsResponse(StatusCode statusCode) {
@@ -37,11 +38,11 @@ public class RssGetShuffleAssignmentsResponse extends ClientResponse {
     super(statusCode, message);
   }
 
-  public Map<Integer, List<ShuffleServerInfo>> getPartitionToServers() {
+  public Map<Integer, List<PartitionServerInfo>> getPartitionToServers() {
     return partitionToServers;
   }
 
-  public void setPartitionToServers(Map<Integer, List<ShuffleServerInfo>> partitionToServers) {
+  public void setPartitionToServers(Map<Integer, List<PartitionServerInfo>> partitionToServers) {
     this.partitionToServers = partitionToServers;
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/request/CreateShuffleReadHandlerRequest.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.PartitionServerInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
-import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.util.IdHelper;
@@ -42,7 +42,7 @@ public class CreateShuffleReadHandlerRequest {
   private String storageBasePath;
   private RssBaseConf rssBaseConf;
   private Configuration hadoopConf;
-  private List<ShuffleServerInfo> shuffleServerInfoList;
+  private List<PartitionServerInfo> partitionServerInfoList;
   private Roaring64NavigableMap expectBlockIds;
   private Roaring64NavigableMap processBlockIds;
   private ShuffleDataDistributionType distributionType;
@@ -137,12 +137,12 @@ public class CreateShuffleReadHandlerRequest {
     this.storageBasePath = storageBasePath;
   }
 
-  public List<ShuffleServerInfo> getShuffleServerInfoList() {
-    return shuffleServerInfoList;
+  public List<PartitionServerInfo> getPartitionServerInfoList() {
+    return partitionServerInfoList;
   }
 
-  public void setShuffleServerInfoList(List<ShuffleServerInfo> shuffleServerInfoList) {
-    this.shuffleServerInfoList = shuffleServerInfoList;
+  public void setPartitionServerInfoList(List<PartitionServerInfo> partitionServerInfoList) {
+    this.partitionServerInfoList = partitionServerInfoList;
   }
 
   public Configuration getHadoopConf() {


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1、add `PartitionServerInfo`
2、`Map<Integer, List<ShuffleServerInfo>> partitionToServers ` chang to  `Map<Integer, List<PartitionServerInfo>> partitionToServers`
  

### Why are the changes needed?

Fix: #1373 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT