### PR TITLE
[#1549] fix(common): Uniformly throw RssException for external callers

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/exception/FileNotFoundException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/FileNotFoundException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class FileNotFoundException extends RuntimeException {
+public class FileNotFoundException extends RssException {
 
   public FileNotFoundException(String message) {
     super(message);

--- a/common/src/main/java/org/apache/uniffle/common/exception/InvalidRequestException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/InvalidRequestException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class InvalidRequestException extends RuntimeException {
+public class InvalidRequestException extends RssException {
 
   public InvalidRequestException(String message) {
     super(message);

--- a/common/src/main/java/org/apache/uniffle/common/exception/NoBufferException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoBufferException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class NoBufferException extends RuntimeException {
+public class NoBufferException extends RssException {
   public NoBufferException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/exception/NoBufferForHugePartitionException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoBufferForHugePartitionException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class NoBufferForHugePartitionException extends RuntimeException {
+public class NoBufferForHugePartitionException extends RssException {
   public NoBufferForHugePartitionException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/exception/NoRegisterException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/NoRegisterException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class NoRegisterException extends RuntimeException {
+public class NoRegisterException extends RssException {
   public NoRegisterException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class RssSendFailedException extends RuntimeException {
+public class RssSendFailedException extends RssException {
   public RssSendFailedException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssWaitFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssWaitFailedException.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.common.exception;
 
-public class RssWaitFailedException extends RuntimeException {
+public class RssWaitFailedException extends RssException {
   public RssWaitFailedException(String message) {
     super(message);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make custom exception classes in the `rss-common` module inherit from `RssException`.

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1549

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
