### PR TITLE
[#1476] feat(rust): Provide dedicated unregister app rpc for rust based server

### DIFF
--- a/rust/experimental/server/src/app.rs
+++ b/rust/experimental/server/src/app.rs
@@ -726,10 +726,15 @@ impl AppManager {
         app_ref.register_shuffle(shuffle_id)
     }
 
-    pub async fn unregister(&self, app_id: String, shuffle_id: i32) -> Result<()> {
+    pub async fn unregister_shuffle(&self, app_id: String, shuffle_id: i32) -> Result<()> {
         self.sender
             .send(PurgeEvent::APP_PARTIAL_SHUFFLES_PURGE(app_id, shuffle_id))
             .await?;
+        Ok(())
+    }
+
+    pub async fn unregister_app(&self, app_id: String) -> Result<()> {
+        self.sender.send(PurgeEvent::APP_PURGE(app_id)).await?;
         Ok(())
     }
 }

--- a/rust/experimental/server/src/proto/uniffle.proto
+++ b/rust/experimental/server/src/proto/uniffle.proto
@@ -23,6 +23,7 @@ package rss.common;
 service ShuffleServer {
   rpc registerShuffle (ShuffleRegisterRequest) returns (ShuffleRegisterResponse);
   rpc unregisterShuffle(ShuffleUnregisterRequest) returns (ShuffleUnregisterResponse);
+  rpc unregisterShuffleByAppId(ShuffleUnregisterByAppIdRequest) returns (ShuffleUnregisterByAppIdResponse);
   rpc sendShuffleData (SendShuffleDataRequest) returns (SendShuffleDataResponse);
   rpc getLocalShuffleIndex (GetLocalShuffleIndexRequest) returns (GetLocalShuffleIndexResponse);
   rpc getLocalShuffleData (GetLocalShuffleDataRequest) returns (GetLocalShuffleDataResponse);
@@ -190,6 +191,15 @@ message ShuffleUnregisterResponse {
 }
 
 message ShuffleRegisterResponse {
+  StatusCode status = 1;
+  string retMsg = 2;
+}
+
+message ShuffleUnregisterByAppIdRequest {
+  string appId = 1;
+}
+
+message ShuffleUnregisterByAppIdResponse {
   StatusCode status = 1;
   string retMsg = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provide dedicated unregister app rpc interface for rust based server

### Why are the changes needed?

Fix: #1476

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
