### PR TITLE
[MINOR] refactor: avoid unnecessary bitmap clone and AND

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -364,10 +364,10 @@ public class RssUtils {
 
   public static void checkProcessedBlockIds(
       Roaring64NavigableMap blockIdBitmap, Roaring64NavigableMap processedBlockIds) {
-    Roaring64NavigableMap cloneBitmap;
-    cloneBitmap = RssUtils.cloneBitMap(blockIdBitmap);
-    cloneBitmap.and(processedBlockIds);
-    if (!blockIdBitmap.equals(cloneBitmap)) {
+    if (!blockIdBitmap.equals(processedBlockIds)) {
+      Roaring64NavigableMap cloneBitmap;
+      cloneBitmap = RssUtils.cloneBitMap(blockIdBitmap);
+      cloneBitmap.and(processedBlockIds);
       throw new RssException(
           "Blocks read inconsistent: expected "
               + blockIdBitmap.getLongCardinality()

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -364,16 +364,22 @@ public class RssUtils {
 
   public static void checkProcessedBlockIds(
       Roaring64NavigableMap blockIdBitmap, Roaring64NavigableMap processedBlockIds) {
+    // processedBlockIds can be a superset of blockIdBitmap,
+    // here we check that processedBlockIds has all bits of blockIdBitmap set
+    // first a quick check:
+    //   we only need to do the bitwise AND when blockIdBitmap is not equal to processedBlockIds
     if (!blockIdBitmap.equals(processedBlockIds)) {
       Roaring64NavigableMap cloneBitmap;
       cloneBitmap = RssUtils.cloneBitMap(blockIdBitmap);
       cloneBitmap.and(processedBlockIds);
-      throw new RssException(
-          "Blocks read inconsistent: expected "
-              + blockIdBitmap.getLongCardinality()
-              + " blocks, actual "
-              + cloneBitmap.getLongCardinality()
-              + " blocks");
+      if (!blockIdBitmap.equals(cloneBitmap)) {
+        throw new RssException(
+                "Blocks read inconsistent: expected "
+                        + blockIdBitmap.getLongCardinality()
+                        + " blocks, actual "
+                        + cloneBitmap.getLongCardinality()
+                        + " blocks");
+      }
     }
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -374,11 +374,11 @@ public class RssUtils {
       cloneBitmap.and(processedBlockIds);
       if (!blockIdBitmap.equals(cloneBitmap)) {
         throw new RssException(
-                "Blocks read inconsistent: expected "
-                        + blockIdBitmap.getLongCardinality()
-                        + " blocks, actual "
-                        + cloneBitmap.getLongCardinality()
-                        + " blocks");
+            "Blocks read inconsistent: expected "
+                + blockIdBitmap.getLongCardinality()
+                + " blocks, actual "
+                + cloneBitmap.getLongCardinality()
+                + " blocks");
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add note that `processedBlockIds` can be a superset of `blockIdBitmap`. Add quick check if `processedBlockIds` is equal to `blockIdBitmap`. In that case, there is no need to clone and `AND` the bitmaps.

### Why are the changes needed?
The logic is equivalent but more performant when `processedBlockIds` is not a superset of `blockIdBitmap` (when no other blocks than the `blockIdBitmap` are retrieved).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests in `ShuffleReadClientImplTest` cover this.