### PR TITLE
[#1189][FOLLOWUP] fix(server): Start NettyDirectMemoryTracker.

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
+++ b/server/src/main/java/org/apache/uniffle/server/NettyDirectMemoryTracker.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -142,6 +142,7 @@ public class ShuffleServer {
     initMetricsReporter();
 
     registerHeartBeat.startHeartBeat();
+    directMemoryUsageReporter.start();
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix PR [#1363](https://github.com/apache/incubator-uniffle/pull/1363).
NettyDirectMemoryTracker will not be started currently.

### Why are the changes needed?

It's a followup PR for [#1363](https://github.com/apache/incubator-uniffle/pull/1363).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
