### PR TITLE
[#1472][part-6] fix(netty): Make UTs truly test Netty mode

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -165,7 +165,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       Function<String, Boolean> taskFailureCallback,
       ShuffleHandleInfo shuffleHandleInfo,
       TaskContext context) {
-    LOG.warn("RssShuffle start write taskAttemptId data" + taskAttemptId);
+    LOG.info("RssShuffle start write taskAttemptId data" + taskAttemptId);
     this.shuffleManager = shuffleManager;
     this.appId = appId;
     this.shuffleId = shuffleId;

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleWriteClientImplTest.java
@@ -83,7 +83,7 @@ public class ShuffleWriteClientImplTest {
     List<ShuffleBlockInfo> shuffleBlockInfoList =
         Lists.newArrayList(
             new ShuffleBlockInfo(
-                0, 0, 10, 10, 10, new byte[] {1}, shuffleServerInfoList, 10, 100, 0));
+                0, 0, 10, 10, 10, new byte[] {10}, shuffleServerInfoList, 10, 100, 0));
 
     // It should directly exit and wont do rpc request.
     Awaitility.await()
@@ -123,7 +123,7 @@ public class ShuffleWriteClientImplTest {
     List<ShuffleBlockInfo> shuffleBlockInfoList =
         Lists.newArrayList(
             new ShuffleBlockInfo(
-                0, 0, 10, 10, 10, new byte[] {1}, shuffleServerInfoList, 10, 100, 0));
+                0, 0, 10, 10, 10, new byte[] {10}, shuffleServerInfoList, 10, 100, 0));
     SendShuffleDataResult result =
         spyClient.sendShuffleData("appId", shuffleBlockInfoList, () -> false);
 
@@ -202,7 +202,7 @@ public class ShuffleWriteClientImplTest {
     List<ShuffleBlockInfo> shuffleBlockInfoList =
         Lists.newArrayList(
             new ShuffleBlockInfo(
-                0, 0, 10, 10, 10, new byte[] {1}, shuffleServerInfoList, 10, 100, 0));
+                0, 0, 10, 10, 10, new byte[] {10}, shuffleServerInfoList, 10, 100, 0));
     SendShuffleDataResult result =
         spyClient.sendShuffleData(appId, shuffleBlockInfoList, () -> false);
     assertEquals(0, result.getFailedBlockIds().size());
