### PR TITLE
[#1428] fix(server): add missing dropped event metrics and disptch all events into unified consumer

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
@@ -77,7 +77,7 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
     } finally {
       if (storage instanceof LocalStorage) {
         ShuffleServerMetrics.counterLocalFileEventFlush.inc();
-      } else if (storage instanceof HadoopStorage){
+      } else if (storage instanceof HadoopStorage) {
         ShuffleServerMetrics.counterHadoopEventFlush.inc();
       }
     }
@@ -123,7 +123,10 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
         localFileThreadPoolExecutor.execute(() -> handleEventAndUpdateMetrics(event, storage));
       } else {
         fallbackThreadPoolExecutor.execute(() -> handleEventAndUpdateMetrics(event, storage));
-        LOG.warn("Found unexpected storage type: {}, this should not happen for event: {}.", storage, event);
+        LOG.warn(
+            "Found unexpected storage type: {}, this should not happen for event: {}.",
+            storage,
+            event);
       }
     } catch (Exception e) {
       LOG.error("Exception happened when process event.", e);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -149,6 +149,7 @@ public class ShuffleFlushManager {
 
       Storage storage = event.getUnderStorage();
       if (storage == null) {
+        ShuffleServerMetrics.counterTotalDroppedEventNum.inc();
         LOG.error("Storage selected is null and this should not happen. event: {}", event);
         return true;
       }
@@ -172,6 +173,7 @@ public class ShuffleFlushManager {
             LOG.error(
                 "Drop this event directly due to already having entered pending queue. event: {}",
                 event);
+            ShuffleServerMetrics.counterTotalDroppedEventNum.inc();
             return true;
           }
           event.increaseRetryTimes();


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. add missing dropped event metrics
2. disptch all events into unified consumer for `DefaultFlushEventHandler`. Otherwise, once the storage is null, the eventQueueSize will not desc.

### Why are the changes needed?

Fix: #1428

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs
