### PR TITLE
[MINOR] build: Move dashboard module into profile

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -84,11 +84,11 @@ jobs:
         restore-keys: |
           mvn-${{ inputs.java-version }}-package-${{ matrix.profile }}-
           mvn-${{ inputs.java-version }}-package-
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -P${{ matrix.profile }}`
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -P${{ matrix.profile }} -Pdashboard`
       run: |
         PROFILES="${{ matrix.profile }}"
         PROFILES=${PROFILES/-/,}
-        ./mvnw -B -fae ${{ inputs.maven-args }} -P${PROFILES} | tee /tmp/maven.log
+        ./mvnw -B -fae ${{ inputs.maven-args }} -P${PROFILES} -Pdashboard | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -68,20 +68,20 @@ jobs:
         key: mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           mvn-${{ inputs.java-version }}-${{ inputs.cache-key }}-
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3 -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark2 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark2 -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark2 -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop2.8`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop2.8 -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop2.8 -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop3.2`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pmr,hadoop3.2 -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pmr,hadoop3.2 -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
-    - name: Execute `./mvnw ${{ inputs.maven-args }} -Ptez`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Ptez | tee -a /tmp/maven.log;
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Ptez -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Ptez -Pdashboard | tee -a /tmp/maven.log;
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
-    - name: Execute `./mvnw ${{ inputs.maven-args }}`
-      run: ./mvnw -B -fae ${{ inputs.maven-args }} | tee /tmp/maven.log
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pdashboard`
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pdashboard | tee /tmp/maven.log
       shell: bash
     - name: Summary of failures
       if: ${{ failure() && inputs.summary != '' }}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To build it, run:
 
 To fix code style issues, run:
 
-    ./mvnw spotless:apply -Pspark3 -Pspark2 -Ptez -Pmr -Phadoop2.8
+    ./mvnw spotless:apply -Pspark3 -Pspark2 -Ptez -Pmr -Phadoop2.8 -Pdashboard
 
 Build against profile Spark 2 (2.4.6)
 
@@ -117,6 +117,10 @@ Build against Tez 0.9.1
 Build against Tez 0.9.1 and Hadoop 3.2.1
 
     ./mvnw -DskipTests clean package -Ptez,hadoop3.2
+
+Build with dashboard
+
+    ./mvnw -DskipTests clean package -Pdashboard
 
 To package the Uniffle, run:
 

--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -43,6 +43,7 @@ function exit_with_usage() {
   exit 1
 }
 
+MVN_OPTS="-Pdashboard"
 SPARK2_PROFILE_ID="spark2"
 SPARK2_MVN_OPTS=""
 SPARK3_PROFILE_ID="spark3"
@@ -138,7 +139,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-BUILD_COMMAND=("$MVN" clean package -DskipTests $@)
+BUILD_COMMAND=("$MVN" clean package -DskipTests $MVN_OPTS $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
     <module>client</module>
     <module>integration-test/common</module>
     <module>cli</module>
-    <module>dashboard</module>
   </modules>
 
   <dependencies>
@@ -1164,6 +1163,12 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>dashboard</id>
+      <modules>
+        <module>dashboard</module>
+      </modules>
+    </profile>
 
     <profile>
       <!-- This will search remote and local repos to generate THIRD-PARTY license file, make sure
@@ -1975,6 +1980,7 @@
         </dependencies>
       </dependencyManagement>
     </profile>
+
     <profile>
       <id>tez</id>
       <modules>
@@ -2169,6 +2175,7 @@
         </dependencies>
       </dependencyManagement>
       </profile>
+
       <profile>
       <id>kubernetes</id>
       <modules>
@@ -2211,6 +2218,7 @@
         </dependency>
       </dependencies>
     </profile>
+
     <profile>
       <id>apache-release</id>
       <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `dashboard` module should be moved into a profile and and **not build by default**.

It can be activated via `-Pdashbboard`.

### Why are the changes needed?
Building and especially incrementally compiling during development always builds dashboard completely. All other modules finish in seconds, but dashboard takes minutes. This increases the iteration cycle from seconds to minutes.

Compiling Uniffle with `dashboard`:

```
./mvnw compile -Pdashboard
…
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Uniffle 0.9.0-SNAPSHOT:
[INFO] 
[INFO] Apache Uniffle ..................................... SUCCESS [  0.804 s]
[INFO] Apache Uniffle Protocols ........................... SUCCESS [  4.486 s]
[INFO] Apache Uniffle Common .............................. SUCCESS [  1.778 s]
[INFO] Apache Uniffle Internal Client ..................... SUCCESS [  0.244 s]
[INFO] Apache Uniffle Coordinator ......................... SUCCESS [  0.492 s]
[INFO] Apache Uniffle Storage ............................. SUCCESS [  1.433 s]
[INFO] Apache Uniffle Server .............................. SUCCESS [  1.161 s]
[INFO] Apache Uniffle Client .............................. SUCCESS [  0.381 s]
[INFO] Apache Uniffle CLI ................................. SUCCESS [  0.107 s]
[INFO] Apache Uniffle Integration Test (Common) ........... SUCCESS [  1.066 s]
[INFO] Apache Uniffle Dashboard ........................... SUCCESS [02:22 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:35 min
```

Compiling Uniffle **without** `dashboard`:

```
./mvnw compile
…
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Uniffle 0.9.0-SNAPSHOT:
[INFO] 
[INFO] Apache Uniffle ..................................... SUCCESS [  0.820 s]
[INFO] Apache Uniffle Protocols ........................... SUCCESS [  4.560 s]
[INFO] Apache Uniffle Common .............................. SUCCESS [  1.825 s]
[INFO] Apache Uniffle Internal Client ..................... SUCCESS [  0.213 s]
[INFO] Apache Uniffle Coordinator ......................... SUCCESS [  0.496 s]
[INFO] Apache Uniffle Storage ............................. SUCCESS [  1.403 s]
[INFO] Apache Uniffle Server .............................. SUCCESS [  1.100 s]
[INFO] Apache Uniffle Client .............................. SUCCESS [  0.431 s]
[INFO] Apache Uniffle CLI ................................. SUCCESS [  0.106 s]
[INFO] Apache Uniffle Integration Test (Common) ........... SUCCESS [  1.052 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.538 s
…


### Does this PR introduce _any_ user-facing change?
Only affects build time.

### How was this patch tested?
Manual testing.