### PR TITLE
[#1464] improvement(spark): Improve the error log message for checkBlockSendResult

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +34,7 @@ import scala.collection.Iterator;
 import scala.collection.Seq;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.ShuffleDependency;
@@ -656,6 +658,14 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       taskToFailedBlockIds.put(taskId, Sets.newHashSet());
     }
     taskToFailedBlockIds.get(taskId).addAll(blockIds);
+  }
+
+  @VisibleForTesting
+  public void addTaskToFailedBlockIdsAndServer(
+      String taskId, Long blockId, ShuffleServerInfo shuffleServerInfo) {
+    taskToFailedBlockIdsAndServer.putIfAbsent(taskId, Maps.newHashMap());
+    taskToFailedBlockIdsAndServer.get(taskId).putIfAbsent(blockId, new LinkedBlockingDeque<>());
+    taskToFailedBlockIdsAndServer.get(taskId).get(blockId).add(shuffleServerInfo);
   }
 
   @VisibleForTesting

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -146,6 +146,8 @@ public class RssShuffleWriterTest {
     // case 3: partial blocks are sent failed, Runtime exception will be thrown
     manager.addSuccessBlockIds(taskId, Sets.newHashSet(1L, 2L));
     manager.addFailedBlockIds(taskId, Sets.newHashSet(3L));
+    ShuffleServerInfo shuffleServerInfo = new ShuffleServerInfo("127.0.0.1", 20001);
+    manager.addTaskToFailedBlockIdsAndServer(taskId, 3L, shuffleServerInfo);
     Throwable e3 =
         assertThrows(
             RuntimeException.class,

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -91,9 +91,7 @@ public class ShuffleServerInfo implements Serializable {
   @Override
   public String toString() {
     if (nettyPort > 0) {
-      return "ShuffleServerInfo{id["
-          + id
-          + "], host["
+      return "ShuffleServerInfo{host["
           + host
           + "],"
           + " grpc port["
@@ -102,14 +100,7 @@ public class ShuffleServerInfo implements Serializable {
           + nettyPort
           + "]}";
     } else {
-      return "ShuffleServerInfo{id["
-          + id
-          + "], host["
-          + host
-          + "],"
-          + " grpc port["
-          + grpcPort
-          + "]}";
+      return "ShuffleServerInfo{host[" + host + "]," + " grpc port[" + grpcPort + "]}";
     }
   }
 

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleServerInfoTest.java
@@ -47,19 +47,11 @@ public class ShuffleServerInfoTest {
   public void testToString() {
     ShuffleServerInfo info = new ShuffleServerInfo("1", "localhost", 1234);
     assertEquals(
-        "ShuffleServerInfo{id["
-            + info.getId()
-            + "], host["
-            + info.getHost()
-            + "], grpc port["
-            + info.getGrpcPort()
-            + "]}",
+        "ShuffleServerInfo{host[" + info.getHost() + "], grpc port[" + info.getGrpcPort() + "]}",
         info.toString());
     ShuffleServerInfo newInfo = new ShuffleServerInfo("1", "localhost", 1234, 5678);
     assertEquals(
-        "ShuffleServerInfo{id["
-            + info.getId()
-            + "], host["
+        "ShuffleServerInfo{host["
             + newInfo.getHost()
             + "], grpc port["
             + newInfo.getGrpcPort()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the error log message for checkBlockSendResult.
As described in [#1464](https://github.com/apache/incubator-uniffle/issues/1464), it will print out the shuffle server's IP and ports.

### Why are the changes needed?

For [#1464](https://github.com/apache/incubator-uniffle/issues/1464)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.
