### PR TITLE
[MINOR] Update dashboard pom.xml to take arguments for node and npm download locations

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -26,6 +26,11 @@
 
     <artifactId>dashboard</artifactId>
     <name>Apache Uniffle Dashboard</name>
+    
+    <properties>
+        <nodeDownloadRoot>https://nodejs.org/dist/</nodeDownloadRoot>
+        <npmDownloadRoot>https://registry.npmjs.org/npm/-/</npmDownloadRoot>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -50,7 +55,8 @@
                         <configuration>
                             <nodeVersion>v14.21.3</nodeVersion>
                             <npmVersion>6.14.18</npmVersion>
-                            <nodeDownloadRoot>https://nodejs.org/dist/</nodeDownloadRoot>
+                            <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
+                            <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
                         </configuration>
                     </execution>
                     <!-- Execute the script to remove node_modules and package-lock.json -->

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -55,8 +55,8 @@
                         <configuration>
                             <nodeVersion>v14.21.3</nodeVersion>
                             <npmVersion>6.14.18</npmVersion>
-                            <nodeDownloadRoot>${nodeDownloadRoot}</nodeDownloadRoot>
-                            <npmDownloadRoot>${npmDownloadRoot}</npmDownloadRoot>
+                            <nodeDownloadRoot>${nodeRepositoryUrl}</nodeDownloadRoot>
+                            <npmDownloadRoot>${npmRepositoryUrl}</npmDownloadRoot>
                         </configuration>
                     </execution>
                     <!-- Execute the script to remove node_modules and package-lock.json -->

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -28,8 +28,8 @@
     <name>Apache Uniffle Dashboard</name>
     
     <properties>
-        <nodeDownloadRoot>https://nodejs.org/dist/</nodeDownloadRoot>
-        <npmDownloadRoot>https://registry.npmjs.org/npm/-/</npmDownloadRoot>
+        <nodeRepositoryUrl>https://nodejs.org/dist/</nodeRepositoryUrl>
+        <npmRepositoryUrl>https://registry.npmjs.org/npm/-/</npmRepositoryUrl>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

When building the dashboard from within an environment without direct internet access you may need to setup a mirror for node and npm download.

This change adds these as args to build like so: `-PnodeRepositoryUrl=https://nodeDownloadLocation -PnpmRepositoryUrl=https://npmDownloadLocation`

The defaults are added as the default args as per https://github.com/eirslett/frontend-maven-plugin

### Why are the changes needed?

Enables build in more environments

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?


No.

### How was this patch tested?
 
Tested build 
