### PR TITLE
[#1428] fix(server): fallback invalid when local storage can't write

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -352,9 +352,7 @@ public class ShuffleServerConf extends RssBaseConf {
   public static final ConfigOption<Long> FALLBACK_MAX_FAIL_TIMES =
       ConfigOptions.key("rss.server.hybrid.storage.fallback.max.fail.times")
           .longType()
-          .checkValue(
-              ConfigUtils.NON_NEGATIVE_LONG_VALIDATOR, " fallback times must be non-negative")
-          .defaultValue(0L)
+          .defaultValue(-1L)
           .withDescription("For hybrid storage, fail times exceed the number, will switch storage")
           .withDeprecatedKeys("rss.server.multistorage.fallback.max.fail.times");
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -352,7 +352,7 @@ public class ShuffleServerConf extends RssBaseConf {
   public static final ConfigOption<Long> FALLBACK_MAX_FAIL_TIMES =
       ConfigOptions.key("rss.server.hybrid.storage.fallback.max.fail.times")
           .longType()
-          .defaultValue(-1L)
+          .defaultValue(0L)
           .withDescription("For hybrid storage, fail times exceed the number, will switch storage")
           .withDeprecatedKeys("rss.server.multistorage.fallback.max.fail.times");
 

--- a/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManagerFallbackStrategy.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManagerFallbackStrategy.java
@@ -37,7 +37,7 @@ public class HadoopStorageManagerFallbackStrategy extends AbstractStorageManager
   @Override
   public StorageManager tryFallback(
       StorageManager current, ShuffleDataFlushEvent event, StorageManager... candidates) {
-    if (event.getRetryTimes() > fallBackTimes) {
+    if (event.getRetryTimes() > fallBackTimes || !current.canWrite(event)) {
       return findNextStorageManager(current, excludeTypes, event, candidates);
     }
     return current;

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManagerFallbackStrategy.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManagerFallbackStrategy.java
@@ -37,7 +37,7 @@ public class LocalStorageManagerFallbackStrategy extends AbstractStorageManagerF
   @Override
   public StorageManager tryFallback(
       StorageManager current, ShuffleDataFlushEvent event, StorageManager... candidates) {
-    if (event.getRetryTimes() > fallBackTimes) {
+    if (event.getRetryTimes() > fallBackTimes || !current.canWrite(event)) {
       return findNextStorageManager(current, excludeTypes, event, candidates);
     }
     return current;

--- a/server/src/main/java/org/apache/uniffle/server/storage/RotateStorageManagerFallbackStrategy.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/RotateStorageManagerFallbackStrategy.java
@@ -32,7 +32,8 @@ public class RotateStorageManagerFallbackStrategy extends AbstractStorageManager
   public StorageManager tryFallback(
       StorageManager current, ShuffleDataFlushEvent event, StorageManager... candidates) {
     if (fallBackTimes > 0
-        && (event.getRetryTimes() < fallBackTimes || event.getRetryTimes() % fallBackTimes > 0)) {
+        && (event.getRetryTimes() < fallBackTimes || event.getRetryTimes() % fallBackTimes > 0)
+        && current.canWrite(event)) {
       return current;
     }
     return findNextStorageManager(current, null, event, candidates);

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -697,16 +697,15 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     List<ShufflePartitionedBlock> blocks =
         Lists.newArrayList(new ShufflePartitionedBlock(100000, 1000, 1, 1, 1L, (byte[]) null));
     ShuffleDataFlushEvent bigEvent =
-        new ShuffleDataFlushEvent(1, "1", 1, 1, 1, 100, blocks, null, null);
+        new ShuffleDataFlushEvent(1, "1", 2, 1, 1, 100, blocks, null, null);
     bigEvent.setUnderStorage(
         ((HybridStorageManager) storageManager).getWarmStorageManager().selectStorage(event));
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
-    event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
+    event = createShuffleDataFlushEvent(appId, 3, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
     Thread.sleep(1000);
     assertTrue(event.getUnderStorage() instanceof HadoopStorage);
-    assertEquals(1, event.getRetryTimes());
   }
 
   @Test
@@ -756,11 +755,11 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ((HybridStorageManager) storageManager).getWarmStorageManager().selectStorage(event));
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
-    event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100);
+    event = createShuffleDataFlushEvent(appId, 2, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
-    waitForFlush(flushManager, appId, 1, 15);
-    assertEquals(1, event.getRetryTimes());
-    assertEquals(2, ShuffleServerMetrics.counterLocalFileEventFlush.get());
+    waitForFlush(flushManager, appId, 2, 5);
+    assertEquals(0, event.getRetryTimes());
+    assertEquals(1, ShuffleServerMetrics.counterLocalFileEventFlush.get());
     assertEquals(2, ShuffleServerMetrics.counterHadoopEventFlush.get());
   }
 

--- a/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
@@ -38,9 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HybridStorageManagerTest {
 
   /**
-   * this tests the fallback strategy when encountering the local storage is invalid.
-   * 1. When specifying the fallback max fail time = 0, the event will be discarded
-   * 2. When specifying the fallback max fail time < 0, the event will be taken by Hadoop Storage.
+   * this tests the fallback strategy when encountering the local storage is invalid. 1. When
+   * specifying the fallback max fail time = 0, the event will be discarded 2. When specifying the
+   * fallback max fail time < 0, the event will be taken by Hadoop Storage.
    */
   @Test
   public void fallbackTestWhenLocalStorageCorrupted() {
@@ -49,11 +49,13 @@ public class HybridStorageManagerTest {
     conf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList("test"));
     conf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
     conf.setString(
-            ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
-    conf.setString(ShuffleServerConf.HYBRID_STORAGE_MANAGER_SELECTOR_CLASS,
-            "org.apache.uniffle.server.storage.hybrid.HugePartitionSensitiveStorageManagerSelector");
-    conf.setString(ShuffleServerConf.HYBRID_STORAGE_FALLBACK_STRATEGY_CLASS,
-            "org.apache.uniffle.server.storage.LocalStorageManagerFallbackStrategy");
+        ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
+    conf.setString(
+        ShuffleServerConf.HYBRID_STORAGE_MANAGER_SELECTOR_CLASS,
+        "org.apache.uniffle.server.storage.hybrid.HugePartitionSensitiveStorageManagerSelector");
+    conf.setString(
+        ShuffleServerConf.HYBRID_STORAGE_FALLBACK_STRATEGY_CLASS,
+        "org.apache.uniffle.server.storage.LocalStorageManagerFallbackStrategy");
 
     // case1: fallback to hadoop storage when fallback_max_fail_time = -1
     conf.setLong(ShuffleServerConf.FALLBACK_MAX_FAIL_TIMES, -1);
@@ -66,9 +68,9 @@ public class HybridStorageManagerTest {
     String appId = "selectStorageManagerWithSelectorAndFallbackStrategy_appId";
     manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-            Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
-            new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
+        new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
 
     // case2: fallback invalid when fallback_max_fail_time = 0
@@ -78,8 +80,7 @@ public class HybridStorageManagerTest {
     localStorageManager = (LocalStorageManager) manager.getWarmStorageManager();
     localStorageManager.getStorages().get(0).markCorrupted();
 
-    event =
-            new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
+    event = new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     assertNull(manager.selectStorage(event));
     // and the event failed at the first time, it will fallback to hadoop storage

--- a/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
@@ -32,9 +32,61 @@ import org.apache.uniffle.storage.common.LocalStorage;
 import org.apache.uniffle.storage.common.Storage;
 import org.apache.uniffle.storage.util.StorageType;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HybridStorageManagerTest {
+
+  /**
+   * this tests the fallback strategy when encountering the local storage is invalid.
+   * 1. When specifying the fallback max fail time = 0, the event will be discarded
+   * 2. When specifying the fallback max fail time < 0, the event will be taken by Hadoop Storage.
+   */
+  @Test
+  public void fallbackTestWhenLocalStorageCorrupted() {
+    ShuffleServerConf conf = new ShuffleServerConf();
+    conf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 2000L);
+    conf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList("test"));
+    conf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
+    conf.setString(
+            ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
+    conf.setString(ShuffleServerConf.HYBRID_STORAGE_MANAGER_SELECTOR_CLASS,
+            "org.apache.uniffle.server.storage.hybrid.HugePartitionSensitiveStorageManagerSelector");
+    conf.setString(ShuffleServerConf.HYBRID_STORAGE_FALLBACK_STRATEGY_CLASS,
+            "org.apache.uniffle.server.storage.LocalStorageManagerFallbackStrategy");
+
+    // case1: fallback to hadoop storage when fallback_max_fail_time = -1
+    conf.setLong(ShuffleServerConf.FALLBACK_MAX_FAIL_TIMES, -1);
+    HybridStorageManager manager = new HybridStorageManager(conf);
+
+    LocalStorageManager localStorageManager = (LocalStorageManager) manager.getWarmStorageManager();
+    localStorageManager.getStorages().get(0).markCorrupted();
+
+    String remoteStorage = "test";
+    String appId = "selectStorageManagerWithSelectorAndFallbackStrategy_appId";
+    manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
+    List<ShufflePartitionedBlock> blocks =
+            Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+    ShuffleDataFlushEvent event =
+            new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
+    assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
+
+    // case2: fallback invalid when fallback_max_fail_time = 0
+    conf.setLong(ShuffleServerConf.FALLBACK_MAX_FAIL_TIMES, 0);
+    manager = new HybridStorageManager(conf);
+
+    localStorageManager = (LocalStorageManager) manager.getWarmStorageManager();
+    localStorageManager.getStorages().get(0).markCorrupted();
+
+    event =
+            new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
+    manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
+    assertNull(manager.selectStorage(event));
+    // and the event failed at the first time, it will fallback to hadoop storage
+    event.increaseRetryTimes();
+    manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
+    assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
+  }
 
   @Test
   public void selectStorageManagerTest() {

--- a/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
@@ -32,7 +32,6 @@ import org.apache.uniffle.storage.common.LocalStorage;
 import org.apache.uniffle.storage.common.Storage;
 import org.apache.uniffle.storage.util.StorageType;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HybridStorageManagerTest {

--- a/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
@@ -73,7 +73,7 @@ public class HybridStorageManagerTest {
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
 
-    // case2: fallback invalid when fallback_max_fail_time = 0
+    // case2: fallback is still valid when fallback_max_fail_time = 0
     conf.setLong(ShuffleServerConf.FALLBACK_MAX_FAIL_TIMES, 0);
     manager = new HybridStorageManager(conf);
 
@@ -81,10 +81,6 @@ public class HybridStorageManagerTest {
     localStorageManager.getStorages().get(0).markCorrupted();
 
     event = new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
-    manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
-    assertNull(manager.selectStorage(event));
-    // and the event failed at the first time, it will fallback to hadoop storage
-    event.increaseRetryTimes();
     manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

allow specifying negative fallback threshold to avoid event being discarded

### Why are the changes needed?

Fix: #1428 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests
