### PR TITLE
[#1546] fix(spark): NPE could happen before uncompressing after #1360

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -166,7 +166,7 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
           || !isSameMemoryType(uncompressedData, rawData)) {
 
         if (LOG.isDebugEnabled()) {
-          if (!isSameMemoryType(uncompressedData, rawData)) {
+          if (uncompressedData != null && !isSameMemoryType(uncompressedData, rawData)) {
             LOG.debug(
                 "This should not happen that the temporary uncompressed data's memory type(isDirect:{}) "
                     + "is not same with fetched data buffer(isDirect:{})",


### PR DESCRIPTION
### What changes were proposed in this pull request?

NPE cound happen before uncompressing after #1360 

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1546

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
