### PR TITLE
[#1267][FOLLOWUP] improvement(client): INFO log level should be used in RetryUtils

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/RetryUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RetryUtils.java
@@ -83,14 +83,14 @@ public class RetryUtils {
         retry++;
         if (isRetryFunc.apply(t) && retry < retryTimes) {
           if (LOG.isDebugEnabled()) {
-            LOG.error("Retry due to Throwable ", t);
+            LOG.debug("Retry due to: ", t);
           } else {
-            LOG.error(
-                "Retry due to Throwable {}. Use DEBUG level to see the full stack: {}",
+            LOG.info(
+                "Retry due to: {}. Use DEBUG level to see the full stack: {}",
                 t.getClass().getName(),
                 t.getMessage());
           }
-          LOG.error(
+          LOG.info(
               "Will retry {} more time(s) after waiting {} milliseconds.",
               retryTimes - retry,
               intervalMs);


### PR DESCRIPTION
### What changes were proposed in this pull request?

INFO log level should be used in RetryUtils. Because these log messages are not actual errors.

### Why are the changes needed?

It's a followup PR for [#1411](https://github.com/apache/incubator-uniffle/pull/1411).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
