### PR TITLE
[#1407] fix(rust): drop events and release memory when errors happened

### DIFF
--- a/rust/experimental/server/src/error.rs
+++ b/rust/experimental/server/src/error.rs
@@ -60,6 +60,9 @@ pub enum WorkerError {
 
     #[error("Data should be read from hdfs in client side instead of from server side")]
     NOT_READ_HDFS_DATA_FROM_SERVER,
+
+    #[error("Spill event has been retried exceed the max limit for app: {0}")]
+    SPILL_EVENT_EXCEED_RETRY_MAX_LIMIT(String),
 }
 
 impl From<AcquireError> for WorkerError {

--- a/rust/experimental/server/src/metric.rs
+++ b/rust/experimental/server/src/metric.rs
@@ -248,7 +248,19 @@ pub static GAUGE_IN_SPILL_DATA_SIZE: Lazy<IntGauge> =
 pub static GAUGE_GRPC_REQUEST_QUEUE_SIZE: Lazy<IntGauge> =
     Lazy::new(|| IntGauge::new("grpc_request_queue_size", "grpc request queue size").unwrap());
 
+pub static TOTAL_SPILL_EVENTS_DROPPED: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "total_spill_events_dropped",
+        "total spill events dropped number",
+    )
+    .expect("")
+});
+
 fn register_custom_metrics() {
+    REGISTRY
+        .register(Box::new(TOTAL_SPILL_EVENTS_DROPPED.clone()))
+        .expect("");
+
     REGISTRY
         .register(Box::new(GAUGE_TOPN_APP_RESIDENT_DATA_SIZE.clone()))
         .expect("");


### PR DESCRIPTION
### What changes were proposed in this pull request?

drop events and release memory when errors happened

### Why are the changes needed?

Drop events to release memory to ensure service stable
Sub tasks for #1407 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Online tests