@@ -248,7 +248,7 @@ public class ShuffleWriteClientImplTest {
     List<ShuffleBlockInfo> shuffleBlockInfoList2 =
         Lists.newArrayList(
             new ShuffleBlockInfo(
-                0, 0, 10, 10, 10, new byte[] {1}, shuffleServerInfoList2, 10, 100, 0));
+                0, 0, 10, 10, 10, new byte[] {10}, shuffleServerInfoList2, 10, 100, 0));
     result = spyClient.sendShuffleData(appId, shuffleBlockInfoList2, () -> false);
     assertEquals(0, result.getFailedBlockIds().size());
     assertEquals(1, spyClient.getDefectiveServers().size());

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.uniffle.proto.RssProtos;
 
 public class ShuffleServerInfo implements Serializable {
@@ -33,11 +35,19 @@ public class ShuffleServerInfo implements Serializable {
 
   private int nettyPort = -1;
 
-  // Only for test
+  @VisibleForTesting
   public ShuffleServerInfo(String host, int port) {
     this.id = host + "-" + port;
     this.host = host;
     this.grpcPort = port;
+  }
+
+  @VisibleForTesting
+  public ShuffleServerInfo(String host, int grpcPort, int nettyPort) {
+    this.id = host + "-" + grpcPort + "-" + nettyPort;
+    this.host = host;
+    this.grpcPort = grpcPort;
+    this.nettyPort = nettyPort;
   }
 
   public ShuffleServerInfo(String id, String host, int port) {

--- a/common/src/main/java/org/apache/uniffle/common/netty/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/TransportFrameDecoder.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.common.netty;
 
 import java.util.LinkedList;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
@@ -81,6 +82,7 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
     }
   }
 
+  @VisibleForTesting
   static boolean shouldRelease(Message msg) {
     if (msg == null || msg.body() == null || msg.body().byteBuf() == null) {
       return true;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AccessClusterTest.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.client.factory.CoordinatorClientFactory;
 import org.apache.uniffle.client.request.RssAccessClusterRequest;
 import org.apache.uniffle.client.response.RssAccessClusterResponse;
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.AccessManager;
@@ -146,7 +147,7 @@ public class AccessClusterTest extends CoordinatorTestBase {
             + "org.apache.uniffle.coordinator.access.checker.AccessClusterLoadChecker");
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
@@ -166,8 +167,10 @@ public class AccessClusterTest extends CoordinatorTestBase {
     assertEquals(StatusCode.ACCESS_DENIED, response.getStatusCode());
     assertTrue(response.getMessage().startsWith("Denied by AccessClusterLoadChecker"));
 
-    shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + 2);
-    shuffleServerConf.setInteger("rss.jetty.http.port", 18082);
+    shuffleServerConf.setInteger(
+        "rss.rpc.server.port", shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 2);
+    shuffleServerConf.setInteger(
+        "rss.jetty.http.port", shuffleServerConf.getInteger(ShuffleServerConf.JETTY_HTTP_PORT) + 1);
     ShuffleServer shuffleServer = new ShuffleServer(shuffleServerConf);
     shuffleServer.start();
     Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/AssignmentWithTagsTest.java
@@ -39,6 +39,7 @@ import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleWriteClientImpl;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShuffleAssignmentsInfo;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
@@ -79,7 +80,7 @@ public class AssignmentWithTagsTest extends CoordinatorTestBase {
 
   private static void createAndStartShuffleServerWithTags(Set<String> tags, File tmpDir)
       throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 4000);
 
     File dataDir1 = new File(tmpDir, "data1");
@@ -108,7 +109,7 @@ public class AssignmentWithTagsTest extends CoordinatorTestBase {
         ports.get(1));
 
     ShuffleServer server = new ShuffleServer(shuffleServerConf);
-    shuffleServers.add(server);
+    grpcShuffleServers.add(server);
     server.start();
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/CoordinatorAssignmentTest.java
@@ -43,6 +43,7 @@ import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.ReconfigurableBase;
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.SimpleClusterManager;
 import org.apache.uniffle.server.ShuffleServer;
@@ -83,9 +84,9 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
     createCoordinatorServer(coordinatorConf2);
 
     for (int i = 0; i < SERVER_NUM; i++) {
-      ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-      File dataDir1 = new File(tmpDir, "data1");
-      String basePath = dataDir1.getAbsolutePath();
+      ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+      File dataDir = new File(tmpDir, "data" + i);
+      String basePath = dataDir.getAbsolutePath();
       shuffleServerConf.setString(
           ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
       shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
@@ -252,7 +253,7 @@ public class CoordinatorAssignmentTest extends CoordinatorTestBase {
     shuffleWriteClient.registerCoordinators(COORDINATOR_QUORUM);
     Set<String> excludeServer = Sets.newConcurrentHashSet();
     List<ShuffleServer> excludeShuffleServer =
-        shuffleServers.stream().limit(3).collect(Collectors.toList());
+        grpcShuffleServers.stream().limit(3).collect(Collectors.toList());
     excludeShuffleServer.stream().map(ss -> ss.getId()).peek(excludeServer::add);
     ShuffleAssignmentsInfo shuffleAssignmentsInfo =
         shuffleWriteClient.getShuffleAssignments(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckCoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HealthCheckCoordinatorGrpcTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.uniffle.client.request.RssGetShuffleAssignmentsRequest;
 import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
 import org.apache.uniffle.common.ServerStatus;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -72,7 +73,7 @@ public class HealthCheckCoordinatorGrpcTest extends CoordinatorTestBase {
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 3000);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     shuffleServerConf.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
@@ -83,8 +84,12 @@ public class HealthCheckCoordinatorGrpcTest extends CoordinatorTestBase {
     shuffleServerConf.setDouble(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, maxUsage);
     shuffleServerConf.setLong(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1000L);
     createShuffleServer(shuffleServerConf);
-    shuffleServerConf.setInteger(ShuffleServerConf.RPC_SERVER_PORT, SHUFFLE_SERVER_PORT + 1);
-    shuffleServerConf.setInteger(ShuffleServerConf.JETTY_HTTP_PORT, 18081);
+    shuffleServerConf.setInteger(
+        ShuffleServerConf.RPC_SERVER_PORT,
+        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 1);
+    shuffleServerConf.setInteger(
+        ShuffleServerConf.JETTY_HTTP_PORT,
+        shuffleServerConf.getInteger(ShuffleServerConf.JETTY_HTTP_PORT) + 1);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageFaultToleranceBase.java
@@ -21,51 +21,81 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssReportShuffleResultRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
 import org.apache.uniffle.client.response.CompressedShuffleBlock;
+import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBase {
-  private ShuffleServerGrpcClient shuffleServerClient;
+  protected ShuffleServerGrpcClient grpcShuffleServerClient;
+  protected ShuffleServerGrpcNettyClient nettyShuffleServerClient;
+  protected static ShuffleServerConf grpcShuffleServerConfig;
+  protected static ShuffleServerConf nettyShuffleServerConfig;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/multi_storage_fault";
 
   @BeforeEach
-  public void createClient() {
+  public void createClient() throws Exception {
     ShuffleServerClientFactory.getInstance().cleanupCache();
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @AfterEach
   public void closeClient() {
-    shuffleServerClient.close();
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
   abstract void makeChaos();
 
-  @Test
-  public void fallbackTest() throws Exception {
+  private static Stream<Arguments> fallbackTestProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fallbackTestProvider")
+  private void fallbackTest(boolean isNettyMode) throws Exception {
     String appId = "fallback_test_" + this.getClass().getSimpleName();
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Map<Integer, List<Integer>> map = Maps.newHashMap();
@@ -75,8 +105,9 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
     final List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 40, 2 * 1024 * 1024, blockBitmap, expectedData);
     makeChaos();
-    sendSinglePartitionToShuffleServer(appId, 0, 0, 0, blocks);
-    validateResult(appId, 0, 0, blockBitmap, Roaring64NavigableMap.bitmapOf(0), expectedData);
+    sendSinglePartitionToShuffleServer(appId, 0, 0, 0, blocks, isNettyMode);
+    validateResult(
+        appId, 0, 0, blockBitmap, Roaring64NavigableMap.bitmapOf(0), expectedData, isNettyMode);
   }
 
   private void registerShuffle(String appId, Map<Integer, List<Integer>> registerMap) {
@@ -88,22 +119,30 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
                 entry.getKey(),
                 Lists.newArrayList(new PartitionRange(partition, partition)),
                 REMOTE_STORAGE);
-        shuffleServerClient.registerShuffle(rr);
+        grpcShuffleServerClient.registerShuffle(rr);
       }
     }
   }
 
   private void sendSinglePartitionToShuffleServer(
-      String appId, int shuffle, int partition, long taskAttemptId, List<ShuffleBlockInfo> blocks) {
+      String appId,
+      int shuffle,
+      int partition,
+      long taskAttemptId,
+      List<ShuffleBlockInfo> blocks,
+      boolean isNettyMode) {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
     Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleToBlocks = Maps.newHashMap();
     partitionToBlocks.put(partition, blocks);
     shuffleToBlocks.put(shuffle, partitionToBlocks);
     RssSendShuffleDataRequest rs = new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rs);
     RssSendCommitRequest rc = new RssSendCommitRequest(appId, shuffle);
-    shuffleServerClient.sendCommit(rc);
     RssFinishShuffleRequest rf = new RssFinishShuffleRequest(appId, shuffle);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rs);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
+    shuffleServerClient.sendCommit(rc);
     shuffleServerClient.finishShuffle(rf);
 
     Map<Integer, List<Long>> partitionToBlockIds = Maps.newHashMap();
@@ -120,7 +159,16 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
       int partitionId,
       Roaring64NavigableMap blockBitmap,
       Roaring64NavigableMap taskBitmap,
-      Map<Long, byte[]> expectedData) {
+      Map<Long, byte[]> expectedData,
+      boolean isNettyMode) {
+    ShuffleServerInfo ssi =
+        isNettyMode
+            ? new ShuffleServerInfo(
+                LOCALHOST,
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
+            : new ShuffleServerInfo(
+                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
     ShuffleReadClientImpl readClient =
         ShuffleClientFactory.newReadBuilder()
             .storageType(StorageType.LOCALFILE_HDFS.name())
@@ -134,8 +182,7 @@ public abstract class HybridStorageFaultToleranceBase extends ShuffleReadWriteBa
             .basePath(REMOTE_STORAGE)
             .blockIdBitmap(blockBitmap)
             .taskIdBitmap(taskBitmap)
-            .shuffleServerInfoList(
-                Lists.newArrayList(new ShuffleServerInfo(LOCALHOST, SHUFFLE_SERVER_PORT)))
+            .shuffleServerInfoList(Lists.newArrayList(ssi))
             .hadoopConf(conf)
             .build();
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageHadoopFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageHadoopFallbackTest.java
@@ -21,8 +21,16 @@ import java.io.File;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
+import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -34,8 +42,26 @@ public class HybridStorageHadoopFallbackTest extends HybridStorageFaultTolerance
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     final CoordinatorConf coordinatorConf = getCoordinatorConf();
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createCoordinatorServer(coordinatorConf);
+
     String basePath = generateBasePath(tmpDir);
+
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, basePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, basePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setDouble(ShuffleServerConf.CLEANUP_THRESHOLD, 0.0);
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
@@ -48,7 +74,23 @@ public class HybridStorageHadoopFallbackTest extends HybridStorageFaultTolerance
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setLong(
         ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 1L * 1024L * 1024L);
-    createAndStartServers(shuffleServerConf, coordinatorConf);
+    return shuffleServerConf;
+  }
+
+  @BeforeEach
+  public void createClient() throws Exception {
+    ShuffleServerClientFactory.getInstance().cleanupCache();
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @Override

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/HybridStorageLocalFileFallbackTest.java
@@ -21,8 +21,16 @@ import java.io.File;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.client.factory.ShuffleServerClientFactory;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
+import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.storage.HybridStorageManager;
@@ -37,8 +45,42 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     final CoordinatorConf coordinatorConf = getCoordinatorConf();
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createCoordinatorServer(coordinatorConf);
+
     String basePath = generateBasePath(tmpDir);
+
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, basePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, basePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  @BeforeEach
+  public void createClient() throws Exception {
+    ShuffleServerClientFactory.getInstance().cleanupCache();
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setDouble(ShuffleServerConf.CLEANUP_THRESHOLD, 0.0);
     shuffleServerConf.setDouble(ShuffleServerConf.HIGH_WATER_MARK_OF_WRITE, 100.0);
     shuffleServerConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 100);
@@ -54,14 +96,14 @@ public class HybridStorageLocalFileFallbackTest extends HybridStorageFaultTolera
     shuffleServerConf.setString(
         ShuffleServerConf.HYBRID_STORAGE_FALLBACK_STRATEGY_CLASS,
         LocalStorageManagerFallbackStrategy.class.getCanonicalName());
-    createAndStartServers(shuffleServerConf, coordinatorConf);
+    return shuffleServerConf;
   }
 
   @Override
   public void makeChaos() {
     LocalStorageManager warmStorageManager =
         (LocalStorageManager)
-            ((HybridStorageManager) shuffleServers.get(0).getStorageManager())
+            ((HybridStorageManager) grpcShuffleServers.get(0).getStorageManager())
                 .getWarmStorageManager();
     for (Storage storage : warmStorageManager.getStorages()) {
       LocalStorage localStorage = (LocalStorage) storage;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
@@ -42,7 +43,12 @@ import org.apache.uniffle.storage.util.StorageType;
 
 public abstract class IntegrationTestBase extends HadoopTestBase {
 
-  protected static final int SHUFFLE_SERVER_PORT = 20001;
+  /** Should not be accessed directly, use `getNextRpcServerPort` instead */
+  private static final int SHUFFLE_SERVER_INITIAL_PORT = 20001;
+
+  /** Should not be accessed directly, use `getNextJettyServerPort` instead */
+  private static final int JETTY_SERVER_INITIAL_PORT = 18080;
+
   protected static final String LOCALHOST;
 
   static {
@@ -58,14 +64,17 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   protected static final int JETTY_PORT_1 = 19998;
   protected static final int JETTY_PORT_2 = 20040;
   protected static final String COORDINATOR_QUORUM = LOCALHOST + ":" + COORDINATOR_PORT_1;
-  protected static final String SHUFFLE_SERVER_METRICS_URL =
-      "http://127.0.0.1:18080/metrics/server";
 
-  protected static List<ShuffleServer> shuffleServers = Lists.newArrayList();
+  protected static List<ShuffleServer> grpcShuffleServers = Lists.newArrayList();
+  protected static List<ShuffleServer> nettyShuffleServers = Lists.newArrayList();
   protected static List<CoordinatorServer> coordinators = Lists.newArrayList();
 
-  protected static final int NETTY_PORT = 21000;
-  protected static AtomicInteger nettyPortCounter = new AtomicInteger();
+  /** Should not be accessed directly, use `getNextNettyServerPort` instead */
+  private static final int NETTY_INITIAL_PORT = 21000;
+
+  private static AtomicInteger serverRpcPortCounter = new AtomicInteger();
+  private static AtomicInteger nettyPortCounter = new AtomicInteger();
+  private static AtomicInteger jettyPortCounter = new AtomicInteger();
 
   static @TempDir File tempDir;
 
@@ -73,7 +82,10 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     for (CoordinatorServer coordinator : coordinators) {
       coordinator.start();
     }
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
+      shuffleServer.start();
+    }
+    for (ShuffleServer shuffleServer : nettyShuffleServers) {
       shuffleServer.start();
     }
   }
@@ -83,10 +95,14 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     for (CoordinatorServer coordinator : coordinators) {
       coordinator.stopServer();
     }
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       shuffleServer.stopServer();
     }
-    shuffleServers = Lists.newArrayList();
+    for (ShuffleServer shuffleServer : nettyShuffleServers) {
+      shuffleServer.stopServer();
+    }
+    grpcShuffleServers = Lists.newArrayList();
+    nettyShuffleServers = Lists.newArrayList();
     coordinators = Lists.newArrayList();
     ShuffleServerMetrics.clear();
     CoordinatorMetrics.clear();
@@ -110,9 +126,9 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
         CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, 5);
   }
 
-  protected static ShuffleServerConf getShuffleServerConf() throws Exception {
+  protected static ShuffleServerConf getShuffleServerConf(ServerType serverType) throws Exception {
     ShuffleServerConf serverConf = new ShuffleServerConf();
-    serverConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT);
+    serverConf.setInteger("rss.rpc.server.port", getNextRpcServerPort());
     serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
     serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
     serverConf.setString("rss.server.buffer.capacity", "671088640");
@@ -122,7 +138,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
     serverConf.setString("rss.server.heartbeat.delay", "1000");
     serverConf.setString("rss.server.heartbeat.interval", "1000");
-    serverConf.setInteger("rss.jetty.http.port", 18080);
+    serverConf.setInteger("rss.jetty.http.port", getNextJettyServerPort());
     serverConf.setInteger("rss.jetty.corePool.size", 64);
     serverConf.setInteger("rss.rpc.executor.size", 10);
     serverConf.setString("rss.server.hadoop.dfs.replication", "2");
@@ -130,10 +146,23 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     serverConf.setBoolean("rss.server.health.check.enable", false);
     serverConf.setBoolean(ShuffleServerConf.RSS_TEST_MODE_ENABLE, true);
     serverConf.set(ShuffleServerConf.SERVER_TRIGGER_FLUSH_CHECK_INTERVAL, 500L);
-    serverConf.setInteger(
-        ShuffleServerConf.NETTY_SERVER_PORT, NETTY_PORT + nettyPortCounter.getAndIncrement());
-    serverConf.setString("rss.server.tags", "GRPC,GRPC_NETTY");
+    serverConf.set(ShuffleServerConf.RPC_SERVER_TYPE, serverType);
+    if (serverType == ServerType.GRPC_NETTY) {
+      serverConf.setInteger(ShuffleServerConf.NETTY_SERVER_PORT, getNextNettyServerPort());
+    }
     return serverConf;
+  }
+
+  public static int getNextRpcServerPort() {
+    return SHUFFLE_SERVER_INITIAL_PORT + serverRpcPortCounter.getAndIncrement();
+  }
+
+  public static int getNextJettyServerPort() {
+    return JETTY_SERVER_INITIAL_PORT + jettyPortCounter.getAndIncrement();
+  }
+
+  public static int getNextNettyServerPort() {
+    return NETTY_INITIAL_PORT + nettyPortCounter.getAndIncrement();
   }
 
   protected static void createCoordinatorServer(CoordinatorConf coordinatorConf) throws Exception {
@@ -141,11 +170,31 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   }
 
   protected static void createShuffleServer(ShuffleServerConf serverConf) throws Exception {
-    shuffleServers.add(new ShuffleServer(serverConf));
+    ServerType serverType = serverConf.get(ShuffleServerConf.RPC_SERVER_TYPE);
+    switch (serverType) {
+      case GRPC:
+        grpcShuffleServers.add(new ShuffleServer(serverConf));
+        break;
+      case GRPC_NETTY:
+        nettyShuffleServers.add(new ShuffleServer(serverConf));
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported server type " + serverType);
+    }
   }
 
   protected static void createMockedShuffleServer(ShuffleServerConf serverConf) throws Exception {
-    shuffleServers.add(new MockedShuffleServer(serverConf));
+    ServerType serverType = serverConf.get(ShuffleServerConf.RPC_SERVER_TYPE);
+    switch (serverType) {
+      case GRPC:
+        grpcShuffleServers.add(new MockedShuffleServer(serverConf));
+        break;
+      case GRPC_NETTY:
+        nettyShuffleServers.add(new MockedShuffleServer(serverConf));
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported server type " + serverType);
+    }
   }
 
   protected static void createAndStartServers(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -42,6 +42,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.metrics.TestUtils;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
 import org.apache.uniffle.coordinator.ServerNode;
@@ -73,6 +74,11 @@ public class ServletTest extends IntegrationTestBase {
   private static CoordinatorServer coordinatorServer;
   private ObjectMapper objectMapper = new ObjectMapper();
 
+  private static int rpcPort1;
+  private static int rpcPort2;
+  private static int rpcPort3;
+  private static int rpcPort4;
+
   @BeforeAll
   public static void setUp(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = new CoordinatorConf();
@@ -81,7 +87,7 @@ public class ServletTest extends IntegrationTestBase {
     coordinatorConf.set(RssBaseConf.RPC_SERVER_PORT, 12346);
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     shuffleServerConf.set(RssBaseConf.RSS_COORDINATOR_QUORUM, "127.0.0.1:12346");
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_SHUTDOWN, false);
     File dataDir1 = new File(tmpDir, "data1");
@@ -90,27 +96,37 @@ public class ServletTest extends IntegrationTestBase {
         Lists.newArrayList(dataDir1.getAbsolutePath(), dataDir2.getAbsolutePath());
     shuffleServerConf.setString(RssBaseConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(RssBaseConf.RSS_STORAGE_BASE_PATH, basePath);
+    rpcPort1 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
     File dataDir3 = new File(tmpDir, "data3");
     File dataDir4 = new File(tmpDir, "data4");
     basePath = Lists.newArrayList(dataDir3.getAbsolutePath(), dataDir4.getAbsolutePath());
     shuffleServerConf.set(RssBaseConf.RSS_STORAGE_BASE_PATH, basePath);
-    shuffleServerConf.set(RssBaseConf.RPC_SERVER_PORT, SHUFFLE_SERVER_PORT + 1);
+    shuffleServerConf.set(
+        RssBaseConf.RPC_SERVER_PORT,
+        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 1);
     shuffleServerConf.set(RssBaseConf.JETTY_HTTP_PORT, 18081);
+    rpcPort2 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
     File dataDir5 = new File(tmpDir, "data5");
     File dataDir6 = new File(tmpDir, "data6");
     basePath = Lists.newArrayList(dataDir5.getAbsolutePath(), dataDir6.getAbsolutePath());
     shuffleServerConf.set(RssBaseConf.RSS_STORAGE_BASE_PATH, basePath);
-    shuffleServerConf.set(RssBaseConf.RPC_SERVER_PORT, SHUFFLE_SERVER_PORT + 2);
+    shuffleServerConf.set(
+        RssBaseConf.RPC_SERVER_PORT,
+        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 1);
     shuffleServerConf.set(RssBaseConf.JETTY_HTTP_PORT, 18082);
+    rpcPort3 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
     File dataDir7 = new File(tmpDir, "data7");
     File dataDir8 = new File(tmpDir, "data8");
     basePath = Lists.newArrayList(dataDir7.getAbsolutePath(), dataDir8.getAbsolutePath());
     shuffleServerConf.set(RssBaseConf.RSS_STORAGE_BASE_PATH, basePath);
-    shuffleServerConf.set(RssBaseConf.RPC_SERVER_PORT, SHUFFLE_SERVER_PORT + 3);
+    shuffleServerConf.set(
+        RssBaseConf.RPC_SERVER_PORT,
+        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 1);
     shuffleServerConf.set(RssBaseConf.JETTY_HTTP_PORT, 18083);
+    rpcPort4 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
     startServers();
     coordinatorServer = coordinators.get(0);
@@ -121,13 +137,13 @@ public class ServletTest extends IntegrationTestBase {
 
   @Test
   public void testGetSingleNode() throws Exception {
-    ShuffleServer shuffleServer = shuffleServers.get(0);
+    ShuffleServer shuffleServer = grpcShuffleServers.get(0);
     String content = TestUtils.httpGet(String.format(SINGLE_NODE_URL, shuffleServer.getId()));
     Response<HashMap<String, Object>> response =
         objectMapper.readValue(content, new TypeReference<Response<HashMap<String, Object>>>() {});
     HashMap<String, Object> server = response.getData();
     assertEquals(0, response.getCode());
-    assertEquals(SHUFFLE_SERVER_PORT, Integer.parseInt(server.get("grpcPort").toString()));
+    assertEquals(rpcPort1, Integer.parseInt(server.get("grpcPort").toString()));
     assertEquals(ServerStatus.ACTIVE.toString(), server.get("status"));
   }
 
@@ -140,11 +156,9 @@ public class ServletTest extends IntegrationTestBase {
     List<HashMap<String, Object>> serverList = response.getData();
     assertEquals(0, response.getCode());
     assertEquals(4, serverList.size());
-    assertEquals(
-        SHUFFLE_SERVER_PORT, Integer.parseInt(serverList.get(0).get("grpcPort").toString()));
+    assertEquals(rpcPort1, Integer.parseInt(serverList.get(0).get("grpcPort").toString()));
     assertEquals(ServerStatus.ACTIVE.toString(), serverList.get(0).get("status"));
-    assertEquals(
-        SHUFFLE_SERVER_PORT + 1, Integer.parseInt(serverList.get(1).get("grpcPort").toString()));
+    assertEquals(rpcPort2, Integer.parseInt(serverList.get(1).get("grpcPort").toString()));
     assertEquals(ServerStatus.ACTIVE.toString(), serverList.get(1).get("status"));
   }
 
@@ -152,8 +166,8 @@ public class ServletTest extends IntegrationTestBase {
   public void testLostNodesServlet() throws IOException {
     SimpleClusterManager clusterManager =
         (SimpleClusterManager) coordinatorServer.getClusterManager();
-    ShuffleServer shuffleServer3 = shuffleServers.get(2);
-    ShuffleServer shuffleServer4 = shuffleServers.get(3);
+    ShuffleServer shuffleServer3 = grpcShuffleServers.get(2);
+    ShuffleServer shuffleServer4 = grpcShuffleServers.get(3);
     Map<String, ServerNode> servers = clusterManager.getServers();
     servers.get(shuffleServer3.getId()).setTimestamp(System.currentTimeMillis() - 40000);
     servers.get(shuffleServer4.getId()).setTimestamp(System.currentTimeMillis() - 40000);
@@ -174,7 +188,7 @@ public class ServletTest extends IntegrationTestBase {
 
   @Test
   public void testDecommissionedNodeServlet() {
-    ShuffleServer shuffleServer = shuffleServers.get(1);
+    ShuffleServer shuffleServer = grpcShuffleServers.get(1);
     shuffleServer.decommission();
     Awaitility.await()
         .atMost(30, TimeUnit.SECONDS)
@@ -196,8 +210,8 @@ public class ServletTest extends IntegrationTestBase {
 
   @Test
   public void testUnhealthyNodesServlet() {
-    ShuffleServer shuffleServer3 = shuffleServers.get(2);
-    ShuffleServer shuffleServer4 = shuffleServers.get(3);
+    ShuffleServer shuffleServer3 = grpcShuffleServers.get(2);
+    ShuffleServer shuffleServer4 = grpcShuffleServers.get(3);
     shuffleServer3.markUnhealthy();
     shuffleServer4.markUnhealthy();
     List<String> expectShuffleIds = Arrays.asList(shuffleServer3.getId(), shuffleServer4.getId());
@@ -222,7 +236,7 @@ public class ServletTest extends IntegrationTestBase {
 
   @Test
   public void testDecommissionServlet() throws Exception {
-    ShuffleServer shuffleServer = shuffleServers.get(0);
+    ShuffleServer shuffleServer = grpcShuffleServers.get(0);
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
     DecommissionRequest decommissionRequest = new DecommissionRequest();
     decommissionRequest.setServerIds(Sets.newHashSet("not_exist_serverId"));
@@ -241,8 +255,7 @@ public class ServletTest extends IntegrationTestBase {
     assertEquals(0, response.getCode());
 
     // Register shuffle, avoid server exiting immediately.
-    ShuffleServerGrpcClient shuffleServerClient =
-        new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    ShuffleServerGrpcClient shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, rpcPort1);
     shuffleServerClient.registerShuffle(
         new RssRegisterShuffleRequest(
             "testDecommissionServlet_appId", 0, Lists.newArrayList(new PartitionRange(0, 1)), ""));
@@ -274,7 +287,7 @@ public class ServletTest extends IntegrationTestBase {
 
   @Test
   public void testDecommissionSingleNode() throws Exception {
-    ShuffleServer shuffleServer = shuffleServers.get(0);
+    ShuffleServer shuffleServer = grpcShuffleServers.get(0);
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
     String content =
         TestUtils.httpPost(String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, "not_exist_serverId"));
@@ -288,8 +301,7 @@ public class ServletTest extends IntegrationTestBase {
     assertEquals(0, response.getCode());
 
     // Register shuffle, avoid server exiting immediately.
-    ShuffleServerGrpcClient shuffleServerClient =
-        new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    ShuffleServerGrpcClient shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, rpcPort1);
     shuffleServerClient.registerShuffle(
         new RssRegisterShuffleRequest(
             "testDecommissionServlet_appId", 0, Lists.newArrayList(new PartitionRange(0, 1)), ""));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
@@ -139,52 +139,6 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
     return dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
   }
 
-  public static List<ShuffleDataSegment> readShuffleIndexSegments(
-      ShuffleServerGrpcClient shuffleServerClient,
-      String appId,
-      int shuffleId,
-      int partitionId,
-      int partitionNumPerRange,
-      int partitionNum,
-      int readBufferSize) {
-    // read index file
-    RssGetShuffleIndexRequest rgsir =
-        new RssGetShuffleIndexRequest(
-            appId, shuffleId, partitionId, partitionNumPerRange, partitionNum);
-    ShuffleIndexResult shuffleIndexResult =
-        shuffleServerClient.getShuffleIndex(rgsir).getShuffleIndexResult();
-    return new FixedSizeSegmentSplitter(readBufferSize).split(shuffleIndexResult);
-  }
-
-  public static ShuffleDataResult readShuffleData(
-      ShuffleServerGrpcClient shuffleServerClient,
-      String appId,
-      int shuffleId,
-      int partitionId,
-      int partitionNumPerRange,
-      int partitionNum,
-      int segmentIndex,
-      List<ShuffleDataSegment> sds) {
-    if (segmentIndex >= sds.size()) {
-      return new ShuffleDataResult();
-    }
-
-    // read shuffle data
-    ShuffleDataSegment segment = sds.get(segmentIndex);
-    RssGetShuffleDataRequest rgsdr =
-        new RssGetShuffleDataRequest(
-            appId,
-            shuffleId,
-            partitionId,
-            partitionNumPerRange,
-            partitionNum,
-            segment.getOffset(),
-            segment.getLength());
-
-    return new ShuffleDataResult(
-        shuffleServerClient.getShuffleData(rgsdr).getShuffleData(), segment.getBufferSegments());
-  }
-
   public static ShuffleDataResult readShuffleData(
       ShuffleServerGrpcClient shuffleServerClient,
       String appId,

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -21,18 +21,22 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.TestUtils;
 import org.apache.uniffle.client.api.ShuffleServerClient;
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
@@ -43,6 +47,9 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
@@ -63,7 +70,8 @@ import static org.mockito.Mockito.when;
 
 public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
 
-  private List<ShuffleServerClient> shuffleServerClients;
+  private List<ShuffleServerClient> grpcShuffleServerClients;
+  private List<ShuffleServerClient> nettyShuffleServerClients;
 
   private String remoteStoragePath = HDFS_URI + "rss/test";
 
@@ -71,35 +79,62 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
   public void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    shuffleServers.add(createServer(0, tmpDir));
-    shuffleServers.add(createServer(1, tmpDir));
-    shuffleServers.add(createServer(2, tmpDir));
+    grpcShuffleServers.add(createServer(0, tmpDir, ServerType.GRPC));
+    grpcShuffleServers.add(createServer(1, tmpDir, ServerType.GRPC));
+    grpcShuffleServers.add(createServer(2, tmpDir, ServerType.GRPC));
+    nettyShuffleServers.add(createServer(0, tmpDir, ServerType.GRPC_NETTY));
+    nettyShuffleServers.add(createServer(1, tmpDir, ServerType.GRPC_NETTY));
+    nettyShuffleServers.add(createServer(2, tmpDir, ServerType.GRPC_NETTY));
     startServers();
-    shuffleServerClients = new ArrayList<>();
-    for (ShuffleServer shuffleServer : shuffleServers) {
-      shuffleServerClients.add(
+    grpcShuffleServerClients = new ArrayList<>();
+    nettyShuffleServerClients = new ArrayList<>();
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
+      grpcShuffleServerClients.add(
           new ShuffleServerGrpcClient(shuffleServer.getIp(), shuffleServer.getGrpcPort()));
+    }
+    for (ShuffleServer shuffleServer : nettyShuffleServers) {
+      nettyShuffleServerClients.add(
+          new ShuffleServerGrpcNettyClient(
+              rssConf, LOCALHOST, shuffleServer.getGrpcPort(), shuffleServer.getNettyPort()));
     }
   }
 
   @AfterEach
   public void cleanEnv() throws Exception {
-    shuffleServerClients.forEach(
+    grpcShuffleServerClients.forEach(
+        (client) -> {
+          client.close();
+        });
+    nettyShuffleServerClients.forEach(
         (client) -> {
           client.close();
         });
     cleanCluster();
   }
 
-  @Test
-  public void testReadFaultTolerance() throws Exception {
+  private static Stream<Arguments> testReadFaultToleranceProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testReadFaultToleranceProvider")
+  private void testReadFaultTolerance(boolean isNettyMode) throws Exception {
+    ShuffleServerClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClients.get(1) : grpcShuffleServerClients.get(1);
+    List<ShuffleServerClient> shuffleServerClients =
+        isNettyMode ? nettyShuffleServerClients : grpcShuffleServerClients;
     String testAppId = "ShuffleServerFaultToleranceTest.testReadFaultTolerance";
     int shuffleId = 0;
     int partitionId = 0;
     RssRegisterShuffleRequest rrsr =
         new RssRegisterShuffleRequest(
             testAppId, shuffleId, Lists.newArrayList(new PartitionRange(0, 0)), remoteStoragePath);
-    registerShuffle(rrsr);
+    shuffleServerClients.forEach(
+        (client) -> {
+          client.registerShuffle(rrsr);
+        });
     Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
     Map<Long, byte[]> dataMap = Maps.newHashMap();
     Roaring64NavigableMap[] bitmaps = new Roaring64NavigableMap[1];
@@ -109,8 +144,9 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
 
     RssSendShuffleDataRequest rssdr =
         getRssSendShuffleDataRequest(testAppId, shuffleId, partitionId, blocks);
-    shuffleServerClients.get(1).sendShuffleData(rssdr);
+    shuffleServerClient.sendShuffleData(rssdr);
 
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     List<ShuffleServerInfo> shuffleServerInfoList = new ArrayList<>();
     for (ShuffleServer shuffleServer : shuffleServers) {
       shuffleServerInfoList.add(
@@ -151,10 +187,10 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
         createShuffleBlockList(shuffleId, partitionId, 0, 3, 25, expectBlockIds, dataMap, mockSSI);
 
     rssdr = getRssSendShuffleDataRequest(testAppId, shuffleId, partitionId, blocks2);
-    shuffleServerClients.get(1).sendShuffleData(rssdr);
+    shuffleServerClient.sendShuffleData(rssdr);
     RssSendCommitRequest commitRequest = new RssSendCommitRequest(testAppId, shuffleId);
-    shuffleServerClients.get(1).sendCommit(commitRequest);
-    waitFlush(testAppId, shuffleId);
+    shuffleServerClient.sendCommit(commitRequest);
+    waitFlush(testAppId, shuffleId, isNettyMode);
     request =
         mockCreateShuffleReadHandlerRequest(
             testAppId,
@@ -190,9 +226,9 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
           expectedData.put(block.getBlockId(), ByteBufUtils.readBytes(block.getData()));
         });
     rssdr = getRssSendShuffleDataRequest(testAppId, shuffleId, partitionId, blocks3);
-    shuffleServerClients.get(1).sendShuffleData(rssdr);
-    shuffleServerClients.get(1).sendCommit(commitRequest);
-    waitFlush(testAppId, shuffleId);
+    shuffleServerClient.sendShuffleData(rssdr);
+    shuffleServerClient.sendCommit(commitRequest);
+    waitFlush(testAppId, shuffleId, isNettyMode);
     request =
         mockCreateShuffleReadHandlerRequest(
             testAppId,
@@ -255,21 +291,15 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     return new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
   }
 
-  private void registerShuffle(RssRegisterShuffleRequest rrsr) {
-    shuffleServerClients.forEach(
-        (client) -> {
-          client.registerShuffle(rrsr);
-        });
-  }
-
-  public static MockedShuffleServer createServer(int id, File tmpDir) throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+  public static MockedShuffleServer createServer(int id, File tmpDir, ServerType serverType)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 40.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 600L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 3.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 8.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 2000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
     shuffleServerConf.set(ShuffleServerConf.DISK_CAPACITY, 1000000L);
     shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
@@ -279,17 +309,21 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     shuffleServerConf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 450L);
-    shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + 20 + id);
+    shuffleServerConf.setInteger(
+        "rss.rpc.server.port",
+        shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + 20 + id);
     shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     return new MockedShuffleServer(shuffleServerConf);
   }
 
-  protected void waitFlush(String appId, int shuffleId) throws InterruptedException {
+  protected void waitFlush(String appId, int shuffleId, boolean isNettyMode)
+      throws InterruptedException {
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     int retry = 0;
     while (true) {
       if (retry > 5) {
-        fail("Timeout for flush data");
+        fail(String.format("Timeout for flush data, isNettyMode=%s", isNettyMode));
       }
       ShuffleBuffer shuffleBuffer =
           shuffleServers.get(1).getShuffleBufferManager().getShuffleBuffer(appId, shuffleId, 0);
@@ -305,10 +339,14 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     for (CoordinatorServer coordinator : coordinators) {
       coordinator.stopServer();
     }
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       shuffleServer.stopServer();
     }
-    shuffleServers = Lists.newArrayList();
+    for (ShuffleServer shuffleServer : nettyShuffleServers) {
+      shuffleServer.stopServer();
+    }
+    grpcShuffleServers = Lists.newArrayList();
+    nettyShuffleServers = Lists.newArrayList();
     coordinators = Lists.newArrayList();
   }
 }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerInternalGrpcTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Lists;
 import io.grpc.StatusRuntimeException;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import org.apache.uniffle.client.response.RssCancelDecommissionResponse;
 import org.apache.uniffle.client.response.RssDecommissionResponse;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ServerStatus;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServer;
@@ -52,26 +54,34 @@ public class ShuffleServerInternalGrpcTest extends IntegrationTestBase {
   private ShuffleServerGrpcClient shuffleServerClient;
   private ShuffleServerInternalGrpcClient shuffleServerInternalClient;
 
+  private static int rpcPort1;
+
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     File dataDir1 = new File(tmpDir, "data1");
     String basePath = dataDir1.getAbsolutePath();
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_CHECK_INTERVAL, 500L);
+    rpcPort1 = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
     startServers();
   }
 
   @BeforeEach
   public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
-    shuffleServerInternalClient =
-        new ShuffleServerInternalGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, rpcPort1);
+    shuffleServerInternalClient = new ShuffleServerInternalGrpcClient(LOCALHOST, rpcPort1);
+  }
+
+  @AfterEach
+  public void closeClient() {
+    shuffleServerClient.close();
+    shuffleServerInternalClient.close();
   }
 
   @Test
@@ -82,7 +92,7 @@ public class ShuffleServerInternalGrpcTest extends IntegrationTestBase {
         new RssRegisterShuffleRequest(
             appId, shuffleId, Lists.newArrayList(new PartitionRange(0, 1)), ""));
 
-    ShuffleServer shuffleServer = shuffleServers.get(0);
+    ShuffleServer shuffleServer = grpcShuffleServers.get(0);
     RssDecommissionResponse response =
         shuffleServerInternalClient.decommission(new RssDecommissionRequest());
     assertEquals(StatusCode.SUCCESS, response.getStatusCode());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerOnRandomPortTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerOnRandomPortTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -37,33 +38,43 @@ public class ShuffleServerOnRandomPortTest extends CoordinatorTestBase {
     coordinatorConf.setLong("rss.coordinator.server.heartbeat.timeout", 3000);
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf grpcShuffleServerConf1 = buildShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf1);
+
+    ShuffleServerConf grpcShuffleServerConf2 = buildShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf2);
+
+    ShuffleServerConf nettyShuffleServerConf1 = buildShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf1);
+
+    ShuffleServerConf nettyShuffleServerConf2 = buildShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf2);
+
+    startServers();
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType) throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setInteger("rss.server.netty.port", 0);
     shuffleServerConf.setInteger("rss.rpc.server.port", 0);
     shuffleServerConf.setInteger("rss.random.port.min", 30000);
     shuffleServerConf.setInteger("rss.random.port.max", 40000);
-    createShuffleServer(shuffleServerConf);
-
-    shuffleServerConf.setInteger("rss.jetty.http.port", 18081);
-    createShuffleServer(shuffleServerConf);
-
-    startServers();
+    return shuffleServerConf;
   }
 
   @Test
   public void startStreamServerOnRandomPort() throws Exception {
     CoordinatorTestUtils.waitForRegister(coordinatorClient, 2);
     Thread.sleep(5000);
-    int actualPort = shuffleServers.get(0).getNettyPort();
+    int actualPort = nettyShuffleServers.get(0).getNettyPort();
     assertTrue(actualPort >= 30000 && actualPort < 40000);
-    actualPort = shuffleServers.get(1).getNettyPort();
+    actualPort = nettyShuffleServers.get(1).getNettyPort();
     assertTrue(actualPort >= 30000 && actualPort <= 40000);
 
     int maxRetries = 100;
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = buildShuffleServerConf(ServerType.GRPC_NETTY);
     // start netty server with already bind port
     shuffleServerConf.setInteger("rss.server.netty.port", actualPort);
-    shuffleServerConf.setInteger("rss.jetty.http.port", 18082);
     shuffleServerConf.setInteger("rss.port.max.retry", maxRetries);
     ShuffleServer ss = new ShuffleServer(shuffleServerConf);
     ss.start();
@@ -75,16 +86,15 @@ public class ShuffleServerOnRandomPortTest extends CoordinatorTestBase {
   public void startGrpcServerOnRandomPort() throws Exception {
     CoordinatorTestUtils.waitForRegister(coordinatorClient, 2);
     Thread.sleep(5000);
-    int actualPort = shuffleServers.get(0).getGrpcPort();
+    int actualPort = grpcShuffleServers.get(0).getGrpcPort();
     assertTrue(actualPort >= 30000 && actualPort < 40000);
-    actualPort = shuffleServers.get(1).getGrpcPort();
+    actualPort = grpcShuffleServers.get(1).getGrpcPort();
     assertTrue(actualPort >= 30000 && actualPort <= 40000);
 
     int maxRetries = 100;
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = buildShuffleServerConf(ServerType.GRPC);
     // start grpc server with already bind port
     shuffleServerConf.setInteger("rss.rpc.server.port", actualPort);
-    shuffleServerConf.setInteger("rss.jetty.http.port", 18083);
     shuffleServerConf.setInteger("rss.port.max.retry", maxRetries);
     ShuffleServer ss = new ShuffleServer(shuffleServerConf);
     ss.start();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfExceptionTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfExceptionTest.java
@@ -28,6 +28,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.handler.impl.MemoryClientReadHandler;
@@ -41,18 +42,21 @@ public class ShuffleServerWithLocalOfExceptionTest extends ShuffleReadWriteBase 
   private ShuffleServerGrpcClient shuffleServerClient;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/test";
 
+  private static int rpcPort;
+
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
+    rpcPort = shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT);
     createShuffleServer(shuffleServerConf);
 
     startServers();
@@ -60,7 +64,7 @@ public class ShuffleServerWithLocalOfExceptionTest extends ShuffleReadWriteBase 
 
   @BeforeEach
   public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, rpcPort);
   }
 
   @AfterEach
@@ -82,7 +86,7 @@ public class ShuffleServerWithLocalOfExceptionTest extends ShuffleReadWriteBase 
             150,
             shuffleServerClient,
             Roaring64NavigableMap.bitmapOf());
-    shuffleServers.get(0).stopServer();
+    grpcShuffleServers.get(0).stopServer();
     try {
       memoryClientReadHandler.readShuffleData();
       fail("Should throw connection exception directly.");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -32,21 +33,30 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.segment.LocalOrderSegmentSplitter;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -55,37 +65,70 @@ import org.apache.uniffle.storage.util.StorageType;
 
 import static org.apache.uniffle.common.ShuffleDataDistributionType.LOCAL_ORDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /** This class is to test the local_order shuffle-data distribution */
 public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase {
 
-  private ShuffleServerGrpcClient shuffleServerClient;
+  private ShuffleServerGrpcClient grpcShuffleServerClient;
+  private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
+  private static ShuffleServerConf grpcShuffleServerConfig;
+  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    String grpcBasePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    File dataDir3 = new File(tmpDir, "data3");
+    File dataDir4 = new File(tmpDir, "data4");
+    String nettyBasePath = dataDir3.getAbsolutePath() + "," + dataDir4.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    return shuffleServerConf;
   }
 
   @BeforeEach
-  public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  public void createClient() throws Exception {
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @AfterEach
   public void closeClient() {
-    shuffleServerClient.close();
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
   public static Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> createTestDataWithMultiMapIdx(
@@ -129,8 +172,15 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
     return partitionToBlocks;
   }
 
-  @Test
-  public void testWriteAndReadWithSpecifiedMapRange() throws Exception {
+  private static Stream<Arguments> testWriteAndReadWithSpecifiedMapRangeProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testWriteAndReadWithSpecifiedMapRangeProvider")
+  private void testWriteAndReadWithSpecifiedMapRange(boolean isNettyMode) throws Exception {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String testAppId = "testWriteAndReadWithSpecifiedMapRange";
 
     for (int i = 0; i < 4; i++) {
@@ -169,7 +219,8 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
 
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     // Flush the data to file
     RssSendCommitRequest rscr = new RssSendCommitRequest(testAppId, 0);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -29,61 +30,111 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
 
-  private ShuffleServerGrpcClient shuffleServerClient;
+  private ShuffleServerGrpcClient grpcShuffleServerClient;
+  private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
+  private static ShuffleServerConf grpcShuffleServerConfig;
+  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    String grpcBasePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    File dataDir3 = new File(tmpDir, "data3");
+    File dataDir4 = new File(tmpDir, "data4");
+    String nettyBasePath = dataDir3.getAbsolutePath() + "," + dataDir4.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
     shuffleServerConf.setString("rss.server.app.expired.withoutHeartbeat", "5000");
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    return shuffleServerConf;
   }
 
   @BeforeEach
-  public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  public void createClient() throws Exception {
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @AfterEach
   public void closeClient() {
-    shuffleServerClient.close();
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
-  @Test
-  public void localWriteReadTest() throws Exception {
+  private static Stream<Arguments> localWriteReadTestProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("localWriteReadTestProvider")
+  private void localWriteReadTest(boolean isNettyMode) throws Exception {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String testAppId = "localWriteReadTest";
     RssRegisterShuffleRequest rrsr =
         new RssRegisterShuffleRequest(
@@ -112,7 +163,8 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
 
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
     RssSendCommitRequest rscr = new RssSendCommitRequest(testAppId, 0);
     shuffleServerClient.sendCommit(rscr);
     RssFinishShuffleRequest rfsr = new RssFinishShuffleRequest(testAppId, 0);
@@ -131,6 +183,7 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
     sdr = readShuffleData(shuffleServerClient, testAppId, 0, 3, 1, 4, 1000, 0);
     validateResult(sdr, expectedBlockIds4, expectedData, 3);
 
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     assertNotNull(
         shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlockIds().get(testAppId));
     Thread.sleep(8000);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemLocalHadoopTest.java
@@ -21,26 +21,40 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.buffer.ShuffleBuffer;
 import org.apache.uniffle.storage.handler.api.ClientReadHandler;
@@ -53,55 +67,101 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
-
-  private ShuffleServerGrpcClient shuffleServerClient;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ShuffleServerWithMemLocalHadoopTest.class);
+  private ShuffleServerGrpcClient grpcShuffleServerClient;
+  private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/test";
+  private static ShuffleServerConf grpcShuffleServerConfig;
+  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+
     File dataDir = new File(tmpDir, "data");
-    String basePath = dataDir.getAbsolutePath();
+    String grpcBasePath = dataDir.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    File dataDir1 = new File(tmpDir, "data1");
+    String nettyBasePath = dataDir1.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  @BeforeEach
+  public void createClient() throws Exception {
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     shuffleServerConf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 450L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 40.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 500L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 5.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 15.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 2000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_TRIGGER_FLUSH_CHECK_INTERVAL, 500L);
-    createShuffleServer(shuffleServerConf);
-    startServers();
-  }
-
-  @BeforeEach
-  public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+    return shuffleServerConf;
   }
 
   @AfterEach
-  public void closeClient() {
-    shuffleServerClient.close();
+  public void closeClient() throws Exception {
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
-  @Test
-  public void memoryLocalFileHadoopReadWithFilterAndSkipTest() throws Exception {
-    runTest(true);
+  @AfterAll
+  public static void tearDown() throws Exception {
+    shutdownServers();
   }
 
-  @Test
-  public void memoryLocalFileHadoopReadWithFilterTest() throws Exception {
-    runTest(false);
+  private static Stream<Arguments> memoryLocalFileHadoopReadWithFilterProvider() {
+    return Stream.of(
+        Arguments.of(true, false),
+        Arguments.of(false, false),
+        Arguments.of(true, true),
+        Arguments.of(false, true));
   }
 
-  private void runTest(boolean checkSkippedMetrics) throws Exception {
+  @ParameterizedTest
+  @MethodSource("memoryLocalFileHadoopReadWithFilterProvider")
+  public void memoryLocalFileHadoopReadWithFilterTest(
+      boolean checkSkippedMetrics, boolean isNettyMode) throws Exception {
+    runTest(checkSkippedMetrics, isNettyMode);
+  }
+
+  private void runTest(boolean checkSkippedMetrics, boolean isNettyMode) throws Exception {
+    LOG.info("checkSkippedMetrics={}, isNettyMode={}", checkSkippedMetrics, isNettyMode);
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String testAppId = "memoryLocalFileHDFSReadWithFilterTest_" + "ship_" + checkSkippedMetrics;
     int shuffleId = 0;
     int partitionId = 0;
@@ -123,7 +183,9 @@ public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
     // send data to shuffle server's memory
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap exceptTaskIds = Roaring64NavigableMap.bitmapOf(0);
@@ -160,14 +222,21 @@ public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
     handlers[0] = memoryClientReadHandler;
     handlers[1] = localFileClientReadHandler;
     handlers[2] = hadoopClientReadHandler;
-    ShuffleServerInfo ssi = new ShuffleServerInfo(LOCALHOST, SHUFFLE_SERVER_PORT);
+    ShuffleServerInfo ssi =
+        isNettyMode
+            ? new ShuffleServerInfo(
+                LOCALHOST,
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
+            : new ShuffleServerInfo(
+                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
     ComposedClientReadHandler composedClientReadHandler =
         new ComposedClientReadHandler(ssi, handlers);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     expectedData.clear();
     expectedData.put(blocks.get(0).getBlockId(), ByteBufUtils.readBytes(blocks.get(0).getData()));
     expectedData.put(blocks.get(1).getBlockId(), ByteBufUtils.readBytes(blocks.get(1).getData()));
-    expectedData.put(blocks.get(2).getBlockId(), ByteBufUtils.readBytes(blocks.get(1).getData()));
+    expectedData.put(blocks.get(2).getBlockId(), ByteBufUtils.readBytes(blocks.get(2).getData()));
     ShuffleDataResult sdr = composedClientReadHandler.readShuffleData();
     validateResult(expectedData, sdr);
     processBlockIds.addLong(blocks.get(0).getBlockId());
@@ -184,8 +253,9 @@ public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
     shuffleToBlocks = Maps.newHashMap();
     shuffleToBlocks.put(shuffleId, partitionToBlocks);
     rssdr = new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
-    waitFlush(testAppId, shuffleId);
+    response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
+    waitFlush(testAppId, shuffleId, isNettyMode);
 
     // read the 2-th segment from localFile
     // notice: the 1-th segment is skipped, because it is processed
@@ -216,8 +286,9 @@ public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
     shuffleToBlocks = Maps.newHashMap();
     shuffleToBlocks.put(shuffleId, partitionToBlocks);
     rssdr = new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
-    waitFlush(testAppId, shuffleId);
+    response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
+    waitFlush(testAppId, shuffleId, isNettyMode);
 
     // read the 4-th segment from HDFS
     sdr = composedClientReadHandler.readShuffleData();
@@ -267,11 +338,13 @@ public class ShuffleServerWithMemLocalHadoopTest extends ShuffleReadWriteBase {
     }
   }
 
-  protected void waitFlush(String appId, int shuffleId) throws InterruptedException {
+  protected void waitFlush(String appId, int shuffleId, boolean isNettyMode)
+      throws InterruptedException {
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     int retry = 0;
     while (true) {
       if (retry > 5) {
-        fail("Timeout for flush data");
+        fail(String.format("Timeout for flush data, isNettyMode=%s", isNettyMode));
       }
       ShuffleBuffer shuffleBuffer =
           shuffleServers.get(0).getShuffleBufferManager().getShuffleBuffer(appId, shuffleId, 0);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemoryTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithMemoryTest.java
@@ -21,26 +21,38 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.client.response.RssSendShuffleDataResponse;
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.buffer.ShuffleBuffer;
 import org.apache.uniffle.storage.handler.api.ClientReadHandler;
@@ -52,43 +64,84 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
 
-  private ShuffleServerGrpcClient shuffleServerClient;
+  private ShuffleServerGrpcClient grpcShuffleServerClient;
+  private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
+  private static ShuffleServerConf grpcShuffleServerConfig;
+  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
     File dataDir = new File(tmpDir, "data");
     String basePath = dataDir.getAbsolutePath();
+
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, basePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, basePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 40.0);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 500L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 5.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 15.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 2000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_TRIGGER_FLUSH_CHECK_INTERVAL, 500L);
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    return shuffleServerConf;
   }
 
   @BeforeEach
-  public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  public void createClient() throws Exception {
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @AfterEach
   public void closeClient() {
-    shuffleServerClient.close();
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
-  @Test
-  public void memoryWriteReadTest() throws Exception {
+  @AfterAll
+  public static void tearDown() throws Exception {
+    shutdownServers();
+  }
+
+  private static Stream<Arguments> memoryWriteReadTestProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("memoryWriteReadTestProvider")
+  private void memoryWriteReadTestProvider(boolean isNettyMode) throws Exception {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String testAppId = "memoryWriteReadTest";
     int shuffleId = 0;
     int partitionId = 0;
@@ -110,9 +163,11 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     // send data to shuffle server
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     // data is cached
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     assertEquals(
         3,
         shuffleServers
@@ -168,9 +223,16 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     ClientReadHandler[] handlers = new ClientReadHandler[2];
     handlers[0] = memoryClientReadHandler;
     handlers[1] = localFileQuorumClientReadHandler;
+    ShuffleServerInfo ssi =
+        isNettyMode
+            ? new ShuffleServerInfo(
+                LOCALHOST,
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
+            : new ShuffleServerInfo(
+                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
     ComposedClientReadHandler composedClientReadHandler =
-        new ComposedClientReadHandler(
-            new ShuffleServerInfo(LOCALHOST, SHUFFLE_SERVER_PORT), handlers);
+        new ComposedClientReadHandler(ssi, handlers);
     // read from memory with ComposedClientReadHandler
     sdr = composedClientReadHandler.readShuffleData();
     expectedData.clear();
@@ -190,12 +252,13 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     shuffleToBlocks.put(shuffleId, partitionToBlocks);
 
     rssdr = new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
     // wait until flush finished
     int retry = 0;
     while (true) {
       if (retry > 5) {
-        fail("Timeout for flush data");
+        fail(String.format("Timeout for flush data, isNettyMode=%s", isNettyMode));
       }
       ShuffleBuffer shuffleBuffer =
           shuffleServers.get(0).getShuffleBufferManager().getShuffleBuffer(testAppId, shuffleId, 0);
@@ -231,8 +294,15 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     assertNull(sdr);
   }
 
-  @Test
-  public void memoryWriteReadWithMultiReplicaTest() throws Exception {
+  private static Stream<Arguments> memoryWriteReadWithMultiReplicaTestProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("memoryWriteReadWithMultiReplicaTestProvider")
+  private void memoryWriteReadWithMultiReplicaTest(boolean isNettyMode) throws Exception {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String testAppId = "memoryWriteReadWithMultiReplicaTest";
     int shuffleId = 0;
     int partitionId = 0;
@@ -259,9 +329,11 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     // send data to shuffle server
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     // data is cached
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     assertEquals(
         3,
         shuffleServers
@@ -306,8 +378,16 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     assertEquals(0, sdr.getBufferSegments().size());
   }
 
-  @Test
-  public void memoryAndLocalFileReadWithFilterTest() throws Exception {
+  private static Stream<Arguments> memoryAndLocalFileReadWithFilterTestProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("memoryAndLocalFileReadWithFilterTestProvider")
+  private void memoryAndLocalFileReadWithFilterTest(boolean isNettyMode) throws Exception {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
+    List<ShuffleServer> shuffleServers = isNettyMode ? nettyShuffleServers : grpcShuffleServers;
     String testAppId = "memoryAndLocalFileReadWithFilterTest";
     int shuffleId = 0;
     int partitionId = 0;
@@ -329,7 +409,8 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     // send data to shuffle server's memory
     RssSendShuffleDataRequest rssdr =
         new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    RssSendShuffleDataResponse response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     // read the 1-th segment from memory
     Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
@@ -352,14 +433,21 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     ClientReadHandler[] handlers = new ClientReadHandler[2];
     handlers[0] = memoryClientReadHandler;
     handlers[1] = localFileClientReadHandler;
+    ShuffleServerInfo ssi =
+        isNettyMode
+            ? new ShuffleServerInfo(
+                LOCALHOST,
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+                nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT))
+            : new ShuffleServerInfo(
+                LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
     ComposedClientReadHandler composedClientReadHandler =
-        new ComposedClientReadHandler(
-            new ShuffleServerInfo(LOCALHOST, SHUFFLE_SERVER_PORT), handlers);
+        new ComposedClientReadHandler(ssi, handlers);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     expectedData.clear();
     expectedData.put(blocks.get(0).getBlockId(), ByteBufUtils.readBytes(blocks.get(0).getData()));
     expectedData.put(blocks.get(1).getBlockId(), ByteBufUtils.readBytes(blocks.get(1).getData()));
-    expectedData.put(blocks.get(2).getBlockId(), ByteBufUtils.readBytes(blocks.get(1).getData()));
+    expectedData.put(blocks.get(2).getBlockId(), ByteBufUtils.readBytes(blocks.get(2).getData()));
     ShuffleDataResult sdr = composedClientReadHandler.readShuffleData();
     validateResult(expectedData, sdr);
     processBlockIds.addLong(blocks.get(0).getBlockId());
@@ -374,12 +462,13 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     shuffleToBlocks = Maps.newHashMap();
     shuffleToBlocks.put(shuffleId, partitionToBlocks);
     rssdr = new RssSendShuffleDataRequest(testAppId, 3, 1000, shuffleToBlocks);
-    shuffleServerClient.sendShuffleData(rssdr);
+    response = shuffleServerClient.sendShuffleData(rssdr);
+    assertSame(StatusCode.SUCCESS, response.getStatusCode());
 
     int retry = 0;
     while (true) {
       if (retry > 5) {
-        fail("Timeout for flush data");
+        fail(String.format("Timeout for flush data, isNettyMode=%s", isNettyMode));
       }
       ShuffleBuffer shuffleBuffer =
           shuffleServers.get(0).getShuffleBufferManager().getShuffleBuffer(testAppId, shuffleId, 0);

--- a/integration-test/mr/src/test/java/org/apache/uniffle/test/MRIntegrationTestBase.java
+++ b/integration-test/mr/src/test/java/org/apache/uniffle/test/MRIntegrationTestBase.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -193,7 +194,7 @@ public class MRIntegrationTestBase extends IntegrationTestBase {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
   }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/AutoAccessTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/AutoAccessTest.java
@@ -32,6 +32,7 @@ import org.apache.spark.shuffle.ShuffleManager;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -87,7 +88,7 @@ public class AutoAccessTest extends IntegrationTestBase {
             + "org.apache.uniffle.coordinator.access.checker.AccessClusterLoadChecker");
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
     Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/FailingTasksTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/FailingTasksTest.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -52,8 +53,10 @@ public class FailingTasksTest extends SparkTaskFailureIntegrationTestBase {
         RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.MockedGrpcServer;
 import org.apache.uniffle.server.ShuffleServer;
@@ -48,14 +49,16 @@ public class RSSStageResubmitTest extends SparkTaskFailureIntegrationTestBase {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createMockedShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    createMockedShuffleServer(grpcShuffleServerConf);
     enableFirstReadRequest(2 * maxTaskFailures);
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    createMockedShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 
   private static void enableFirstReadRequest(int failCount) {
-    for (ShuffleServer server : shuffleServers) {
+    for (ShuffleServer server : grpcShuffleServers) {
       ((MockedGrpcServer) server.getServer()).getService().enableFirstNReadRequestToFail(failCount);
     }
   }

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithHadoopHybridStorageRssTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithHadoopHybridStorageRssTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -55,18 +56,32 @@ public class RepartitionWithHadoopHybridStorageRssTest extends RepartitionTest {
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
     // local storage config
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    String grpcBasePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
+    createShuffleServer(grpcShuffleServerConf);
+
+    // local storage config
+    File dataDir3 = new File(tmpDir, "data3");
+    File dataDir4 = new File(tmpDir, "data4");
+    String nettyBasePath = dataDir3.getAbsolutePath() + "," + dataDir4.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType, String basePath)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE_HDFS.name());
     shuffleServerConf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 1024L * 1024L);
-
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    return shuffleServerConf;
   }
 
   @Override

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithLocalFileRssTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithLocalFileRssTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.uniffle.common.compression.Codec;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -46,7 +47,7 @@ public class RepartitionWithLocalFileRssTest extends RepartitionTest {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithMemoryRssTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RepartitionWithMemoryRssTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -42,17 +43,19 @@ public class RepartitionWithMemoryRssTest extends RepartitionTest {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    shuffleServerConf.set(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL, 5000L);
-    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 4000L);
+
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
-    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString(
-        ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
-    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
-    shuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
-    createShuffleServer(shuffleServerConf);
+    String grpcBasePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC, grpcBasePath);
+
+    File dataDir3 = new File(tmpDir, "data3");
+    File dataDir4 = new File(tmpDir, "data4");
+    String nettyBasePath = dataDir3.getAbsolutePath() + "," + dataDir4.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(ServerType.GRPC_NETTY, nettyBasePath);
+    createShuffleServer(grpcShuffleServerConf);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 
@@ -67,6 +70,18 @@ public class RepartitionWithMemoryRssTest extends RepartitionTest {
 
     // oom if there has no memory release
     runSparkApp(sparkConf, fileName);
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType grpc, String basePath)
+      throws Exception {
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(grpc);
+    grpcShuffleServerConf.set(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL, 5000L);
+    grpcShuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 4000L);
+    grpcShuffleServerConf.setString(
+        ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
+    grpcShuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(basePath));
+    grpcShuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
+    return grpcShuffleServerConf;
   }
 
   @Override

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.client.util.RssClientConfig;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
-import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,8 +54,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
         RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createShuffleServer(shuffleServerConf);
+    createShuffleServer(getShuffleServerConf(ServerType.GRPC));
     startServers();
   }
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHadoopTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithHadoopTest.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -49,9 +50,12 @@ public class ShuffleUnregisterWithHadoopTest extends SparkIntegrationTestBase {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    shuffleServerConf.setString("rss.storage.type", StorageType.HDFS.name());
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    grpcShuffleServerConf.setString("rss.storage.type", StorageType.HDFS.name());
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    nettyShuffleServerConf.setString("rss.storage.type", StorageType.HDFS.name());
+    createShuffleServer(grpcShuffleServerConf);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/ShuffleUnregisterWithLocalfileTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -50,9 +51,12 @@ public class ShuffleUnregisterWithLocalfileTest extends SparkIntegrationTestBase
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    grpcShuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    nettyShuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
+    createShuffleServer(grpcShuffleServerConf);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 
@@ -84,7 +88,7 @@ public class ShuffleUnregisterWithLocalfileTest extends SparkIntegrationTestBase
     // method.
     if (runCounter == 1) {
       String path =
-          shuffleServers
+          grpcShuffleServers
               .get(0)
               .getShuffleServerConf()
               .get(RssBaseConf.RSS_STORAGE_BASE_PATH)

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SimpleTestBase.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SimpleTestBase.java
@@ -24,6 +24,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.BeforeAll;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -38,8 +39,10 @@ public abstract class SimpleTestBase extends SparkIntegrationTestBase {
         RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.test;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -27,21 +28,28 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient;
+import org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcNettyClient;
 import org.apache.uniffle.client.request.RssFinishShuffleRequest;
 import org.apache.uniffle.client.request.RssRegisterShuffleRequest;
 import org.apache.uniffle.client.request.RssSendCommitRequest;
 import org.apache.uniffle.client.request.RssSendShuffleDataRequest;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -55,37 +63,81 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
   private static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
-  private static File DATA_DIR1;
-  private static File DATA_DIR2;
-  private ShuffleServerGrpcClient shuffleServerClient;
-  private List<ShuffleServerInfo> shuffleServerInfo =
-      Lists.newArrayList(new ShuffleServerInfo(LOCALHOST, SHUFFLE_SERVER_PORT));
+  private static File GRPC_DATA_DIR1;
+  private static File GRPC_DATA_DIR2;
+  private static File NETTY_DATA_DIR1;
+  private static File NETTY_DATA_DIR2;
+  private ShuffleServerGrpcClient grpcShuffleServerClient;
+  private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
+  private static ShuffleServerConf grpcShuffleServerConfig;
+  private static ShuffleServerConf nettyShuffleServerConfig;
 
   @BeforeAll
   public static void setupServers(@TempDir File tmpDir) throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    DATA_DIR1 = new File(tmpDir, "data1");
-    DATA_DIR2 = new File(tmpDir, "data2");
-    String basePath = DATA_DIR1.getAbsolutePath() + "," + DATA_DIR2.getAbsolutePath();
+
+    GRPC_DATA_DIR1 = new File(tmpDir, "data1");
+    GRPC_DATA_DIR2 = new File(tmpDir, "data2");
+    String grpcBasePath = GRPC_DATA_DIR1.getAbsolutePath() + "," + GRPC_DATA_DIR2.getAbsolutePath();
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(grpcBasePath, ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+
+    NETTY_DATA_DIR1 = new File(tmpDir, "netty_data1");
+    NETTY_DATA_DIR2 = new File(tmpDir, "netty_data2");
+    String nettyBasePath =
+        NETTY_DATA_DIR1.getAbsolutePath() + "," + NETTY_DATA_DIR2.getAbsolutePath();
+    ShuffleServerConf nettyShuffleServerConf =
+        buildShuffleServerConf(nettyBasePath, ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
+
+    startServers();
+
+    grpcShuffleServerConfig = grpcShuffleServerConf;
+    nettyShuffleServerConfig = nettyShuffleServerConf;
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(String basePath, ServerType serverType)
+      throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);
-    createShuffleServer(shuffleServerConf);
-    startServers();
+    return shuffleServerConf;
   }
 
   @BeforeEach
-  public void createClient() {
-    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  public void createClient() throws Exception {
+    grpcShuffleServerClient =
+        new ShuffleServerGrpcClient(
+            LOCALHOST, grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+    RssConf rssConf = new RssConf();
+    rssConf.set(RssClientConf.RSS_CLIENT_TYPE, ClientType.GRPC_NETTY);
+    nettyShuffleServerClient =
+        new ShuffleServerGrpcNettyClient(
+            rssConf,
+            LOCALHOST,
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+            nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
   }
 
   @AfterEach
   public void closeClient() {
-    shuffleServerClient.close();
+    grpcShuffleServerClient.close();
+    nettyShuffleServerClient.close();
   }
 
-  private ShuffleClientFactory.ReadClientBuilder baseReadBuilder() {
+  private ShuffleClientFactory.ReadClientBuilder baseReadBuilder(boolean isNettyMode) {
+    List<ShuffleServerInfo> shuffleServerInfo =
+        isNettyMode
+            ? Lists.newArrayList(
+                new ShuffleServerInfo(
+                    LOCALHOST,
+                    nettyShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT),
+                    nettyShuffleServerConfig.getInteger(ShuffleServerConf.NETTY_SERVER_PORT)))
+            : Lists.newArrayList(
+                new ShuffleServerInfo(
+                    LOCALHOST,
+                    grpcShuffleServerConfig.getInteger(ShuffleServerConf.RPC_SERVER_PORT)));
     return ShuffleClientFactory.newReadBuilder()
         .storageType(StorageType.LOCALFILE.name())
         .shuffleId(0)
@@ -97,18 +149,23 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
         .shuffleServerInfoList(shuffleServerInfo);
   }
 
-  @Test
-  public void readTest1() {
+  private static Stream<Arguments> isNettyModeProvider() {
+    return Stream.of(Arguments.of(true), Arguments.of(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest1(boolean isNettyMode) {
     String testAppId = "localReadTest1";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
-    createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap);
+    createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap, isNettyMode);
     blockIdBitmap.addLong(BlockId.getBlockId(0, 1, 0));
     ShuffleReadClientImpl readClient;
     readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -125,22 +182,23 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     }
   }
 
-  @Test
-  public void readTest2() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest2(boolean isNettyMode) {
     String testAppId = "localReadTest2";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 2, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
     blocks = createShuffleBlockList(0, 0, 0, 2, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -151,25 +209,35 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  @Test
-  public void readTest3() throws Exception {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest3(boolean isNettyMode) throws Exception {
     String testAppId = "localReadTest3";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 2, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
-    FileUtils.deleteDirectory(new File(DATA_DIR1.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
-    FileUtils.deleteDirectory(new File(DATA_DIR2.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
+    if (isNettyMode) {
+      FileUtils.deleteDirectory(
+          new File(NETTY_DATA_DIR1.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
+      FileUtils.deleteDirectory(
+          new File(NETTY_DATA_DIR2.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
+    } else {
+      FileUtils.deleteDirectory(
+          new File(GRPC_DATA_DIR1.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
+      FileUtils.deleteDirectory(
+          new File(GRPC_DATA_DIR2.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
+    }
     // sleep to wait delete operation
     Thread.sleep(2000);
 
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -178,10 +246,11 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  @Test
-  public void readTest4() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest4(boolean isNettyMode) {
     String testAppId = "localReadTest4";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 1)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 1)), isNettyMode);
 
     Map<Long, byte[]> expectedData1 = Maps.newHashMap();
     Map<Long, byte[]> expectedData2 = Maps.newHashMap();
@@ -189,24 +258,24 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 10, 30, blockIdBitmap1, expectedData1, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     Roaring64NavigableMap blockIdBitmap2 = Roaring64NavigableMap.bitmapOf();
     blocks = createShuffleBlockList(0, 1, 0, 10, 30, blockIdBitmap2, expectedData2, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     blocks = createShuffleBlockList(0, 0, 0, 10, 30, blockIdBitmap1, expectedData1, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     ShuffleReadClientImpl readClient1 =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .partitionNumPerRange(2)
             .blockIdBitmap(blockIdBitmap1)
             .taskIdBitmap(taskIdBitmap)
             .build();
     final ShuffleReadClientImpl readClient2 =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .partitionId(1)
             .partitionNumPerRange(2)
@@ -222,11 +291,12 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient2.close();
   }
 
-  @Test
-  public void readTest5() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest5(boolean isNettyMode) {
     String testAppId = "localReadTest5";
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .partitionId(1)
             .partitionNumPerRange(2)
@@ -237,17 +307,18 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.checkProcessedBlockIds();
   }
 
-  @Test
-  public void readTest6() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest6(boolean isNettyMode) {
     String testAppId = "localReadTest6";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 5, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     Roaring64NavigableMap wrongBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     LongIterator iter = blockIdBitmap.getLongIterator();
@@ -258,7 +329,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     }
 
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(wrongBlockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -272,10 +343,11 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     }
   }
 
-  @Test
-  public void readTest7() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest7(boolean isNettyMode) {
     String testAppId = "localReadTest7";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
@@ -283,17 +355,17 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 5, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     blocks = createShuffleBlockList(0, 0, 1, 5, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     blocks = createShuffleBlockList(0, 0, 2, 5, 30, blockIdBitmap, Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -304,35 +376,36 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  @Test
-  public void readTest8() {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest8(boolean isNettyMode) {
     String testAppId = "localReadTest8";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 3);
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 5, 30, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     // test case: data generated by speculation task without report result
     blocks =
         createShuffleBlockList(
             0, 0, 1, 5, 30, Roaring64NavigableMap.bitmapOf(), Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
     // test case: data generated by speculation task with report result
     blocks = createShuffleBlockList(0, 0, 2, 5, 30, blockIdBitmap, Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     blocks =
         createShuffleBlockList(
             0, 0, 3, 5, 30, Roaring64NavigableMap.bitmapOf(), Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -343,30 +416,31 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  @Test
-  public void readTest9() throws Exception {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest9(boolean isNettyMode) throws Exception {
     String testAppId = "localReadTest9";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
 
     List<ShuffleBlockInfo> blocks;
 
-    createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap);
+    createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap, isNettyMode);
     Roaring64NavigableMap beforeAdded = RssUtils.cloneBitMap(blockIdBitmap);
     // write data by another task, read data again, the cache for index file should be updated
     blocks = createShuffleBlockList(0, 0, 1, 3, 25, blockIdBitmap, Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
     // test with un-changed expected blockId
     ShuffleReadClientImpl readClient;
-    baseReadBuilder()
+    baseReadBuilder(isNettyMode)
         .appId(testAppId)
         .blockIdBitmap(beforeAdded)
         .taskIdBitmap(taskIdBitmap)
         .build();
     readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(beforeAdded)
             .taskIdBitmap(taskIdBitmap)
@@ -377,7 +451,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     // test with changed expected blockId
     readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)
@@ -387,10 +461,11 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  @Test
-  public void readTest10() throws Exception {
+  @ParameterizedTest
+  @MethodSource("isNettyModeProvider")
+  public void readTest10(boolean isNettyMode) throws Exception {
     String testAppId = "localReadTest10";
-    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)));
+    registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap expectedBlockIds = Roaring64NavigableMap.bitmapOf();
@@ -399,20 +474,20 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     // send some expected data
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 2, 30, expectedBlockIds, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
     // send some unexpected data
     blocks = createShuffleBlockList(0, 0, 0, 2, 30, unexpectedBlockIds, Maps.newHashMap(), mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
     // send some expected data
     blocks = createShuffleBlockList(0, 0, 1, 2, 30, expectedBlockIds, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
-    baseReadBuilder()
+    sendTestData(testAppId, blocks, isNettyMode);
+    baseReadBuilder(isNettyMode)
         .appId(testAppId)
         .blockIdBitmap(expectedBlockIds)
         .taskIdBitmap(taskIdBitmap)
         .build();
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(expectedBlockIds)
             .taskIdBitmap(taskIdBitmap)
@@ -423,13 +498,19 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     readClient.close();
   }
 
-  protected void registerApp(String testAppId, List<PartitionRange> partitionRanges) {
+  protected void registerApp(
+      String testAppId, List<PartitionRange> partitionRanges, boolean isNettyMode) {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     RssRegisterShuffleRequest rrsr =
         new RssRegisterShuffleRequest(testAppId, 0, partitionRanges, "");
     shuffleServerClient.registerShuffle(rrsr);
   }
 
-  protected void sendTestData(String testAppId, List<ShuffleBlockInfo> blocks) {
+  protected void sendTestData(
+      String testAppId, List<ShuffleBlockInfo> blocks, boolean isNettyMode) {
+    ShuffleServerGrpcClient shuffleServerClient =
+        isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
     partitionToBlocks.put(0, blocks);
 
@@ -449,13 +530,14 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
       String testAppId,
       Map<Long, byte[]> expectedData,
       Roaring64NavigableMap blockIdBitmap,
-      Roaring64NavigableMap taskIdBitmap) {
+      Roaring64NavigableMap taskIdBitmap,
+      boolean isNettyMode) {
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 3, 25, blockIdBitmap, expectedData, mockSSI);
-    sendTestData(testAppId, blocks);
+    sendTestData(testAppId, blocks, isNettyMode);
 
     ShuffleReadClientImpl readClient =
-        baseReadBuilder()
+        baseReadBuilder(isNettyMode)
             .appId(testAppId)
             .blockIdBitmap(blockIdBitmap)
             .taskIdBitmap(taskIdBitmap)

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerFallbackTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithDelegationShuffleManagerFallbackTest.java
@@ -30,6 +30,7 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -56,7 +57,7 @@ public class SparkSQLWithDelegationShuffleManagerFallbackTest extends SparkSQLTe
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL, 1000L);
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 4000L);
     File dataDir1 = new File(tmpDir, "data1");

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithMemoryLocalTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkSQLWithMemoryLocalTest.java
@@ -26,6 +26,7 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -44,15 +45,25 @@ public class SparkSQLWithMemoryLocalTest extends SparkSQLTest {
     dynamicConf.put(RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
-    shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 4000);
     File dataDir1 = new File(tmpDir, "data1");
     File dataDir2 = new File(tmpDir, "data2");
     basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
-    shuffleServerConf.setString("rss.storage.basePath", basePath);
-    createShuffleServer(shuffleServerConf);
+
+    ShuffleServerConf grpcShuffleServerConf = buildShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+
+    ShuffleServerConf nettyShuffleServerConf = buildShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
+
     startServers();
+  }
+
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType) throws Exception {
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType);
+    shuffleServerConf.setLong("rss.server.heartbeat.interval", 5000);
+    shuffleServerConf.setLong("rss.server.app.expired.withoutHeartbeat", 4000);
+    shuffleServerConf.setString("rss.storage.basePath", basePath);
+    return shuffleServerConf;
   }
 
   @Override

--- a/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark2/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -88,7 +89,7 @@ public class GetReaderTest extends IntegrationTestBase {
     coordinatorConf.setInteger("rss.coordinator.remote.storage.schedule.access.times", 1);
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
     Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQERepartitionTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQERepartitionTest.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -51,8 +52,10 @@ public class AQERepartitionTest extends SparkIntegrationTestBase {
         RssSparkConfig.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/AQESkewedJoinTest.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -47,8 +48,10 @@ public class AQESkewedJoinTest extends SparkIntegrationTestBase {
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
-    createShuffleServer(shuffleServerConf);
+    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    createShuffleServer(grpcShuffleServerConf);
+    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    createShuffleServer(nettyShuffleServerConf);
     startServers();
   }
 

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/ContinuousSelectPartitionStrategyTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/ContinuousSelectPartitionStrategyTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.strategy.assignment.AbstractAssignmentStrategy;
 import org.apache.uniffle.server.MockedGrpcServer;
@@ -77,32 +79,42 @@ public class ContinuousSelectPartitionStrategyTest extends SparkIntegrationTestB
   private static void createShuffleServers() throws Exception {
     for (int i = 0; i < 3; i++) {
       // Copy from IntegrationTestBase#getShuffleServerConf
-      ShuffleServerConf serverConf = new ShuffleServerConf();
-      serverConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + i);
-      serverConf.setInteger("rss.server.netty.port", NETTY_PORT + i);
-      serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
-      serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
-      serverConf.setString("rss.server.buffer.capacity", String.valueOf(671088640 - i));
-      serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");
-      serverConf.setString("rss.server.memory.shuffle.lowWaterMark", "0.0");
-      serverConf.setString("rss.server.read.buffer.capacity", "335544320");
-      serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
-      serverConf.setString("rss.server.heartbeat.delay", "1000");
-      serverConf.setString("rss.server.heartbeat.interval", "1000");
-      serverConf.setInteger("rss.jetty.http.port", 18080 + i);
-      serverConf.setInteger("rss.jetty.corePool.size", 64);
-      serverConf.setInteger("rss.rpc.executor.size", 10);
-      serverConf.setString("rss.server.hadoop.dfs.replication", "2");
-      serverConf.setLong("rss.server.disk.capacity", 10L * 1024L * 1024L * 1024L);
-      serverConf.setBoolean("rss.server.health.check.enable", false);
-      serverConf.setString("rss.server.tags", "GRPC,GRPC_NETTY");
-      createMockedShuffleServer(serverConf);
+      ShuffleServerConf grpcServerConf = buildShuffleServerConf(i, ServerType.GRPC);
+      createMockedShuffleServer(grpcServerConf);
+      ShuffleServerConf nettyServerConf = buildShuffleServerConf(i, ServerType.GRPC_NETTY);
+      createMockedShuffleServer(nettyServerConf);
     }
     enableRecordGetShuffleResult();
   }
 
+  private static ShuffleServerConf buildShuffleServerConf(int i, ServerType serverType) {
+    ShuffleServerConf serverConf = new ShuffleServerConf();
+    serverConf.setInteger("rss.rpc.server.port", IntegrationTestBase.getNextRpcServerPort());
+    serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
+    serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
+    serverConf.setString("rss.server.buffer.capacity", String.valueOf(671088640 - i));
+    serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");
+    serverConf.setString("rss.server.memory.shuffle.lowWaterMark", "0.0");
+    serverConf.setString("rss.server.read.buffer.capacity", "335544320");
+    serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
+    serverConf.setString("rss.server.heartbeat.delay", "1000");
+    serverConf.setString("rss.server.heartbeat.interval", "1000");
+    serverConf.setInteger("rss.jetty.http.port", IntegrationTestBase.getNextJettyServerPort());
+    serverConf.setInteger("rss.jetty.corePool.size", 64);
+    serverConf.setInteger("rss.rpc.executor.size", 10);
+    serverConf.setString("rss.server.hadoop.dfs.replication", "2");
+    serverConf.setLong("rss.server.disk.capacity", 10L * 1024L * 1024L * 1024L);
+    serverConf.setBoolean("rss.server.health.check.enable", false);
+    serverConf.set(ShuffleServerConf.RPC_SERVER_TYPE, serverType);
+    if (serverType == ServerType.GRPC_NETTY) {
+      serverConf.setInteger(
+          ShuffleServerConf.NETTY_SERVER_PORT, IntegrationTestBase.getNextNettyServerPort());
+    }
+    return serverConf;
+  }
+
   private static void enableRecordGetShuffleResult() {
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       ((MockedGrpcServer) shuffleServer.getServer()).getService().enableRecordGetShuffleResult();
     }
   }
@@ -213,13 +225,19 @@ public class ContinuousSelectPartitionStrategyTest extends SparkIntegrationTestB
               .mapToInt(x -> x.get())
               .sum();
       // Validate getShuffleResultForMultiPart is correct before return result
-      validateRequestCount(spark.sparkContext().applicationId(), expectRequestNum * replicateRead);
+      ClientType clientType =
+          ClientType.valueOf(spark.sparkContext().getConf().get(RssSparkConfig.RSS_CLIENT_TYPE));
+      if (ClientType.GRPC == clientType) {
+        // TODO skip validating for GRPC_NETTY, needs to mock ShuffleServerNettyHandler
+        validateRequestCount(
+            spark.sparkContext().applicationId(), expectRequestNum * replicateRead);
+      }
     }
     return map;
   }
 
   public void validateRequestCount(String appId, int expectRequestNum) {
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       MockedShuffleServerGrpcService service =
           ((MockedGrpcServer) shuffleServer.getServer()).getService();
       Map<String, Map<Integer, AtomicInteger>> serviceRequestCount =

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -54,6 +54,7 @@ import org.apache.spark.util.TaskFailureListener;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -101,7 +102,7 @@ public class GetReaderTest extends IntegrationTestBase {
     coordinatorConf.setInteger("rss.coordinator.remote.storage.schedule.access.times", 1);
     createCoordinatorServer(coordinatorConf);
 
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
     Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetShuffleReportForMultiPartTest.java
@@ -45,7 +45,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.MockedGrpcServer;
@@ -81,32 +83,42 @@ public class GetShuffleReportForMultiPartTest extends SparkIntegrationTestBase {
   private static void createShuffleServers() throws Exception {
     for (int i = 0; i < 4; i++) {
       // Copy from IntegrationTestBase#getShuffleServerConf
-      ShuffleServerConf serverConf = new ShuffleServerConf();
-      serverConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + i);
-      serverConf.setInteger("rss.server.netty.port", NETTY_PORT + i);
-      serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
-      serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
-      serverConf.setString("rss.server.buffer.capacity", "671088640");
-      serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");
-      serverConf.setString("rss.server.memory.shuffle.lowWaterMark", "0.0");
-      serverConf.setString("rss.server.read.buffer.capacity", "335544320");
-      serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
-      serverConf.setString("rss.server.heartbeat.delay", "1000");
-      serverConf.setString("rss.server.heartbeat.interval", "1000");
-      serverConf.setInteger("rss.jetty.http.port", 18080 + i);
-      serverConf.setInteger("rss.jetty.corePool.size", 64);
-      serverConf.setInteger("rss.rpc.executor.size", 10);
-      serverConf.setString("rss.server.hadoop.dfs.replication", "2");
-      serverConf.setLong("rss.server.disk.capacity", 10L * 1024L * 1024L * 1024L);
-      serverConf.setBoolean("rss.server.health.check.enable", false);
-      serverConf.setString("rss.server.tags", "GRPC,GRPC_NETTY");
-      createMockedShuffleServer(serverConf);
+      ShuffleServerConf grpcServerConf = buildShuffleServerConf(ServerType.GRPC);
+      createMockedShuffleServer(grpcServerConf);
+      ShuffleServerConf nettyServerConf = buildShuffleServerConf(ServerType.GRPC_NETTY);
+      createMockedShuffleServer(nettyServerConf);
     }
     enableRecordGetShuffleResult();
   }
 
+  private static ShuffleServerConf buildShuffleServerConf(ServerType serverType) {
+    ShuffleServerConf serverConf = new ShuffleServerConf();
+    serverConf.setInteger("rss.rpc.server.port", IntegrationTestBase.getNextRpcServerPort());
+    serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
+    serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
+    serverConf.setString("rss.server.buffer.capacity", "671088640");
+    serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");
+    serverConf.setString("rss.server.memory.shuffle.lowWaterMark", "0.0");
+    serverConf.setString("rss.server.read.buffer.capacity", "335544320");
+    serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
+    serverConf.setString("rss.server.heartbeat.delay", "1000");
+    serverConf.setString("rss.server.heartbeat.interval", "1000");
+    serverConf.setInteger("rss.jetty.http.port", IntegrationTestBase.getNextJettyServerPort());
+    serverConf.setInteger("rss.jetty.corePool.size", 64);
+    serverConf.setInteger("rss.rpc.executor.size", 10);
+    serverConf.setString("rss.server.hadoop.dfs.replication", "2");
+    serverConf.setLong("rss.server.disk.capacity", 10L * 1024L * 1024L * 1024L);
+    serverConf.setBoolean("rss.server.health.check.enable", false);
+    serverConf.set(ShuffleServerConf.RPC_SERVER_TYPE, serverType);
+    if (serverType == ServerType.GRPC_NETTY) {
+      serverConf.setInteger(
+          ShuffleServerConf.NETTY_SERVER_PORT, IntegrationTestBase.getNextNettyServerPort());
+    }
+    return serverConf;
+  }
+
   private static void enableRecordGetShuffleResult() {
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       ((MockedGrpcServer) shuffleServer.getServer()).getService().enableRecordGetShuffleResult();
     }
   }
@@ -213,13 +225,19 @@ public class GetShuffleReportForMultiPartTest extends SparkIntegrationTestBase {
               .mapToInt(x -> x.get())
               .sum();
       // Validate getShuffleResultForMultiPart is correct before return result
-      validateRequestCount(spark.sparkContext().applicationId(), expectRequestNum * replicateRead);
+      ClientType clientType =
+          ClientType.valueOf(spark.sparkContext().getConf().get(RssSparkConfig.RSS_CLIENT_TYPE));
+      if (ClientType.GRPC == clientType) {
+        // TODO skip validating for GRPC_NETTY, needs to mock ShuffleServerNettyHandler
+        validateRequestCount(
+            spark.sparkContext().applicationId(), expectRequestNum * replicateRead);
+      }
     }
     return map;
   }
 
   public void validateRequestCount(String appId, int expectRequestNum) {
-    for (ShuffleServer shuffleServer : shuffleServers) {
+    for (ShuffleServer shuffleServer : grpcShuffleServers) {
       MockedShuffleServerGrpcService service =
           ((MockedGrpcServer) shuffleServer.getServer()).getService();
       Map<String, Map<Integer, AtomicInteger>> serviceRequestCount =

--- a/integration-test/tez/src/test/java/org/apache/uniffle/test/TezIntegrationTestBase.java
+++ b/integration-test/tez/src/test/java/org/apache/uniffle/test/TezIntegrationTestBase.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -81,7 +82,7 @@ public class TezIntegrationTestBase extends IntegrationTestBase {
     dynamicConf.put(RssTezConfig.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
   }

--- a/integration-test/tez/src/test/java/org/apache/uniffle/test/TezWordCountWithFailuresTest.java
+++ b/integration-test/tez/src/test/java/org/apache/uniffle/test/TezWordCountWithFailuresTest.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ClientType;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -102,7 +103,7 @@ public class TezWordCountWithFailuresTest extends IntegrationTestBase {
     dynamicConf.put(RssTezConfig.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE_HDFS.name());
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
     createShuffleServer(shuffleServerConf);
     startServers();
   }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -45,6 +45,7 @@ import org.apache.uniffle.common.metrics.MetricReporter;
 import org.apache.uniffle.common.metrics.MetricReporterFactory;
 import org.apache.uniffle.common.metrics.NettyMetrics;
 import org.apache.uniffle.common.rpc.ServerInterface;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.security.SecurityConfig;
 import org.apache.uniffle.common.security.SecurityContextFactory;
 import org.apache.uniffle.common.util.Constants;
@@ -286,8 +287,10 @@ public class ShuffleServer {
             shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager);
     shuffleTaskManager.start();
 
-    nettyServerEnabled = shuffleServerConf.get(ShuffleServerConf.NETTY_SERVER_PORT) >= 0;
+    nettyServerEnabled =
+        shuffleServerConf.get(ShuffleServerConf.RPC_SERVER_TYPE) == ServerType.GRPC_NETTY;
     if (nettyServerEnabled) {
+      assert nettyPort >= 0;
       streamServer = new StreamServer(this);
     }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -278,21 +278,22 @@ public class ShuffleServer {
       healthCheck.start();
     }
 
-    registerHeartBeat = new RegisterHeartBeat(this);
-    directMemoryUsageReporter = new NettyDirectMemoryTracker(shuffleServerConf);
-    shuffleFlushManager = new ShuffleFlushManager(shuffleServerConf, this, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager);
-    shuffleTaskManager =
-        new ShuffleTaskManager(
-            shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager);
-    shuffleTaskManager.start();
-
     nettyServerEnabled =
         shuffleServerConf.get(ShuffleServerConf.RPC_SERVER_TYPE) == ServerType.GRPC_NETTY;
     if (nettyServerEnabled) {
       assert nettyPort >= 0;
       streamServer = new StreamServer(this);
     }
+
+    registerHeartBeat = new RegisterHeartBeat(this);
+    directMemoryUsageReporter = new NettyDirectMemoryTracker(shuffleServerConf);
+    shuffleFlushManager = new ShuffleFlushManager(shuffleServerConf, this, storageManager);
+    shuffleBufferManager =
+        new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager, nettyServerEnabled);
+    shuffleTaskManager =
+        new ShuffleTaskManager(
+            shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager);
+    shuffleTaskManager.start();
 
     setServer();
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedData;
-import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
@@ -71,7 +70,6 @@ public class ShuffleBufferManager {
   // Huge partition vars
   private long hugePartitionSizeThreshold;
   private long hugePartitionMemoryLimitSize;
-  private boolean nettyServerEnabled;
 
   protected long bufferSize = 0;
   protected AtomicLong preAllocatedSize = new AtomicLong(0L);
@@ -83,8 +81,8 @@ public class ShuffleBufferManager {
   // appId -> shuffleId -> shuffle size in buffer
   protected Map<String, Map<Integer, AtomicLong>> shuffleSizeMap = JavaUtils.newConcurrentMap();
 
-  public ShuffleBufferManager(ShuffleServerConf conf, ShuffleFlushManager shuffleFlushManager) {
-    this.nettyServerEnabled = conf.get(ShuffleServerConf.RPC_SERVER_TYPE) == ServerType.GRPC_NETTY;
+  public ShuffleBufferManager(
+      ShuffleServerConf conf, ShuffleFlushManager shuffleFlushManager, boolean nettyServerEnabled) {
     long heapSize = Runtime.getRuntime().maxMemory();
     this.capacity = conf.getSizeAsBytes(ShuffleServerConf.SERVER_BUFFER_CAPACITY);
     if (this.capacity < 0) {

--- a/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
@@ -75,6 +75,7 @@ public class KerberizedShuffleTaskManagerTest extends KerberizedHadoopBase {
       shuffleServer.stopServer();
       shuffleServer = null;
     }
+    ShuffleServerMetrics.clear();
   }
 
   /**

--- a/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerFactory.java
+++ b/server/src/test/java/org/apache/uniffle/server/MockedShuffleServerFactory.java
@@ -35,7 +35,7 @@ public class MockedShuffleServerFactory extends ShuffleServerFactory {
     ShuffleServerConf conf = getConf();
     ShuffleServer shuffleServer = getShuffleServer();
     ServerType type = conf.get(ShuffleServerConf.RPC_SERVER_TYPE);
-    if (type == ServerType.GRPC) {
+    if (type == ServerType.GRPC || type == ServerType.GRPC_NETTY) {
       return new MockedGrpcServer(
           conf, new MockedShuffleServerGrpcService(shuffleServer), shuffleServer.getGrpcMetrics());
     } else {

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ServerStatus;
+import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.util.ExitUtils;
 import org.apache.uniffle.common.util.ExitUtils.ExitException;
 import org.apache.uniffle.storage.util.StorageType;
@@ -45,7 +46,7 @@ public class ShuffleServerTest {
 
   @Test
   public void startTest() throws Exception {
-    ShuffleServerConf serverConf = createShuffleServerConf();
+    ShuffleServerConf serverConf = createShuffleServerConf(ServerType.GRPC);
     ShuffleServer ss1 = new ShuffleServer(serverConf);
     ss1.start();
     ExitUtils.disableSystemExit();
@@ -84,7 +85,7 @@ public class ShuffleServerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void decommissionTest(boolean shutdown) throws Exception {
-    ShuffleServerConf serverConf = createShuffleServerConf();
+    ShuffleServerConf serverConf = createShuffleServerConf(ServerType.GRPC);
     serverConf.set(SERVER_DECOMMISSION_CHECK_INTERVAL, 1000L);
     serverConf.set(SERVER_DECOMMISSION_SHUTDOWN, shutdown);
     serverConf.set(ShuffleServerConf.RPC_SERVER_PORT, 19527);
@@ -119,7 +120,7 @@ public class ShuffleServerTest {
     }
   }
 
-  private ShuffleServerConf createShuffleServerConf() throws Exception {
+  private ShuffleServerConf createShuffleServerConf(ServerType serverType) throws Exception {
     ShuffleServerConf serverConf = new ShuffleServerConf();
     serverConf.setInteger(ShuffleServerConf.RPC_SERVER_PORT, 9527);
     serverConf.setString(ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
@@ -131,12 +132,13 @@ public class ShuffleServerTest {
     serverConf.setLong(ShuffleServerConf.DISK_CAPACITY, 1024L * 1024L * 1024L);
     serverConf.setLong(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 100);
     serverConf.setLong(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY, 10);
+    serverConf.set(ShuffleServerConf.RPC_SERVER_TYPE, serverType);
     return serverConf;
   }
 
   @Test
   public void nettyServerTest() throws Exception {
-    ShuffleServerConf serverConf = createShuffleServerConf();
+    ShuffleServerConf serverConf = createShuffleServerConf(ServerType.GRPC_NETTY);
     serverConf.set(ShuffleServerConf.NETTY_SERVER_PORT, 29999);
     ShuffleServer ss1 = new ShuffleServer(serverConf);
     ss1.start();

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -102,6 +102,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
       shuffleServer.stopServer();
       shuffleServer = null;
     }
+    ShuffleServerMetrics.clear();
   }
 
   @Test

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -84,7 +84,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     mockShuffleServer = mock(ShuffleServer.class);
     mockShuffleTaskManager = mock(ShuffleTaskManager.class);
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
-    shuffleBufferManager = new ShuffleBufferManager(conf, mockShuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(conf, mockShuffleFlushManager, false);
   }
 
   @Test
@@ -386,7 +386,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     StorageManager storageManager = StorageManagerFactory.getInstance().createStorageManager(conf);
     ShuffleFlushManager shuffleFlushManager =
         new ShuffleFlushManager(conf, mockShuffleServer, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(conf, shuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(conf, shuffleFlushManager, false);
 
     when(mockShuffleServer.getShuffleFlushManager()).thenReturn(shuffleFlushManager);
     when(mockShuffleServer.getShuffleBufferManager()).thenReturn(shuffleBufferManager);
@@ -456,7 +456,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
         StorageManagerFactory.getInstance().createStorageManager(shuffleConf);
     ShuffleFlushManager shuffleFlushManager =
         new ShuffleFlushManager(shuffleConf, mockShuffleServer, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager, false);
     ShuffleTaskManager shuffleTaskManager =
         new ShuffleTaskManager(
             shuffleConf, shuffleFlushManager, shuffleBufferManager, storageManager);
@@ -516,7 +516,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
         StorageManagerFactory.getInstance().createStorageManager(shuffleConf);
     ShuffleFlushManager shuffleFlushManager =
         new ShuffleFlushManager(shuffleConf, mockShuffleServer, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager, false);
 
     when(mockShuffleServer.getShuffleFlushManager()).thenReturn(shuffleFlushManager);
     when(mockShuffleServer.getShuffleBufferManager()).thenReturn(shuffleBufferManager);
@@ -552,7 +552,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     StorageManager storageManager = StorageManagerFactory.getInstance().createStorageManager(conf);
     ShuffleFlushManager shuffleFlushManager =
         new ShuffleFlushManager(conf, mockShuffleServer, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(serverConf, shuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(serverConf, shuffleFlushManager, false);
 
     String appId = "shuffleFlushTest";
     int shuffleId = 0;
@@ -621,7 +621,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   @Test
   public void bufferManagerInitTest() {
     ShuffleServerConf serverConf = new ShuffleServerConf();
-    shuffleBufferManager = new ShuffleBufferManager(serverConf, mockShuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(serverConf, mockShuffleFlushManager, false);
     double ratio = ShuffleServerConf.SERVER_BUFFER_CAPACITY_RATIO.defaultValue();
     double readRatio = ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO.defaultValue();
     assertEquals(
@@ -633,7 +633,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     readRatio = 0.1;
     serverConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY_RATIO, ratio);
     serverConf.set(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO, readRatio);
-    shuffleBufferManager = new ShuffleBufferManager(serverConf, mockShuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(serverConf, mockShuffleFlushManager, false);
     assertEquals(
         (long) (Runtime.getRuntime().maxMemory() * ratio), shuffleBufferManager.getCapacity());
     assertEquals(
@@ -669,7 +669,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
         StorageManagerFactory.getInstance().createStorageManager(shuffleConf);
     ShuffleFlushManager shuffleFlushManager =
         new ShuffleFlushManager(shuffleConf, mockShuffleServer, storageManager);
-    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager);
+    shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager, false);
 
     when(mockShuffleServer.getShuffleFlushManager()).thenReturn(shuffleFlushManager);
     when(mockShuffleServer.getShuffleBufferManager()).thenReturn(shuffleBufferManager);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix [#1008](https://github.com/apache/incubator-uniffle/pull/1008). It does not actually test `GRPC_NETTY` mode, because it uses `ShuffleServerGrpcClient` everywhere instead of `ShuffleServerGrpcNettyClient`. 
Setting the shuffle server's tags to `GRPC_NETTY,GRPC` is useless, because we are not using `ShuffleServerGrpcNettyClient` at all.

### Why are the changes needed?

It is a sub PR for: https://github.com/apache/incubator-uniffle/pull/1519
Also, it is a follow-up PR for: https://github.com/apache/incubator-uniffle/pull/1008

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
