### PR TITLE
[MINOR] fix: Get and increment ATOMIC_LONG in that order everywhere

### DIFF
--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -611,7 +611,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
       long blockId =
-          (ATOMIC_LONG.incrementAndGet()
+          (ATOMIC_LONG.getAndIncrement()
                   << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
               + taskAttemptId;
       ShufflePartitionedBlock spb =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `ShuffleReadClientImplTest.writeDuplicatedData` call `ATOMIC_LONG.getAndIncrement`, rather than `ATOMIC_LONG.incrementAndGet`.

### Why are the changes needed?
In `ShuffleReadClientImplTest`
- method `writeTestData` calls `ATOMIC_LONG.getAndIncrement()`
- method `writeDuplicatedData` calls `ATOMIC_LONG.incrementAndGet()`

Calling `writeTestData` after `writeDuplicatedData` produces a duplicate sequence number, which is unexpected. All code paths in `ShuffleReadClientImplTest` that increment `ATOMIC_LONG` should use the same order of get and increment.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually.