### PR TITLE
[MINOR] fix(pom): Add missing shuffle-server dependencies to work with -Ptez

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <version.checksum-maven-plugin>1.11</version.checksum-maven-plugin>
     <awaitility.version>4.2.0</awaitility.version>
     <checkstyle.version>9.3</checkstyle.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-lang3.version>3.10</commons-lang3.version>
     <commons-codec.version>1.9</commons-codec.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -85,6 +85,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>${hadoop.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
       <exclusions>
         <exclusion>
@@ -112,6 +117,11 @@
           <artifactId>jersey-json</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>${commons-collections.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make missing `shuffle-server` dependencies explicit in `server/pom.xml`.

### Why are the changes needed?
The `shuffle-server` module has dependencies that are not explicitly stated in the `pom.xml`, but transitively available. Notably, these are `commons-collections` and `hadoop-common`:
https://github.com/apache/incubator-uniffle/blob/866f5ff121948e2144729300a0f5cb03510db29d/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java#L27-L29

Run
```
./mvnw dependency:tree -pl org.apache.uniffle:shuffle-server -am
```
to see the dependency tree:
```
[INFO] -----------------< org.apache.uniffle:shuffle-server >------------------
[INFO] Building Apache Uniffle Server 0.9.0-SNAPSHOT                      [6/6]
[INFO]   from server/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] …
[INFO] --- dependency:2.10:tree (default-cli) @ shuffle-server ---
[INFO] org.apache.uniffle:shuffle-server:jar:0.9.0-SNAPSHOT
[INFO] …
[INFO] +- org.apache.hadoop:hadoop-minicluster:jar:2.8.5:test
[INFO] |  +- org.apache.hadoop:hadoop-common:test-jar:tests:2.8.5:test
[INFO] …
[INFO] |  |  +- commons-collections:commons-collections:jar:3.2.2:provided
[INFO] …
[INFO] |  +- org.apache.hadoop:hadoop-common:jar:2.8.5:provided
```

Both dependencies are available through `org.apache.hadoop:hadoop-minicluster` as `provided`.

However, with `-Ptez`, the dependency tree changes in such a way that those transitive dependency become available only in `test` scope, breaking compilation of the `shuffle-server` module:
```
./mvnw dependency:tree -pl org.apache.uniffle:shuffle-server -am -Ptez
```
```
[INFO] -----------------< org.apache.uniffle:shuffle-server >------------------
[INFO] Building Apache Uniffle Server 0.9.0-SNAPSHOT                      [6/6]
[INFO]   from server/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] …
[INFO] --- dependency:2.10:tree (default-cli) @ shuffle-server ---
[INFO] org.apache.uniffle:shuffle-server:jar:0.9.0-SNAPSHOT
[INFO] …
[INFO] +- org.apache.hadoop:hadoop-minicluster:jar:2.8.5:test
[INFO] …
[INFO] |  |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] …
[INFO] |  +- org.apache.hadoop:hadoop-common:jar:2.8.5:compile
```

The required dependencies are now in `compile` scope under a `test` scope dependency. The `mvnw` command line build tool seems robust against this, which is why CI works just fine. But IntelliJ IDE seems to handle those dependency trees literally and compilation breaks.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually.