### PR TITLE
[MINOR] fix(deploy): Fix invocation of kubernetes bash scripts

### DIFF
--- a/deploy/kubernetes/integration-test/e2e/set-up-local-cluster.sh
+++ b/deploy/kubernetes/integration-test/e2e/set-up-local-cluster.sh
@@ -66,7 +66,7 @@ function prepare_local_k8s_cluster() {
 function build_rss_image() {
   cd $RSS_BUILD_DIR
   export IMAGE_VERSION=$TEST_VERSION
-  sh ./build.sh --registry $TEST_REGISTRY
+  ./build.sh --registry $TEST_REGISTRY
   cd "$OLDPWD"
 }
 

--- a/deploy/kubernetes/integration-test/e2e/start-e2e.sh
+++ b/deploy/kubernetes/integration-test/e2e/start-e2e.sh
@@ -31,5 +31,5 @@ echo "BUILD_NEW_CLUSTER: $BUILD_NEW_CLUSTER"
 echo "BUILD_RSS_IMAGE: $BUILD_RSS_IMAGE"
 echo "BUILD_RSS_OPERATOR: $BUILD_RSS_OPERATOR"
 
-sh set-up-local-cluster.sh --registry "$TEST_REGISTRY" --build-kind-cluster "$BUILD_NEW_CLUSTER" \
+./set-up-local-cluster.sh --registry "$TEST_REGISTRY" --build-kind-cluster "$BUILD_NEW_CLUSTER" \
           --build-rss-image "$BUILD_RSS_IMAGE" --build-operator "$BUILD_RSS_OPERATOR"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not invoke bash scripts via `sh ./SCRIPT.sh`, but `./SCRIPT.sh`.

### Why are the changes needed?
These bash scripts are invoked via `sh ./SCRIPT.sh`, which overrides the shebang line in the script, effectively executing the scripts via `/bin/sh`. The scripts require `bash` though, so the invocation fails.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually tested.