### PR TITLE
[MINOR] fix: Assert actual number of bitmaps matches bitmapNum

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -56,6 +56,7 @@ import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.FileNotFoundException;
+import org.apache.uniffle.common.exception.InvalidRequestException;
 import org.apache.uniffle.common.exception.NoBufferException;
 import org.apache.uniffle.common.exception.NoBufferForHugePartitionException;
 import org.apache.uniffle.common.exception.NoRegisterException;
@@ -383,6 +384,15 @@ public class ShuffleTaskManager {
           return blockIds;
         });
     Roaring64NavigableMap[] blockIds = shuffleIdToPartitions.get(shuffleId);
+    if (blockIds.length != bitmapNum) {
+      throw new InvalidRequestException(
+          "Request expects "
+              + bitmapNum
+              + " bitmaps, but there are "
+              + blockIds.length
+              + " bitmaps!");
+    }
+
     for (Map.Entry<Integer, long[]> entry : partitionToBlockIds.entrySet()) {
       Integer partitionId = entry.getKey();
       Roaring64NavigableMap bitmap = blockIds[partitionId % bitmapNum];

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -49,6 +49,7 @@ import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
+import org.apache.uniffle.common.exception.InvalidRequestException;
 import org.apache.uniffle.common.exception.NoBufferForHugePartitionException;
 import org.apache.uniffle.common.exception.NoRegisterException;
 import org.apache.uniffle.common.exception.RssException;
@@ -851,6 +852,14 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
         shuffleTaskManager.getFinishedBlockIds(appId, shuffleId, requestPartitions);
     Roaring64NavigableMap resBlockIds = RssUtils.deserializeBitMap(serializeBitMap);
     assertEquals(expectedBlockIds, resBlockIds);
+
+    try {
+      // calling with same appId and shuffleId but different bitmapNum should fail
+      shuffleTaskManager.addFinishedBlockIds(appId, shuffleId, blockIdsToReport, bitNum - 1);
+      fail("Exception should be thrown");
+    } catch (InvalidRequestException e) {
+      assertEquals(e.getMessage(), "Request expects 2 bitmaps, but there are 3 bitmaps!");
+    }
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Method `ShuffleTaskManager.addFinishedBlockIds` should check the actual number of bitmaps matches the requested `bitmapNum`.

### Why are the changes needed?
Calling `ShuffleTaskManager.addFinishedBlockIds(String appId, Integer shuffleId, …, bitmapNum)` initializes an array of bitmaps for the first call per `(appId, shuffleId)`, according to the `bitmapNum`. Subsequent calls must use the same `bitmapNum`, otherwise you get into trouble:

- with a larger `bimapNum` you would see an out-of-bound exception, e.g.: `java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3`
- a lower `bimapNum` would silently add the blocks to the wrong bitmap, potentially hiding them from shuffle read clients

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test added to `ShuffleTaskManagerTest.testGetFinishedBlockIds`.