### PR TITLE
[#974] fix(coordinator): Dynamic remote storage conf invalid for `LegacyClientConfParser`

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.coordinator.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
@@ -17,7 +17,9 @@
 
 package org.apache.uniffle.coordinator.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/util/CoordinatorUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.uniffle.coordinator.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -141,7 +141,10 @@ public class CoordinatorUtils {
     }
 
     for (String s : clusterConfItems) {
-      String[] item = s.split(Constants.COMMA_SPLIT_CHAR);
+      Pattern pattern = Pattern.compile("([^,=]+=)");
+      Matcher matcher = pattern.matcher(s);
+      List<Integer> matchIndices = getMatchIndices(matcher);
+      String[] item = splitStringByIndices(s, matchIndices);
       if (ArrayUtils.isEmpty(item) || item.length < 2) {
         LOG.warn(msg, s);
         return Maps.newHashMap();
@@ -166,5 +169,30 @@ public class CoordinatorUtils {
       res.put(clusterId, curClusterConf);
     }
     return res;
+  }
+
+  public static List<Integer> getMatchIndices(Matcher matcher) {
+    List<Integer> matchIndices = new ArrayList<>();
+    while (matcher.find()) {
+      matchIndices.add(matcher.start());
+    }
+    return matchIndices.isEmpty() ? Collections.emptyList() : matchIndices;
+  }
+
+  public static String[] splitStringByIndices(String inputString, List<Integer> indices) {
+    if (indices.get(0) != 0) {
+      indices.add(0, 0);
+    }
+    int length = indices.size();
+    String[] resultArray = new String[length];
+    for (int i = 0; i < length; i++) {
+      int startIndex = indices.get(i);
+      int endIndex = (i < length - 1) ? indices.get(i + 1) : inputString.length();
+      resultArray[i] =
+          (inputString.charAt(endIndex - 1) == ',')
+              ? inputString.substring(startIndex, endIndex - 1)
+              : inputString.substring(startIndex, endIndex);
+    }
+    return resultArray;
   }
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/conf/LegacyClientConfParserTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/conf/LegacyClientConfParserTest.java
@@ -32,6 +32,10 @@ public class LegacyClientConfParserTest {
     assertEquals("v1", conf.getRssClientConf().get("k1"));
     assertEquals("v2", conf.getRssClientConf().get("k2"));
     assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://a-ns01").getConfItems().get("k1"));
-    assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k1"));
+    assertEquals(
+        "v1,v2,v3", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k1"));
+    assertEquals("v4", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k2"));
+    assertEquals(
+        "v5,v6", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k3"));
   }
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/conf/YamlClientConfParserTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/conf/YamlClientConfParserTest.java
@@ -32,7 +32,8 @@ public class YamlClientConfParserTest {
             getClass().getClassLoader().getResource("dynamicClientConf.yaml").openStream());
     assertEquals("v1", conf.getRssClientConf().get("k1"));
     assertEquals("v2", conf.getRssClientConf().get("k2"));
-    assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://a-ns01").getConfItems().get("k1"));
+    assertEquals(
+        "v1,v2,v3", conf.getRemoteStorageInfos().get("hdfs://a-ns01").getConfItems().get("k1"));
     assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k1"));
   }
 
@@ -74,7 +75,7 @@ public class YamlClientConfParserTest {
     yaml =
         "remoteStorageInfos:\n"
             + "   hdfs://a-ns01:\n"
-            + "      k1: v1\n"
+            + "      k1: v1,v5\n"
             + "      k2: v2\n"
             + "   hdfs://x-ns01:\n"
             + "      k1: v1\n"
@@ -82,7 +83,8 @@ public class YamlClientConfParserTest {
     conf = parser.tryParse(IOUtils.toInputStream(yaml));
     assertEquals(0, conf.getRssClientConf().size());
     assertEquals(2, conf.getRemoteStorageInfos().size());
-    assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://a-ns01").getConfItems().get("k1"));
+    assertEquals(
+        "v1,v5", conf.getRemoteStorageInfos().get("hdfs://a-ns01").getConfItems().get("k1"));
     assertEquals("v1", conf.getRemoteStorageInfos().get("hdfs://x-ns01").getConfItems().get("k1"));
 
     yaml =

--- a/coordinator/src/test/resources/dynamicClientConf.legacy
+++ b/coordinator/src/test/resources/dynamicClientConf.legacy
@@ -19,5 +19,5 @@ k1 v1
 k2 v2
 
 rss.coordinator.remote.storage.path hdfs://x-ns01,hdfs://a-ns01
-rss.coordinator.remote.storage.cluster.conf x-ns01,k1=v1,k2=v2;a-ns01,k1=v1,k2=v2
+rss.coordinator.remote.storage.cluster.conf x-ns01,k1=v1,v2,v3,k2=v4,k3=v5,v6;a-ns01,k1=v1,k2=v2
 

--- a/coordinator/src/test/resources/dynamicClientConf.yaml
+++ b/coordinator/src/test/resources/dynamicClientConf.yaml
@@ -24,7 +24,7 @@ remoteStorageInfos:
     <configuration>
         <property>
           <name>k1</name>
-          <value>v1</value>
+          <value>v1,v2,v3</value>
         </property>
 
         <property>


### PR DESCRIPTION
<!--
1. Title: [#974 ] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

As title



### Why are the changes needed?

Fix: #974 

### Does this PR introduce _any_ user-facing change?

Before:
`rss.coordinator.remote.storage.cluster.conf hadoop-ns01,dfs.hosts=a,b,c,dfs.service=sssss`
will trigger a bug.

After:
`rss.coordinator.remote.storage.cluster.conf hadoop-ns01,dfs.hosts=a,b,c,dfs.service=sssss`
will work correctly.


Yes.

### How was this patch tested?

unit test
