### PR TITLE
[#1407] feat(rust): support multiple spill policies and simplify hdfs config

### DIFF
--- a/rust/experimental/server/Cargo.lock
+++ b/rust/experimental/server/Cargo.lock
@@ -467,8 +467,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tonic",
  "tracing-core",
 ]
@@ -485,7 +485,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.11.9",
  "serde",
  "serde_json",
  "thread_local",
@@ -1227,9 +1227,9 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hdfs-native"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824c00b5e1b0ba3aeb5678debcb78bf3a26d3d6473e7fd0f53d1310c988c1f02"
+checksum = "7068d52978481fb74f1ac1522c0823d180a6e112c459169cf72f3cd08b207b0d"
 dependencies = [
  "base64 0.21.4",
  "bytes 1.5.0",
@@ -1240,8 +1240,8 @@ dependencies = [
  "libgssapi",
  "log",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "roxmltree",
  "socket2 0.5.4",
  "thiserror",
@@ -2337,7 +2337,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.5.0",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes 1.5.0",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -2354,8 +2364,8 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -2376,12 +2386,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -3419,7 +3451,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "once_cell",
- "prost-types",
+ "prost-types 0.11.9",
  "ratatui",
  "regex",
  "serde",
@@ -3587,7 +3619,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.3",
- "prost",
+ "prost 0.11.9",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3809,7 +3841,7 @@ dependencies = [
  "poem",
  "pprof",
  "prometheus",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "serde",
  "signal-hook",

--- a/rust/experimental/server/Cargo.toml
+++ b/rust/experimental/server/Cargo.toml
@@ -100,7 +100,7 @@ spin = "0.9.8"
 opendal = { version = "0.44.0", features = ["services-fs"]}
 
 [dependencies.hdfs-native]
-version = "0.5.0"
+version = "0.7.0"
 optional = true
 features = ["kerberos"]
 

--- a/rust/experimental/server/README.md
+++ b/rust/experimental/server/README.md
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-Another implementation of Apache Uniffle shuffle server
+Another implementation of Apache Uniffle shuffle server (Single binary, no extra dependencies)
 
 ## Benchmark report
 
@@ -90,7 +90,7 @@ In the future, rust-based server will use io_uring mechanism to improve writing 
 
 ## Build
 
-`cargo build --release`
+`cargo build --release --features hdfs,jemalloc`
 
 Uniffle-x currently treats all compiler warnings as error, with some dead-code warning excluded. When you are developing
 and really want to ignore the warnings for now, you can use `ccargo --config 'build.rustflags=["-W", "warnings"]' build`
@@ -115,7 +115,6 @@ data_paths = ["/data1/uniffle", "/data2/uniffle"]
 healthy_check_min_disks = 0
 
 [hdfs_store]
-data_path = "hdfs://rbf-x/user/bi"
 max_concurrency = 10
 
 [hybrid_store]
@@ -135,6 +134,7 @@ push_gateway_endpoint = "http://xxxxxxxxxxxxxx/pushgateway"
 ### HDFS Setup 
 
 Benefit from the hdfs-native crate, there is no need to setup the JAVA_HOME and relative dependencies.
+If HDFS store is valid, the spark client must specify the conf of `spark.rss.client.remote.storage.useLocalConfAsDefault=true`
 
 ```shell
 cargo build --features hdfs --release

--- a/rust/experimental/server/src/app.rs
+++ b/rust/experimental/server/src/app.rs
@@ -246,7 +246,10 @@ impl App {
             return Err(WorkerError::MEMORY_USAGE_LIMITED_BY_HUGE_PARTITION);
         }
 
-        self.store.require_buffer(ctx).await
+        self.store.require_buffer(ctx).await.map_err(|err| {
+            TOTAL_REQUIRE_BUFFER_FAILED.inc();
+            err
+        })
     }
 
     pub async fn release_buffer(&self, ticket_id: i64) -> Result<i64, WorkerError> {

--- a/rust/experimental/server/src/config.rs
+++ b/rust/experimental/server/src/config.rs
@@ -45,7 +45,6 @@ impl MemoryStoreConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct HdfsStoreConfig {
-    pub data_path: String,
     pub max_concurrency: Option<i32>,
 }
 

--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -34,6 +34,9 @@ pub enum WorkerError {
     #[error("Partial data has been lost, corrupted path: {0}")]
     PARTIAL_DATA_LOST(String),
 
+    #[error("Local disk:[{0}] is not healthy")]
+    LOCAL_DISK_UNHEALTHY(String),
+
     #[error("Local disk:[{0}] owned by current partition has been corrupted")]
     LOCAL_DISK_OWNED_BY_PARTITION_CORRUPTED(String),
 

--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -54,6 +54,9 @@ pub enum WorkerError {
 
     #[error("Ticket id: {0} not exist")]
     TICKET_ID_NOT_EXIST(i64),
+
+    #[error("Hdfs native client not found for app: {0}")]
+    HDFS_NATIVE_CLIENT_NOT_FOUND(String),
 }
 
 impl From<AcquireError> for WorkerError {

--- a/rust/experimental/server/src/grpc.rs
+++ b/rust/experimental/server/src/grpc.rs
@@ -184,10 +184,7 @@ impl ShuffleServer for DefaultShuffleServer {
                 shuffle_id,
                 partition_id,
             };
-            let ctx = WritingViewContext {
-                uid: uid.clone(),
-                data_blocks: blocks,
-            };
+            let ctx = WritingViewContext::from(uid.clone(), blocks);
 
             let inserted = app
                 .insert(ctx)

--- a/rust/experimental/server/src/main.rs
+++ b/rust/experimental/server/src/main.rs
@@ -17,7 +17,7 @@
 
 #![feature(impl_trait_in_assoc_type)]
 
-use crate::app::{AppManager, AppManagerRef};
+use crate::app::{AppManager, AppManagerRef, SHUFFLE_SERVER_ID};
 use crate::await_tree::AWAIT_TREE_REGISTRY;
 use crate::config::{Config, LogConfig, RotationConfig};
 use crate::grpc::await_tree_middleware::AwaitTreeMiddlewareLayer;
@@ -201,6 +201,8 @@ fn main() -> Result<()> {
 
     let rpc_port = config.grpc_port.unwrap_or(19999);
     let worker_uid = gen_worker_uid(rpc_port);
+    // todo: remove some unnecessary worker_id transfer.
+    SHUFFLE_SERVER_ID.get_or_init(|| worker_uid.clone());
 
     let metric_config = config.metrics.clone();
     init_metric_service(runtime_manager.clone(), &metric_config, worker_uid.clone());

--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -17,14 +17,15 @@
 
 use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
-    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
+    RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::HdfsStoreConfig;
 use crate::error::WorkerError;
+use std::collections::HashMap;
 
 use crate::metric::TOTAL_HDFS_USED;
 use crate::store::{Persistent, RequireBufferResponse, ResponseData, ResponseDataIndex, Store};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use async_trait::async_trait;
 use await_tree::InstrumentAwait;
@@ -40,6 +41,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
 
 use tracing::debug;
+use url::Url;
 
 struct PartitionCachedMeta {
     is_file_created: bool,
@@ -62,9 +64,10 @@ impl Default for PartitionCachedMeta {
 }
 
 pub struct HdfsStore {
-    root: String,
-    filesystem: Box<HdfsNativeClient>,
     concurrency_access_limiter: Semaphore,
+
+    // key: app_id, value: hdfs_native_client
+    app_remote_clients: DashMap<String, HdfsNativeClient>,
 
     partition_file_locks: DashMap<String, Arc<Mutex<()>>>,
     partition_cached_meta: DashMap<String, PartitionCachedMeta>,
@@ -76,26 +79,21 @@ impl Persistent for HdfsStore {}
 
 impl HdfsStore {
     pub fn from(conf: HdfsStoreConfig) -> Self {
-        let data_path = conf.data_path;
-
-        let filesystem = HdfsNativeClient::new();
-
         HdfsStore {
-            root: data_path,
-            filesystem: Box::new(filesystem),
             partition_file_locks: DashMap::new(),
             concurrency_access_limiter: Semaphore::new(conf.max_concurrency.unwrap_or(1) as usize),
             partition_cached_meta: Default::default(),
+            app_remote_clients: Default::default(),
         }
     }
 
     fn get_app_dir(&self, app_id: &str) -> String {
-        format!("{}/{}/", &self.root, app_id)
+        format!("{}/", app_id)
     }
 
     /// the dir created with app_id/shuffle_id
     fn get_shuffle_dir(&self, app_id: &str, shuffle_id: i32) -> String {
-        format!("{}/{}/{}/", &self.root, app_id, shuffle_id)
+        format!("{}/{}/", app_id, shuffle_id)
     }
 
     fn get_file_path_by_uid(&self, uid: &PartitionedUId) -> (String, String) {
@@ -103,14 +101,15 @@ impl HdfsStore {
         let shuffle_id = &uid.shuffle_id;
         let p_id = &uid.partition_id;
 
+        let worker_id = crate::app::SHUFFLE_SERVER_ID.get().unwrap();
         (
             format!(
-                "{}/{}/{}/{}-{}/partition-{}.data",
-                &self.root, app_id, shuffle_id, p_id, p_id, p_id
+                "{}/{}/{}-{}/{}.data",
+                app_id, shuffle_id, p_id, p_id, worker_id
             ),
             format!(
-                "{}/{}/{}/{}-{}/partition-{}.index",
-                &self.root, app_id, shuffle_id, p_id, p_id, p_id
+                "{}/{}/{}-{}/{}.index",
+                app_id, shuffle_id, p_id, p_id, worker_id
             ),
         )
     }
@@ -151,17 +150,22 @@ impl Store for HdfsStore {
             ))
             .await;
 
+        let filesystem = self.app_remote_clients.get(&uid.app_id).ok_or(
+            WorkerError::HDFS_NATIVE_CLIENT_NOT_FOUND(uid.app_id.to_string()),
+        )?;
+
         let mut next_offset = match self.partition_cached_meta.get(&data_file_path) {
             None => {
                 // setup the parent folder
                 let parent_dir = Path::new(data_file_path.as_str()).parent().unwrap();
                 let parent_path_str = format!("{}/", parent_dir.to_str().unwrap());
                 debug!("creating dir: {}", parent_path_str.as_str());
-                self.filesystem.create_dir(parent_path_str.as_str()).await?;
+
+                filesystem.create_dir(parent_path_str.as_str()).await?;
 
                 // setup the file
-                self.filesystem.touch(&data_file_path).await?;
-                self.filesystem.touch(&index_file_path).await?;
+                filesystem.touch(&data_file_path).await?;
+                filesystem.touch(&index_file_path).await?;
 
                 self.partition_cached_meta
                     .insert(data_file_path.to_string(), Default::default());
@@ -196,11 +200,11 @@ impl Store for HdfsStore {
             total_flushed += length;
         }
 
-        self.filesystem
+        filesystem
             .append(&data_file_path, data_bytes_holder.freeze())
             .instrument_await(format!("hdfs writing data. path: {}", data_file_path))
             .await?;
-        self.filesystem
+        filesystem
             .append(&index_file_path, index_bytes_holder.freeze())
             .instrument_await(format!("hdfs writing index. path: {}", data_file_path))
             .await?;
@@ -240,6 +244,9 @@ impl Store for HdfsStore {
 
     async fn purge(&self, ctx: PurgeDataContext) -> Result<()> {
         let app_id = ctx.app_id;
+        let filesystem = self.app_remote_clients.get(&app_id).ok_or(
+            WorkerError::HDFS_NATIVE_CLIENT_NOT_FOUND(app_id.to_string()),
+        )?;
 
         let dir = match ctx.shuffle_id {
             Some(shuffle_id) => self.get_shuffle_dir(app_id.as_str(), shuffle_id),
@@ -259,11 +266,36 @@ impl Store for HdfsStore {
         }
 
         info!("The hdfs data for {} has been deleted", &dir);
-        self.filesystem.delete_dir(dir.as_str()).await
+        filesystem.delete_dir(dir.as_str()).await?;
+        drop(filesystem);
+
+        if ctx.shuffle_id.is_none() {
+            self.app_remote_clients.remove(&app_id);
+        }
+
+        Ok(())
     }
 
     async fn is_healthy(&self) -> Result<bool> {
         Ok(true)
+    }
+
+    async fn register_app(&self, ctx: RegisterAppContext) -> Result<()> {
+        let remote_storage_conf_option = ctx.app_config_options.remote_storage_config_option;
+        if remote_storage_conf_option.is_none() {
+            return Err(anyhow!(
+                "The remote config must be populated by app registry action!"
+            ));
+        }
+
+        let remote_storage_conf = remote_storage_conf_option.unwrap();
+        let client = HdfsNativeClient::new(remote_storage_conf.root, remote_storage_conf.configs)?;
+
+        let app_id = ctx.app_id.clone();
+        self.app_remote_clients
+            .entry(app_id)
+            .or_insert_with(|| client);
+        Ok(())
     }
 }
 
@@ -279,18 +311,38 @@ trait HdfsDelegator {
 
 struct HdfsNativeClient {
     client: Client,
+    root: String,
 }
 
 impl HdfsNativeClient {
-    fn new() -> Self {
-        let client = Client::default();
-        Self { client }
+    fn new(root: String, configs: HashMap<String, String>) -> Result<Self> {
+        // todo: do more optimizations!
+        let url = Url::parse(root.as_str())?;
+        let url_header = format!("{}://{}", url.scheme(), url.host().unwrap());
+
+        let root_path = url.path();
+
+        info!(
+            "Created hdfs client, header: {}, path: {}",
+            &url_header, root_path
+        );
+
+        let client = Client::new_with_config(url_header.as_str(), configs)?;
+        Ok(Self {
+            client,
+            root: root_path.to_string(),
+        })
+    }
+
+    fn wrap_root(&self, path: &str) -> String {
+        format!("{}/{}", &self.root, path)
     }
 }
 
 #[async_trait]
 impl HdfsDelegator for HdfsNativeClient {
     async fn touch(&self, file_path: &str) -> Result<()> {
+        let file_path = &self.wrap_root(file_path);
         self.client
             .create(file_path, WriteOptions::default())
             .await?
@@ -300,6 +352,7 @@ impl HdfsDelegator for HdfsNativeClient {
     }
 
     async fn append(&self, file_path: &str, data: Bytes) -> Result<()> {
+        let file_path = &self.wrap_root(file_path);
         let mut file_writer = self.client.append(file_path).await?;
         file_writer.write(data).await?;
         file_writer.close().await?;
@@ -307,16 +360,19 @@ impl HdfsDelegator for HdfsNativeClient {
     }
 
     async fn len(&self, file_path: &str) -> Result<u64> {
+        let file_path = &self.wrap_root(file_path);
         let file_info = self.client.get_file_info(file_path).await?;
         Ok(file_info.length as u64)
     }
 
     async fn create_dir(&self, dir: &str) -> Result<()> {
+        let dir = &self.wrap_root(dir);
         let _ = self.client.mkdirs(dir, 777, true).await?;
         Ok(())
     }
 
     async fn delete_dir(&self, dir: &str) -> Result<()> {
+        let dir = &self.wrap_root(dir);
         self.client.delete(dir, true).await?;
         Ok(())
     }
@@ -325,6 +381,16 @@ impl HdfsDelegator for HdfsNativeClient {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use url::Url;
+
+    #[test]
+    fn url_test() {
+        let url = Url::parse("hdfs://rbf-1:19999/a/b").unwrap();
+        assert_eq!("hdfs", url.scheme());
+        assert_eq!("rbf-1", url.host().unwrap().to_string());
+        assert_eq!(19999, url.port().unwrap());
+        assert_eq!("/a/b", url.path());
+    }
 
     #[test]
     fn dir_test() -> anyhow::Result<()> {

--- a/rust/experimental/server/src/store/hybrid.rs
+++ b/rust/experimental/server/src/store/hybrid.rs
@@ -85,9 +85,12 @@ pub struct HybridStore {
     runtime_manager: RuntimeManager,
 }
 
+#[derive(Clone)]
 struct SpillMessage {
     ctx: WritingViewContext,
     id: i64,
+    retry_cnt: i32,
+    previous_spilled_storage: Option<Arc<Box<dyn PersistentStore>>>,
 }
 
 unsafe impl Send for HybridStore {}
@@ -181,9 +184,12 @@ impl HybridStore {
 
     async fn memory_spill_to_persistent_store(
         &self,
-        mut ctx: WritingViewContext,
-        in_flight_blocks_id: i64,
+        spill_message: SpillMessage,
     ) -> Result<String, WorkerError> {
+        let mut ctx: WritingViewContext = spill_message.ctx;
+        let in_flight_blocks_id: i64 = spill_message.id;
+        let retry_cnt = spill_message.retry_cnt;
+
         let uid = ctx.uid.clone();
         let blocks = &ctx.data_blocks;
         let mut spill_size = 0i64;
@@ -197,9 +203,15 @@ impl HybridStore {
             .ok_or(anyhow!("empty warm store. It should not happen"))?;
         let cold = self.cold_store.as_ref().unwrap_or(warm);
 
-        let candidate_store = if warm.is_healthy().await? {
+        // we should cover the following cases
+        // 1. local store is unhealthy. spill to hdfs
+        // 2. event flushed to localfile failed. and exceed retry max cnt, fallback to hdfs
+        // 3. huge partition directly flush to hdfs
+
+        // normal assignment
+        let mut candidate_store = if warm.is_healthy().await? {
             let cold_spilled_size = self.memory_spill_to_cold_threshold_size.unwrap_or(u64::MAX);
-            if cold_spilled_size < spill_size as u64 {
+            if cold_spilled_size < spill_size as u64 || ctx.owned_by_huge_partition {
                 cold
             } else {
                 warm
@@ -207,6 +219,11 @@ impl HybridStore {
         } else {
             cold
         };
+
+        // fallback assignment. propose hdfs always is active and stable
+        if retry_cnt >= 1 {
+            candidate_store = cold;
+        }
 
         match self.get_store_type(candidate_store) {
             StorageType::LOCALFILE => {
@@ -290,16 +307,15 @@ impl HybridStore {
         blocks: Vec<PartitionedDataBlock>,
         uid: PartitionedUId,
     ) -> Result<()> {
-        let writing_ctx = WritingViewContext {
-            uid,
-            data_blocks: blocks,
-        };
+        let writing_ctx = WritingViewContext::from(uid, blocks);
 
         if self
             .memory_spill_send
             .send(SpillMessage {
                 ctx: writing_ctx,
                 id: in_flight_uid,
+                retry_cnt: 0,
+                previous_spilled_storage: None,
             })
             .await
             .is_err()
@@ -339,7 +355,7 @@ impl Store for HybridStore {
         let concurrency_limiter =
             Arc::new(Semaphore::new(store.memory_spill_max_concurrency as usize));
         self.runtime_manager.write_runtime.spawn(async move {
-            while let Ok(message) = store.memory_spill_recv.recv().await {
+            while let Ok(mut message) = store.memory_spill_recv.recv().await {
                 let await_root = await_tree_registry
                     .register(format!("hot->warm flush. uid: {:#?}", &message.ctx.uid))
                     .await;
@@ -364,7 +380,7 @@ impl Store for HybridStore {
                             size += block.length as u64;
                         }
                         match store_cloned
-                            .memory_spill_to_persistent_store(message.ctx.clone(), message.id)
+                            .memory_spill_to_persistent_store(message.clone())
                             .instrument_await("memory_spill_to_persistent_store.")
                             .await
                         {
@@ -375,9 +391,11 @@ impl Store for HybridStore {
                             Err(error) => {
                                 TOTAL_MEMORY_SPILL_OPERATION_FAILED.inc();
                                 error!(
-                                "Errors on spill memory data to persistent storage. error: {:#?}",
-                                error
-                            );
+                                "Errors on spill memory data to persistent storage for event_id:{:?}. The error: {:#?}",
+                                    message.id,
+                                    error);
+
+                                message.retry_cnt = message.retry_cnt + 1;
                                 // re-push to the queue to execute
                                 let _ = store_cloned.memory_spill_send.send(message).await;
                             }
@@ -628,9 +646,9 @@ mod tests {
         let mut block_ids = vec![];
         for i in 0..batch_size {
             block_ids.push(i);
-            let writing_ctx = WritingViewContext {
-                uid: uid.clone(),
-                data_blocks: vec![PartitionedDataBlock {
+            let writing_ctx = WritingViewContext::from(
+                uid.clone(),
+                vec![PartitionedDataBlock {
                     block_id: i,
                     length: data_len as i32,
                     uncompress_length: 100,
@@ -638,7 +656,7 @@ mod tests {
                     data: Bytes::copy_from_slice(data),
                     task_attempt_id: 0,
                 }],
-            };
+            );
             let _ = store.insert(writing_ctx).await;
         }
 

--- a/rust/experimental/server/src/store/local/disk.rs
+++ b/rust/experimental/server/src/store/local/disk.rs
@@ -228,15 +228,15 @@ impl LocalDisk {
         Ok(())
     }
 
-    fn mark_corrupted(&self) {
+    pub fn mark_corrupted(&self) {
         self.is_corrupted.store(true, Ordering::SeqCst);
     }
 
-    fn mark_unhealthy(&self) {
+    pub fn mark_unhealthy(&self) {
         self.is_healthy.store(false, Ordering::SeqCst);
     }
 
-    fn mark_healthy(&self) {
+    pub fn mark_healthy(&self) {
         self.is_healthy.store(true, Ordering::SeqCst);
     }
 

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -203,6 +203,12 @@ impl Store for LocalFileStore {
             return Err(WorkerError::PARTIAL_DATA_LOST(local_disk.root.to_string()));
         }
 
+        if !local_disk.is_healthy()? {
+            return Err(WorkerError::LOCAL_DISK_UNHEALTHY(
+                local_disk.root.to_string(),
+            ));
+        }
+
         if !parent_dir_is_created {
             if let Some(path) = Path::new(&data_file_path).parent() {
                 local_disk
@@ -410,9 +416,93 @@ mod test {
     };
     use crate::store::localfile::LocalFileStore;
 
+    use crate::error::WorkerError;
     use crate::store::{PartitionedDataBlock, ResponseData, ResponseDataIndex, Store};
     use bytes::{Buf, Bytes, BytesMut};
     use log::info;
+
+    fn create_writing_ctx() -> WritingViewContext {
+        let uid = PartitionedUId {
+            app_id: "100".to_string(),
+            shuffle_id: 0,
+            partition_id: 0,
+        };
+
+        let data = b"hello world!hello china!";
+        let size = data.len();
+        let writing_ctx = WritingViewContext {
+            uid: uid.clone(),
+            data_blocks: vec![
+                PartitionedDataBlock {
+                    block_id: 0,
+                    length: size as i32,
+                    uncompress_length: 200,
+                    crc: 0,
+                    data: Bytes::copy_from_slice(data),
+                    task_attempt_id: 0,
+                },
+                PartitionedDataBlock {
+                    block_id: 1,
+                    length: size as i32,
+                    uncompress_length: 200,
+                    crc: 0,
+                    data: Bytes::copy_from_slice(data),
+                    task_attempt_id: 0,
+                },
+            ],
+        };
+
+        writing_ctx
+    }
+
+    #[test]
+    fn local_disk_under_exception_test() -> anyhow::Result<()> {
+        let temp_dir = tempdir::TempDir::new("local_disk_under_exception_test").unwrap();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+        println!("init local file path: {}", &temp_path);
+        let local_store = LocalFileStore::new(vec![temp_path.to_string()]);
+
+        let runtime = local_store.runtime_manager.clone();
+
+        let writing_view_ctx = create_writing_ctx();
+        let insert_result = runtime.wait(local_store.insert(writing_view_ctx));
+
+        if insert_result.is_err() {
+            println!("{:?}", insert_result.err());
+            panic!()
+        }
+
+        // case1: mark the local disk unhealthy, that will the following flush throw exception directly.
+        let local_disk = local_store.local_disks[0].clone();
+        local_disk.mark_unhealthy();
+
+        let writing_view_ctx = create_writing_ctx();
+        let insert_result = runtime.wait(local_store.insert(writing_view_ctx));
+        match insert_result {
+            Err(WorkerError::LOCAL_DISK_UNHEALTHY(_)) => {}
+            _ => panic!(),
+        }
+
+        // case2: mark the local disk healthy, all things work!
+        local_disk.mark_healthy();
+        let writing_view_ctx = create_writing_ctx();
+        let insert_result = runtime.wait(local_store.insert(writing_view_ctx));
+        match insert_result {
+            Err(WorkerError::LOCAL_DISK_UNHEALTHY(_)) => panic!(),
+            _ => {}
+        }
+
+        // case3: mark the local disk corrupted, fail directly.
+        local_disk.mark_corrupted();
+        let writing_view_ctx = create_writing_ctx();
+        let insert_result = runtime.wait(local_store.insert(writing_view_ctx));
+        match insert_result {
+            Err(WorkerError::PARTIAL_DATA_LOST(_)) => {}
+            _ => panic!(),
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn purge_test() -> anyhow::Result<()> {

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -18,7 +18,7 @@
 use crate::app::ReadingOptions::FILE_OFFSET_AND_LEN;
 use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
-    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
+    RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::LocalfileStoreConfig;
 use crate::error::WorkerError;
@@ -405,6 +405,10 @@ impl Store for LocalFileStore {
 
     async fn release_buffer(&self, _ctx: ReleaseBufferContext) -> Result<i64, WorkerError> {
         todo!()
+    }
+
+    async fn register_app(&self, _ctx: RegisterAppContext) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -430,9 +430,9 @@ mod test {
 
         let data = b"hello world!hello china!";
         let size = data.len();
-        let writing_ctx = WritingViewContext {
-            uid: uid.clone(),
-            data_blocks: vec![
+        let writing_ctx = WritingViewContext::from(
+            uid.clone(),
+            vec![
                 PartitionedDataBlock {
                     block_id: 0,
                     length: size as i32,
@@ -450,7 +450,7 @@ mod test {
                     task_attempt_id: 0,
                 },
             ],
-        };
+        );
 
         writing_ctx
     }
@@ -522,9 +522,9 @@ mod test {
 
         let data = b"hello world!hello china!";
         let size = data.len();
-        let writing_ctx = WritingViewContext {
-            uid: uid.clone(),
-            data_blocks: vec![
+        let writing_ctx = WritingViewContext::from(
+            uid.clone(),
+            vec![
                 PartitionedDataBlock {
                     block_id: 0,
                     length: size as i32,
@@ -542,7 +542,7 @@ mod test {
                     task_attempt_id: 0,
                 },
             ],
-        };
+        );
 
         let insert_result = runtime.wait(local_store.insert(writing_ctx));
         if insert_result.is_err() {
@@ -596,9 +596,9 @@ mod test {
 
         let data = b"hello world!hello china!";
         let size = data.len();
-        let writing_ctx = WritingViewContext {
-            uid: uid.clone(),
-            data_blocks: vec![
+        let writing_ctx = WritingViewContext::from(
+            uid.clone(),
+            vec![
                 PartitionedDataBlock {
                     block_id: 0,
                     length: size as i32,
@@ -616,7 +616,7 @@ mod test {
                     task_attempt_id: 0,
                 },
             ],
-        };
+        );
 
         let insert_result = runtime.wait(local_store.insert(writing_ctx));
         if insert_result.is_err() {

--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -882,7 +882,7 @@ mod test {
                 task_attempt_id: 0,
             });
         }
-        WritingViewContext { uid, data_blocks }
+        WritingViewContext::from(uid, data_blocks)
     }
 
     #[test]
@@ -927,9 +927,9 @@ mod test {
             .wait(store.require_buffer(RequireBufferContext::new(uid.clone(), 40)))
             .expect("");
 
-        let writing_ctx = WritingViewContext {
-            uid: uid.clone(),
-            data_blocks: vec![PartitionedDataBlock {
+        let writing_ctx = WritingViewContext::from(
+            uid.clone(),
+            vec![PartitionedDataBlock {
                 block_id: 0,
                 length: 10,
                 uncompress_length: 100,
@@ -937,7 +937,7 @@ mod test {
                 data: Default::default(),
                 task_attempt_id: 0,
             }],
-        };
+        );
         runtime.wait(store.insert(writing_ctx)).expect("");
 
         let reading_ctx = ReadingViewContext {
@@ -988,9 +988,9 @@ mod test {
         let store = MemoryStore::new(1024 * 1024 * 1024);
         let runtime = store.runtime_manager.clone();
 
-        let writing_ctx = WritingViewContext {
-            uid: Default::default(),
-            data_blocks: vec![
+        let writing_ctx = WritingViewContext::from(
+            Default::default(),
+            vec![
                 PartitionedDataBlock {
                     block_id: 0,
                     length: 10,
@@ -1008,7 +1008,7 @@ mod test {
                     task_attempt_id: 1,
                 },
             ],
-        };
+        );
         runtime.wait(store.insert(writing_ctx)).unwrap();
 
         let reading_ctx = ReadingViewContext {
@@ -1033,9 +1033,9 @@ mod test {
         let runtime = store.runtime_manager.clone();
 
         // 1. insert 2 block
-        let writing_ctx = WritingViewContext {
-            uid: Default::default(),
-            data_blocks: vec![
+        let writing_ctx = WritingViewContext::from(
+            Default::default(),
+            vec![
                 PartitionedDataBlock {
                     block_id: 0,
                     length: 10,
@@ -1053,7 +1053,7 @@ mod test {
                     task_attempt_id: 1,
                 },
             ],
-        };
+        );
         runtime.wait(store.insert(writing_ctx)).unwrap();
 
         // 2. block_ids_filter is empty, should return 2 blocks

--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -18,7 +18,7 @@
 use crate::app::ReadingOptions::MEMORY_LAST_BLOCK_ID_AND_MAX_SIZE;
 use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
-    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
+    RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::MemoryStoreConfig;
 use crate::error::WorkerError;
@@ -454,6 +454,10 @@ impl Store for MemoryStore {
     async fn release_buffer(&self, ctx: ReleaseBufferContext) -> Result<i64, WorkerError> {
         let ticket_id = ctx.ticket_id;
         self.ticket_manager.delete(ticket_id)
+    }
+
+    async fn register_app(&self, _ctx: RegisterAppContext) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/rust/experimental/server/src/store/mod.rs
+++ b/rust/experimental/server/src/store/mod.rs
@@ -24,8 +24,8 @@ pub mod mem;
 pub mod memory;
 
 use crate::app::{
-    PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, ReleaseBufferContext,
-    RequireBufferContext, WritingViewContext,
+    PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RegisterAppContext,
+    ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
 use crate::config::Config;
 use crate::error::WorkerError;
@@ -176,6 +176,7 @@ pub trait Store {
         ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, WorkerError>;
     async fn release_buffer(&self, ctx: ReleaseBufferContext) -> Result<i64, WorkerError>;
+    async fn register_app(&self, ctx: RegisterAppContext) -> Result<()>;
 }
 
 pub trait Persistent {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. fix(rust): fast fail of writing to localfile when disk is unhealthy
2. fix(rust): incorrect failed buffer required cnt metrics
3. feat(rust): support fallback to hdfs when local store is invalid
4. btw: support huge partition flushing to hdfs directly
5. feat(rust): avoid setting hdfs config in server client

### Why are the changes needed?

For #1407, hope bringing up this into production env.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests.
