### PR TITLE
[MINOR] CI: Rework build and rust workflow events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,15 @@
 
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'branch-*'
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -52,7 +60,7 @@ jobs:
     with:
       maven-args: test-compile spotbugs:check
       cache-key: spotbugs
-  
+
   java-11:
     needs: [spotbugs] # delay execution
     name: 'compile'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,15 @@
 
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'branch-*'
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +42,7 @@ jobs:
 
       - name: Install native libs
         run: sudo apt-get install -y libkrb5-dev libgsasl-dev
-        
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -48,5 +48,5 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          check_name: Test Results (${{ github.event.workflow_run.event }})
+          check_name: Test Results
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rework events that trigger `build` and `rust` workflows: the `push` event only triggers on branches `master`, `branch-*` and tags, not on any other branch. Other branches are already covered by the `pull_request` event.

Further, allows to trigger those workflows on branches and tags manually.

### Why are the changes needed?
Currently you have both `push` and `pull_request` run on commits done to branches that have pull requests. Branches are eventually merged into one of the above branches via pull requests. Hence, running `push` on those branches is pretty redundant.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually.