### PR TITLE
[#1472][FOLLOWUP] fix(client): Fix IllegalReferenceCountException issues when exceptions happened in clientReadHandler.readShuffleData()

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -269,6 +269,10 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     // because PlatformDependent.freeDirectBuffer can only release the ByteBuffer with cleaner.
     if (sdr != null) {
       sdr.release();
+      // We set sdr to null here to prevent IllegalReferenceCountException that could occur
+      // if sdr.release() is called multiple times in the close() method,
+      // when an exception is thrown by clientReadHandler.readShuffleData().
+      sdr = null;
     }
     sdr = clientReadHandler.readShuffleData();
     readDataTime.addAndGet(System.currentTimeMillis() - start);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix IllegalReferenceCountException issues when exceptions happened in clientReadHandler.readShuffleData().

### Why are the changes needed?

A follow-up PR for: https://github.com/apache/incubator-uniffle/pull/1522

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
