### PR TITLE
[#1472][part-6][FOLLOWUP] Fix Netty transport time when sending shuffle data requests

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequest.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequest.java
@@ -141,4 +141,8 @@ public class SendShuffleDataRequest extends RequestMessage {
   public long getTimestamp() {
     return timestamp;
   }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -131,6 +131,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
               }
 
               sendShuffleDataRequest.setRequireId(requireId);
+              sendShuffleDataRequest.setTimestamp(System.currentTimeMillis());
               long start = System.currentTimeMillis();
               RpcResponse rpcResponse =
                   transportClient.sendRpcSync(sendShuffleDataRequest, rpcTimeout);

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -116,7 +116,7 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
       try {
         RetryUtils.retryWithCondition(
             () -> {
-              TransportClient transportClient = getTransportClient();
+              final TransportClient transportClient = getTransportClient();
               long requireId =
                   requirePreAllocation(
                       request.getAppId(),
@@ -129,7 +129,6 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
                         "requirePreAllocation failed! size[%s], host[%s], port[%s]",
                         allocateSize, host, port));
               }
-
               sendShuffleDataRequest.setRequireId(requireId);
               sendShuffleDataRequest.setTimestamp(System.currentTimeMillis());
               long start = System.currentTimeMillis();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refresh `timestamp` when sending `SendShuffleDataRequest`.

### Why are the changes needed?

A follow-up PR for: https://github.com/apache/incubator-uniffle/pull/1534

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
