### PR TITLE
[#1462] fix(server): Memory may leak when flushQueue is full

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
@@ -71,6 +71,7 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
       LOG.error("Flush queue is full, discard event: " + event);
       // We need to release the memory when discarding the event
       event.doCleanup();
+      ShuffleServerMetrics.counterTotalDroppedEventNum.inc();
     } else {
       ShuffleServerMetrics.gaugeEventQueueSize.inc();
     }

--- a/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
@@ -69,6 +69,8 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
   public void handle(ShuffleDataFlushEvent event) {
     if (!flushQueue.offer(event)) {
       LOG.error("Flush queue is full, discard event: " + event);
+      // We need to release the memory when discarding the event
+      event.doCleanup();
     } else {
       ShuffleServerMetrics.gaugeEventQueueSize.inc();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release the memory when a flush event is dropped.

### Why are the changes needed?

For [#1462](https://github.com/apache/incubator-uniffle/issues/1462)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
