### PR TITLE
[#1119] improvement(client): Explicitly throw `BUFFER_LIMIT_OF_HUGE_PARTITION`

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/exception/NoBufferException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoBufferException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.exception;
+
+public class NoBufferException extends RuntimeException {
+  public NoBufferException(String message) {
+    super(message);
+  }
+
+  public NoBufferException(Throwable e) {
+    super(e);
+  }
+
+  public NoBufferException(String message, Throwable e) {
+    super(message, e);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/exception/NoBufferForHugePartitionException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoBufferForHugePartitionException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.exception;
+
+public class NoBufferForHugePartitionException extends RuntimeException {
+  public NoBufferForHugePartitionException(String message) {
+    super(message);
+  }
+
+  public NoBufferForHugePartitionException(Throwable e) {
+    super(e);
+  }
+
+  public NoBufferForHugePartitionException(String message, Throwable e) {
+    super(message, e);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/exception/NoRegisterException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoRegisterException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.exception;
+
+public class NoRegisterException extends RuntimeException {
+  public NoRegisterException(String message) {
+    super(message);
+  }
+
+  public NoRegisterException(Throwable e) {
+    super(e);
+  }
+
+  public NoRegisterException(String message, Throwable e) {
+    super(message, e);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/StatusCode.java
@@ -34,6 +34,7 @@ public enum StatusCode {
   TIMEOUT(7),
   ACCESS_DENIED(8),
   INVALID_REQUEST(9),
+  NO_BUFFER_FOR_HUGE_PARTITION(10),
   UNKNOWN(-1);
 
   static final Map<Integer, StatusCode> VALUE_MAP =

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -58,6 +58,8 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   protected static final int JETTY_PORT_1 = 19998;
   protected static final int JETTY_PORT_2 = 20040;
   protected static final String COORDINATOR_QUORUM = LOCALHOST + ":" + COORDINATOR_PORT_1;
+  protected static final String SHUFFLE_SERVER_METRICS_URL =
+      "http://127.0.0.1:18080/metrics/server";
 
   protected static List<ShuffleServer> shuffleServers = Lists.newArrayList();
   protected static List<CoordinatorServer> coordinators = Lists.newArrayList();

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -223,17 +223,18 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
     long result = FAILED_REQUIRE_ID;
     Random random = new Random();
     final int backOffBase = 2000;
-    while (rpcResponse.getStatus() == RssProtos.StatusCode.NO_BUFFER) {
-      LOG.info(
-          "Can't require "
-              + requireSize
-              + " bytes from "
-              + host
-              + ":"
-              + port
-              + ", sleep and try["
-              + retry
-              + "] again");
+    LOG.info(
+        "Can't require buffer for appId: {}, shuffleId: {}, partitionIds: {} with {} bytes from {}:{} due to {}, sleep and try[{}] again",
+        appId,
+        shuffleId,
+        partitionIds,
+        requireSize,
+        host,
+        port,
+        rpcResponse.getStatus(),
+        retry);
+    while (rpcResponse.getStatus() == RssProtos.StatusCode.NO_BUFFER
+        || rpcResponse.getStatus() == RssProtos.StatusCode.NO_BUFFER_FOR_HUGE_PARTITION) {
       if (retry >= retryMax) {
         LOG.warn(
             "ShuffleServer "
@@ -241,7 +242,9 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
                 + ":"
                 + port
                 + " is full and can't send shuffle"
-                + " data successfully after retry "
+                + " data successfully due to "
+                + rpcResponse.getStatus()
+                + " after retry "
                 + retryMax
                 + " times, cost: {}(ms)",
             System.currentTimeMillis() - start);

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -286,6 +286,7 @@ enum StatusCode {
   TIMEOUT = 7;
   ACCESS_DENIED = 8;
   INVALID_REQUEST = 9;
+  NO_BUFFER_FOR_HUGE_PARTITION = 10;
   // add more status
 }
 

--- a/rust/experimental/server/src/grpc.rs
+++ b/rust/experimental/server/src/grpc.rs
@@ -65,6 +65,7 @@ enum StatusCode {
     NO_PARTITION = 5,
     INTERNAL_ERROR = 6,
     TIMEOUT = 7,
+    NO_BUFFER_FOR_HUGE_PARTITION = 8,
 }
 
 impl Into<i32> for StatusCode {

--- a/rust/experimental/server/src/proto/uniffle.proto
+++ b/rust/experimental/server/src/proto/uniffle.proto
@@ -280,6 +280,7 @@ enum StatusCode {
   TIMEOUT = 7;
   ACCESS_DENIED = 8;
   INVALID_REQUEST = 9;
+  NO_BUFFER_FOR_HUGE_PARTITION = 10;
   // add more status
 }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -69,10 +69,6 @@ public class ShuffleServerMetrics {
 
   private static final String IS_HEALTHY = "is_healthy";
   private static final String ALLOCATED_BUFFER_SIZE = "allocated_buffer_size";
-  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_SIZE_TOTAL =
-      "expired_pre_allocated_buffer_size_total";
-  private static final String EXPIRED_PRE_ALLOCATED_BUFFER_ID_TOTAL =
-      "expired_pre_allocated_buffer_id_total";
   private static final String IN_FLUSH_BUFFER_SIZE = "in_flush_buffer_size";
   private static final String USED_BUFFER_SIZE = "used_buffer_size";
   private static final String READ_USED_BUFFER_SIZE = "read_used_buffer_size";
@@ -84,7 +80,7 @@ public class ShuffleServerMetrics {
   private static final String LOCAL_DISK_PATH_LABEL = "local_disk_path";
   public static final String LOCAL_DISK_PATH_LABEL_ALL = "ALL";
   private static final String TOTAL_REQUIRE_BUFFER_FAILED = "total_require_buffer_failed";
-  private static final String TOTAL_REQUIRE_BUFFER_FAILED_FOR_HUGE_PARTITION =
+  public static final String TOTAL_REQUIRE_BUFFER_FAILED_FOR_HUGE_PARTITION =
       "total_require_buffer_failed_for_huge_partition";
   private static final String TOTAL_REQUIRE_BUFFER_FAILED_FOR_REGULAR_PARTITION =
       "total_require_buffer_failed_for_regular_partition";
@@ -180,8 +176,6 @@ public class ShuffleServerMetrics {
   public static Counter counterRemoteStorageSuccessWrite;
   public static Counter counterTotalHadoopWriteDataSize;
   public static Counter counterTotalLocalFileWriteDataSize;
-  public static Counter counterExpiredPreAllocatedBufferSizeTotal;
-  public static Counter counterExpiredPreAllocatedBufferIdTotal;
 
   private static String tags;
   public static Counter counterLocalFileEventFlush;
@@ -287,11 +281,13 @@ public class ShuffleServerMetrics {
             TOTAL_HADOOP_WRITE_DATA, Constants.METRICS_TAG_LABEL_NAME, STORAGE_HOST_LABEL);
     counterTotalLocalFileWriteDataSize =
         metricsManager.addCounter(TOTAL_LOCALFILE_WRITE_DATA, LOCAL_DISK_PATH_LABEL);
+
     counterTotalRequireBufferFailed = metricsManager.addLabeledCounter(TOTAL_REQUIRE_BUFFER_FAILED);
     counterTotalRequireBufferFailedForRegularPartition =
         metricsManager.addLabeledCounter(TOTAL_REQUIRE_BUFFER_FAILED_FOR_REGULAR_PARTITION);
     counterTotalRequireBufferFailedForHugePartition =
         metricsManager.addLabeledCounter(TOTAL_REQUIRE_BUFFER_FAILED_FOR_HUGE_PARTITION);
+
     counterLocalStorageTotalWrite = metricsManager.addLabeledCounter(STORAGE_TOTAL_WRITE_LOCAL);
     counterLocalStorageRetryWrite = metricsManager.addLabeledCounter(STORAGE_RETRY_WRITE_LOCAL);
     counterLocalStorageFailedWrite = metricsManager.addLabeledCounter(STORAGE_FAILED_WRITE_LOCAL);
@@ -333,10 +329,6 @@ public class ShuffleServerMetrics {
 
     gaugeIsHealthy = metricsManager.addLabeledGauge(IS_HEALTHY);
     gaugeAllocatedBufferSize = metricsManager.addLabeledGauge(ALLOCATED_BUFFER_SIZE);
-    counterExpiredPreAllocatedBufferSizeTotal =
-        metricsManager.addCounter(EXPIRED_PRE_ALLOCATED_BUFFER_SIZE_TOTAL);
-    counterExpiredPreAllocatedBufferIdTotal =
-        metricsManager.addCounter(EXPIRED_PRE_ALLOCATED_BUFFER_ID_TOTAL);
     gaugeInFlushBufferSize = metricsManager.addLabeledGauge(IN_FLUSH_BUFFER_SIZE);
     gaugeUsedBufferSize = metricsManager.addLabeledGauge(USED_BUFFER_SIZE);
     gaugeReadBufferUsedSize = metricsManager.addLabeledGauge(READ_USED_BUFFER_SIZE);


### PR DESCRIPTION

### What changes were proposed in this pull request?

Explicitly throw `BUFFER_LIMIT_OF_HUGE_PARTITION` instead of `NO_BUFFER`

### Why are the changes needed?

Fix:  https://github.com/apache/incubator-uniffle/issues/1119

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

unit test
