### PR TITLE
[#1464][FOLLOWUP] improvement(spark): print abnormal shuffle servers that blocks fail to send

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.writer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -377,7 +378,9 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                 + "] failed because "
                 + failedBlockIds.size()
                 + " blocks can't be sent to shuffle server: "
-                + failedBlockIdsWithShuffleServer.values().stream().collect(Collectors.toSet());
+                + failedBlockIdsWithShuffleServer.values().stream()
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
         LOG.error(errorMsg);
         throw new RssSendFailedException(errorMsg);
       }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.writer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -400,7 +401,9 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
               + " failed because "
               + failedBlockIds.size()
               + " blocks can't be sent to shuffle server: "
-              + failedBlockIdsWithShuffleServer.values().stream().collect(Collectors.toSet());
+              + failedBlockIdsWithShuffleServer.values().stream()
+                  .flatMap(Collection::stream)
+                  .collect(Collectors.toSet());
       LOG.error(errorMsg);
       throw new RssSendFailedException(errorMsg);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The output of failed shuffle servers' result has not been successfully deduplicated.

### Why are the changes needed?

It's a followup PR for [#1465](https://github.com/apache/incubator-uniffle/pull/1465).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
