### PR TITLE
[#1467] feat(server): introduce total hdfs write data size metric for huge partition

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -76,6 +76,8 @@ public class ShuffleServerMetrics {
   private static final String TOTAL_FAILED_WRITTEN_EVENT_NUM = "total_failed_written_event_num";
   private static final String TOTAL_DROPPED_EVENT_NUM = "total_dropped_event_num";
   private static final String TOTAL_HADOOP_WRITE_DATA = "total_hadoop_write_data";
+  private static final String TOTAL_HADOOP_WRITE_DATA_FOR_HUGE_PARTITION =
+      "total_hadoop_write_data_for_huge_partition";
   private static final String TOTAL_LOCALFILE_WRITE_DATA = "total_localfile_write_data";
   private static final String LOCAL_DISK_PATH_LABEL = "local_disk_path";
   public static final String LOCAL_DISK_PATH_LABEL_ALL = "ALL";
@@ -188,6 +190,7 @@ public class ShuffleServerMetrics {
   public static Counter counterRemoteStorageFailedWrite;
   public static Counter counterRemoteStorageSuccessWrite;
   public static Counter counterTotalHadoopWriteDataSize;
+  public static Counter counterTotalHadoopWriteDataSizeForHugePartition;
   public static Counter counterTotalLocalFileWriteDataSize;
 
   private static String tags;
@@ -259,12 +262,25 @@ public class ShuffleServerMetrics {
     }
   }
 
-  public static void incHadoopStorageWriteDataSize(String storageHost, long size) {
+  public static void incHadoopStorageWriteDataSize(
+      String storageHost, long size, boolean isOwnedByHugePartition) {
     if (StringUtils.isEmpty(storageHost)) {
       return;
     }
     counterTotalHadoopWriteDataSize.labels(tags, storageHost).inc(size);
     counterTotalHadoopWriteDataSize.labels(tags, STORAGE_HOST_LABEL_ALL).inc(size);
+    if (isOwnedByHugePartition) {
+      counterTotalHadoopWriteDataSizeForHugePartition.labels(tags, storageHost).inc(size);
+      counterTotalHadoopWriteDataSizeForHugePartition
+          .labels(tags, STORAGE_HOST_LABEL_ALL)
+          .inc(size);
+    }
+  }
+
+  // only for test cases
+  @VisibleForTesting
+  public static void incHadoopStorageWriteDataSize(String storageHost, long size) {
+    incHadoopStorageWriteDataSize(storageHost, size, false);
   }
 
   private static void setUpMetrics() {
@@ -292,6 +308,11 @@ public class ShuffleServerMetrics {
     counterTotalHadoopWriteDataSize =
         metricsManager.addCounter(
             TOTAL_HADOOP_WRITE_DATA, Constants.METRICS_TAG_LABEL_NAME, STORAGE_HOST_LABEL);
+    counterTotalHadoopWriteDataSizeForHugePartition =
+        metricsManager.addCounter(
+            TOTAL_HADOOP_WRITE_DATA_FOR_HUGE_PARTITION,
+            Constants.METRICS_TAG_LABEL_NAME,
+            STORAGE_HOST_LABEL);
     counterTotalLocalFileWriteDataSize =
         metricsManager.addCounter(TOTAL_LOCALFILE_WRITE_DATA, LOCAL_DISK_PATH_LABEL);
 

--- a/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManager.java
@@ -73,7 +73,8 @@ public class HadoopStorageManager extends SingleStorageManager {
       LOG.warn("The storage owned by event: {} is null, this should not happen", event);
       return;
     }
-    ShuffleServerMetrics.incHadoopStorageWriteDataSize(storage.getStorageHost(), event.getSize());
+    ShuffleServerMetrics.incHadoopStorageWriteDataSize(
+        storage.getStorageHost(), event.getSize(), event.isOwnedByHugePartition());
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

introduce total hdfs write data size for huge partition:
1. `total_hadoop_write_data_for_huge_partition` is introduced

### Why are the changes needed?

For #1467, it is to show the hdfs spill data size for huge partition

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
