### PR TITLE
[#1453] improvement: Force to use the UNIX line ending when using spotless-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -940,6 +940,7 @@
                 <file>${execution.root}/.baseline/copyright/apache-license-header.txt</file>
               </licenseHeader>
             </java>
+            <lineEndings>UNIX</lineEndings>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Force to use the UNIX line ending when using spotless-maven-plugin.

### Why are the changes needed?

For [#1453](https://github.com/apache/incubator-uniffle/issues/1453)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By running `./mvnw spotless:apply -Pspark3 -Pspark2 -Ptez -Pmr -Phadoop2.8` on Windows.