### PR TITLE
[#1407] fix(rust): return error when getting data from hdfs by client

### DIFF
--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -57,6 +57,9 @@ pub enum WorkerError {
 
     #[error("Hdfs native client not found for app: {0}")]
     HDFS_NATIVE_CLIENT_NOT_FOUND(String),
+
+    #[error("Data should be read from hdfs in client side instead of from server side")]
+    READ_HDFS_DATA_NOT_FROM_SERVER,
 }
 
 impl From<AcquireError> for WorkerError {

--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -59,7 +59,7 @@ pub enum WorkerError {
     HDFS_NATIVE_CLIENT_NOT_FOUND(String),
 
     #[error("Data should be read from hdfs in client side instead of from server side")]
-    READ_HDFS_DATA_NOT_FROM_SERVER,
+    NOT_READ_HDFS_DATA_FROM_SERVER,
 }
 
 impl From<AcquireError> for WorkerError {

--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -221,14 +221,14 @@ impl Store for HdfsStore {
     }
 
     async fn get(&self, _ctx: ReadingViewContext) -> Result<ResponseData, WorkerError> {
-        Err(WorkerError::READ_HDFS_DATA_NOT_FROM_SERVER)
+        Err(WorkerError::NOT_READ_HDFS_DATA_FROM_SERVER)
     }
 
     async fn get_index(
         &self,
         _ctx: ReadingIndexViewContext,
     ) -> Result<ResponseDataIndex, WorkerError> {
-        Err(WorkerError::READ_HDFS_DATA_NOT_FROM_SERVER)
+        Err(WorkerError::NOT_READ_HDFS_DATA_FROM_SERVER)
     }
 
     async fn require_buffer(

--- a/rust/experimental/server/src/store/hdfs.rs
+++ b/rust/experimental/server/src/store/hdfs.rs
@@ -221,14 +221,14 @@ impl Store for HdfsStore {
     }
 
     async fn get(&self, _ctx: ReadingViewContext) -> Result<ResponseData, WorkerError> {
-        todo!()
+        Err(WorkerError::READ_HDFS_DATA_NOT_FROM_SERVER)
     }
 
     async fn get_index(
         &self,
         _ctx: ReadingIndexViewContext,
     ) -> Result<ResponseDataIndex, WorkerError> {
-        todo!()
+        Err(WorkerError::READ_HDFS_DATA_NOT_FROM_SERVER)
     }
 
     async fn require_buffer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

If client using the `memory_local` type, but the server is using `memory_hdfs` type, 
server will panic when getting shuffle data. This PR is to avoid this.

### Why are the changes needed?

This is the sub-tasks for #1407 .

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

needn't
