### PR TITLE
[MINOR] improvement(tez): Only invoking LOG.debug when LOG.isDebugEnabled is true

### DIFF
--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBuffer.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBuffer.java
@@ -147,13 +147,15 @@ public class WriteBuffer<K, V> extends OutputStream {
 
   private boolean compact(int lastIndex, int lastOffset, int dataLength) {
     if (lastIndex != currentIndex) {
-      LOG.debug(
-          "compact lastIndex {}, currentIndex {}, lastOffset {} currentOffset {} dataLength {}",
-          lastIndex,
-          currentIndex,
-          lastOffset,
-          currentOffset,
-          dataLength);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "compact lastIndex {}, currentIndex {}, lastOffset {} currentOffset {} dataLength {}",
+            lastIndex,
+            currentIndex,
+            lastOffset,
+            currentOffset,
+            dataLength);
+      }
       WrappedBuffer buffer = new WrappedBuffer(lastOffset + dataLength);
       // copy data
       int offset = 0;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Only invoking LOG.debug when LOG.isDebugEnabled is true

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1201

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
