### PR TITLE
[#1433] fix(server): Race conditions with ShuffleServer state

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/HealthCheck.java
+++ b/server/src/main/java/org/apache/uniffle/server/HealthCheck.java
@@ -88,15 +88,13 @@ public class HealthCheck {
   public void check() {
     for (Checker checker : checkers) {
       if (!checker.checkIsHealthy()) {
-        serverStatus.set(ServerStatus.UNHEALTHY);
+        serverStatus.compareAndSet(ServerStatus.ACTIVE, ServerStatus.UNHEALTHY);
         ShuffleServerMetrics.gaugeIsHealthy.set(1);
         return;
       }
     }
     ShuffleServerMetrics.gaugeIsHealthy.set(0);
-    if (serverStatus.get() == ServerStatus.UNHEALTHY) {
-      serverStatus.set(ServerStatus.ACTIVE);
-    }
+    serverStatus.compareAndSet(ServerStatus.UNHEALTHY, ServerStatus.ACTIVE);
   }
 
   public ServerStatus getServerStatus() {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -333,7 +333,8 @@ public class ShuffleServer {
       LOG.info("Shuffle Server is decommissioning. Nothing needs to be done.");
       return;
     }
-    boolean wasActive = serverStatus.compareAndSet(ServerStatus.ACTIVE, ServerStatus.DECOMMISSIONING);
+    boolean wasActive =
+        serverStatus.compareAndSet(ServerStatus.ACTIVE, ServerStatus.DECOMMISSIONING);
     if (!wasActive) {
       throw new InvalidRequestException(
           "Shuffle Server is processing other procedures, current status:" + serverStatus);
@@ -353,7 +354,8 @@ public class ShuffleServer {
     while (isDecommissioning()) {
       remainApplicationNum = shuffleTaskManager.getAppIds().size();
       if (remainApplicationNum == 0) {
-        boolean wasDecommissioning = serverStatus.compareAndSet(ServerStatus.DECOMMISSIONING, ServerStatus.DECOMMISSIONED);
+        boolean wasDecommissioning =
+            serverStatus.compareAndSet(ServerStatus.DECOMMISSIONING, ServerStatus.DECOMMISSIONED);
         if (!wasDecommissioning) {
           break;
         }
@@ -387,8 +389,10 @@ public class ShuffleServer {
   }
 
   public synchronized void cancelDecommission() {
-    boolean wasDecomissioning = serverStatus.compareAndSet(ServerStatus.DECOMMISSIONING, ServerStatus.ACTIVE);
-    boolean wasDecomissioned = serverStatus.compareAndSet(ServerStatus.DECOMMISSIONED, ServerStatus.ACTIVE);
+    boolean wasDecomissioning =
+        serverStatus.compareAndSet(ServerStatus.DECOMMISSIONING, ServerStatus.ACTIVE);
+    boolean wasDecomissioned =
+        serverStatus.compareAndSet(ServerStatus.DECOMMISSIONED, ServerStatus.ACTIVE);
     if (!wasDecomissioning && !wasDecomissioned) {
       LOG.info("Shuffle server is not decommissioning. Nothing needs to be done.");
       return;

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -356,11 +356,12 @@ public class ShuffleServer {
       if (remainApplicationNum == 0) {
         boolean wasDecommissioning =
             serverStatus.compareAndSet(ServerStatus.DECOMMISSIONING, ServerStatus.DECOMMISSIONED);
+        LOG.info("All applications finished. Current status is " + serverStatus);
         if (!wasDecommissioning) {
+          LOG.info("Ready to decommission but decommissioning state left unexpectedly.");
           break;
         }
 
-        LOG.info("All applications finished. Current status is " + serverStatus);
         if (shutdownAfterDecommission) {
           LOG.info("Exiting...");
           try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make state transitions in ShuffleServer robust.

### Why are the changes needed?

Avoids the following race conditions / undesired state transitions:
- ShuffleServer is decommissioning, then getting unhealthy, which stops decommissioning
- ShuffleServer is in any non-active state, getting unhealthy, turns active when healthy

Fix: #1433

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Untested.