### PR TITLE
[#1407] fix(rust): avoid checking storage type in runtime

### DIFF
--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -19,7 +19,7 @@ use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
     RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
-use crate::config::HdfsStoreConfig;
+use crate::config::{HdfsStoreConfig, StorageType};
 use crate::error::WorkerError;
 use std::collections::HashMap;
 
@@ -299,6 +299,10 @@ impl Store for HdfsStore {
             .entry(app_id)
             .or_insert_with(|| client);
         Ok(())
+    }
+
+    async fn name(&self) -> StorageType {
+        StorageType::HDFS
     }
 }
 

--- a/rust/experimental/server/src/store/localfile.rs
+++ b/rust/experimental/server/src/store/localfile.rs
@@ -20,7 +20,7 @@ use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
     RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
-use crate::config::LocalfileStoreConfig;
+use crate::config::{LocalfileStoreConfig, StorageType};
 use crate::error::WorkerError;
 use crate::metric::TOTAL_LOCALFILE_USED;
 use crate::store::ResponseDataIndex::Local;
@@ -414,6 +414,10 @@ impl Store for LocalFileStore {
 
     async fn register_app(&self, _ctx: RegisterAppContext) -> Result<()> {
         Ok(())
+    }
+
+    async fn name(&self) -> StorageType {
+        StorageType::LOCALFILE
     }
 }
 

--- a/rust/experimental/server/src/store/memory.rs
+++ b/rust/experimental/server/src/store/memory.rs
@@ -20,7 +20,7 @@ use crate::app::{
     PartitionedUId, PurgeDataContext, ReadingIndexViewContext, ReadingViewContext,
     RegisterAppContext, ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
-use crate::config::MemoryStoreConfig;
+use crate::config::{MemoryStoreConfig, StorageType};
 use crate::error::WorkerError;
 use crate::metric::{
     GAUGE_MEMORY_ALLOCATED, GAUGE_MEMORY_CAPACITY, GAUGE_MEMORY_USED, TOTAL_MEMORY_USED,
@@ -458,6 +458,10 @@ impl Store for MemoryStore {
 
     async fn register_app(&self, _ctx: RegisterAppContext) -> Result<()> {
         Ok(())
+    }
+
+    async fn name(&self) -> StorageType {
+        StorageType::MEMORY
     }
 }
 

--- a/rust/experimental/server/src/store/mod.rs
+++ b/rust/experimental/server/src/store/mod.rs
@@ -27,7 +27,7 @@ use crate::app::{
     PurgeDataContext, ReadingIndexViewContext, ReadingViewContext, RegisterAppContext,
     ReleaseBufferContext, RequireBufferContext, WritingViewContext,
 };
-use crate::config::Config;
+use crate::config::{Config, StorageType};
 use crate::error::WorkerError;
 use crate::proto::uniffle::{ShuffleData, ShuffleDataBlockSegment};
 use crate::store::hybrid::HybridStore;
@@ -177,6 +177,8 @@ pub trait Store {
     ) -> Result<RequireBufferResponse, WorkerError>;
     async fn release_buffer(&self, ctx: ReleaseBufferContext) -> Result<i64, WorkerError>;
     async fn register_app(&self, ctx: RegisterAppContext) -> Result<()>;
+
+    async fn name(&self) -> StorageType;
 }
 
 pub trait Persistent {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid checking storage type of spill in runtime to improve performance.

### Why are the changes needed?

improve performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing uts
