### PR TITLE
[#1472][part-2] fix(server): Reuse ByteBuf when decoding shuffle blocks instead of reallocating it

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
@@ -28,7 +28,6 @@ import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.ByteBufUtils;
-import org.apache.uniffle.common.util.NettyUtils;
 
 public class Decoders {
   public static ShuffleServerInfo decodeShuffleServerInfo(ByteBuf byteBuf) {
@@ -47,8 +46,7 @@ public class Decoders {
     long crc = byteBuf.readLong();
     long taskAttemptId = byteBuf.readLong();
     int dataLength = byteBuf.readInt();
-    ByteBuf data = NettyUtils.getNettyBufferAllocator().directBuffer(dataLength);
-    data.writeBytes(byteBuf, dataLength);
+    ByteBuf data = byteBuf.retain().readSlice(dataLength);
     int lengthOfShuffleServers = byteBuf.readInt();
     List<ShuffleServerInfo> serverInfos = Lists.newArrayList();
     for (int k = 0; k < lengthOfShuffleServers; k++) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reuse ByteBuf when decoding shuffle blocks instead of reallocating it

### Why are the changes needed?

A sub PR for: https://github.com/apache/incubator-uniffle/pull/1519

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
