### PR TITLE
[#1554] feat(spark): Fetch dynamic client conf as early as possible

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -130,9 +130,13 @@ public class RssSparkShuffleUtils {
         sparkConfKey = RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + sparkConfKey;
       }
       String confVal = kv.getValue();
-      if (!sparkConf.contains(sparkConfKey)
-          || RssSparkConfig.RSS_MANDATORY_CLUSTER_CONF.contains(sparkConfKey)) {
-        LOG.warn("Use conf dynamic conf {} = {}", sparkConfKey, confVal);
+      boolean isMandatory = RssSparkConfig.RSS_MANDATORY_CLUSTER_CONF.contains(sparkConfKey);
+      if (!sparkConf.contains(sparkConfKey) || isMandatory) {
+        if (sparkConf.contains(sparkConfKey) && isMandatory) {
+          LOG.warn("Override with mandatory dynamic conf {} = {}", sparkConfKey, confVal);
+        } else {
+          LOG.info("Use dynamic conf {} = {}", sparkConfKey, confVal);
+        }
         sparkConf.set(sparkConfKey, confVal);
       }
     }

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
@@ -18,8 +18,11 @@
 package org.apache.uniffle.shuffle.manager;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.junit.jupiter.api.Test;
@@ -27,17 +30,33 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
+import org.apache.uniffle.client.api.CoordinatorClient;
+import org.apache.uniffle.client.factory.CoordinatorClientFactory;
+import org.apache.uniffle.client.request.RssFetchClientConfRequest;
+import org.apache.uniffle.client.response.RssFetchClientConfResponse;
+import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 
+import static org.apache.uniffle.common.rpc.StatusCode.INVALID_REQUEST;
+import static org.apache.uniffle.common.rpc.StatusCode.SUCCESS;
 import static org.apache.uniffle.shuffle.manager.RssShuffleManagerBase.getTaskAttemptIdForBlockId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RssShuffleManagerBaseTest {
 
@@ -627,5 +646,68 @@ public class RssShuffleManagerBaseTest {
         e.getMessage());
     // check that a lower mapIndex works as expected
     assertEquals(bits("11111111|00"), getTaskAttemptIdForBlockId(255, 0, 4, false, 10));
+  }
+
+  @Test
+  void testFetchAndApplyDynamicConf() {
+    ClientType clientType = ClientType.GRPC;
+    String coordinators = "host1,host2,host3";
+    int timeout = RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.defaultValue().get() / 10;
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_CLIENT_TYPE, clientType.toString());
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM, coordinators);
+    conf.set(RssSparkConfig.RSS_ACCESS_TIMEOUT_MS, timeout);
+
+    CoordinatorClientFactory mockFactoryInstance = mock(CoordinatorClientFactory.class);
+    CoordinatorClient mockClient1 = mock(CoordinatorClient.class);
+    CoordinatorClient mockClient2 = mock(CoordinatorClient.class);
+    CoordinatorClient mockClient3 = mock(CoordinatorClient.class);
+
+    Map<String, String> clientConf1 = ImmutableMap.of("rss.config.from", "client1");
+    Map<String, String> clientConf2 = ImmutableMap.of("rss.config.from", "client2");
+    Map<String, String> clientConf3 = ImmutableMap.of("rss.config.from", "client3");
+
+    when(mockClient1.fetchClientConf(any(RssFetchClientConfRequest.class)))
+        .thenReturn(new RssFetchClientConfResponse(INVALID_REQUEST, "error", clientConf1));
+    when(mockClient2.fetchClientConf(any(RssFetchClientConfRequest.class)))
+        .thenReturn(new RssFetchClientConfResponse(SUCCESS, "success", clientConf2));
+    when(mockClient3.fetchClientConf(any(RssFetchClientConfRequest.class)))
+        .thenReturn(new RssFetchClientConfResponse(SUCCESS, "success", clientConf3));
+
+    List<CoordinatorClient> mockClients = Arrays.asList(mockClient1, mockClient2, mockClient3);
+    when(mockFactoryInstance.createCoordinatorClient(clientType, coordinators))
+        .thenReturn(mockClients);
+
+    assertFalse(conf.contains("rss.config.from"));
+    assertFalse(conf.contains("spark.rss.config.from"));
+
+    try (MockedStatic<CoordinatorClientFactory> mockFactoryStatic =
+        mockStatic(CoordinatorClientFactory.class)) {
+      mockFactoryStatic.when(CoordinatorClientFactory::getInstance).thenReturn(mockFactoryInstance);
+      RssShuffleManagerBase.fetchAndApplyDynamicConf(conf);
+    }
+
+    assertFalse(conf.contains("rss.config.from"));
+    assertTrue(conf.contains("spark.rss.config.from"));
+    assertEquals("client2", conf.get("spark.rss.config.from"));
+
+    ArgumentCaptor<RssFetchClientConfRequest> request1 =
+        ArgumentCaptor.forClass(RssFetchClientConfRequest.class);
+    ArgumentCaptor<RssFetchClientConfRequest> request2 =
+        ArgumentCaptor.forClass(RssFetchClientConfRequest.class);
+    ArgumentCaptor<RssFetchClientConfRequest> request3 =
+        ArgumentCaptor.forClass(RssFetchClientConfRequest.class);
+
+    verify(mockClient1, times(1)).fetchClientConf(request1.capture());
+    verify(mockClient2, times(1)).fetchClientConf(request2.capture());
+    verify(mockClient3, never()).fetchClientConf(request3.capture());
+
+    assertEquals(timeout, request1.getValue().getTimeoutMs());
+    assertEquals(timeout, request2.getValue().getTimeoutMs());
+
+    verify(mockClient1, times(1)).close();
+    verify(mockClient2, times(1)).close();
+    verify(mockClient3, times(1)).close();
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -152,6 +152,15 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.blockIdLayout = BlockIdLayout.from(rssConf);
     this.user = sparkConf.get("spark.rss.quota.user", "user");
     this.uuid = sparkConf.get("spark.rss.quota.uuid", Long.toString(System.currentTimeMillis()));
+
+    this.dynamicConfEnabled = sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED);
+
+    // fetch client conf and apply them if necessary
+    if (isDriver && this.dynamicConfEnabled) {
+      fetchAndApplyDynamicConf(sparkConf);
+    }
+    RssSparkShuffleUtils.validateRssClientConf(sparkConf);
+
     // set & check replica config
     this.dataReplica = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA);
     this.dataReplicaWrite = sparkConf.get(RssSparkConfig.RSS_DATA_REPLICA_WRITE);
@@ -176,7 +185,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.heartbeatInterval = sparkConf.get(RssSparkConfig.RSS_HEARTBEAT_INTERVAL);
     this.heartbeatTimeout =
         sparkConf.getLong(RssSparkConfig.RSS_HEARTBEAT_TIMEOUT.key(), heartbeatInterval / 2);
-    this.dynamicConfEnabled = sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED);
     int retryMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX);
     long retryIntervalMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_INTERVAL_MAX);
     int heartBeatThreadNum = sparkConf.get(RssSparkConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM);
@@ -203,13 +211,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
                     .unregisterRequestTimeSec(unregisterRequestTimeoutSec)
                     .rssConf(rssConf));
     registerCoordinator();
-    // fetch client conf and apply them if necessary and disable ESS
-    if (isDriver && dynamicConfEnabled) {
-      Map<String, String> clusterClientConf =
-          shuffleWriteClient.fetchClientConf(sparkConf.get(RssSparkConfig.RSS_ACCESS_TIMEOUT_MS));
-      RssSparkShuffleUtils.applyDynamicClientConf(sparkConf, clusterClientConf);
-    }
-    RssSparkShuffleUtils.validateRssClientConf(sparkConf);
     // External shuffle service is not supported when using remote shuffle service
     sparkConf.set("spark.shuffle.service.enabled", "false");
     LOG.info("Disable external shuffle service in RssShuffleManager.");

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -125,6 +125,7 @@ public class DelegationRssShuffleManagerTest {
     conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
     conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
     conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+    conf.set(RssSparkConfig.RSS_STORAGE_TYPE.key(), "MEMORY_LOCALFILE");
 
     // fall back to SortShuffleManager in driver
     assertCreateSortShuffleManager(conf);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -108,7 +108,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker;
   private ScheduledExecutorService heartBeatScheduledExecutorService;
   private boolean heartbeatStarted = false;
-  private boolean dynamicConfEnabled = false;
+  private boolean dynamicConfEnabled;
   private final ShuffleDataDistributionType dataDistributionType;
   private final BlockIdLayout blockIdLayout;
   private final int maxConcurrencyPerPartitionToWrite;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -165,9 +165,10 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     }
     this.user = sparkConf.get("spark.rss.quota.user", "user");
     this.uuid = sparkConf.get("spark.rss.quota.uuid", Long.toString(System.currentTimeMillis()));
+    this.dynamicConfEnabled = sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED);
 
     // fetch client conf and apply them if necessary
-    if (isDriver && sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED)) {
+    if (isDriver && this.dynamicConfEnabled) {
       fetchAndApplyDynamicConf(sparkConf);
     }
     RssSparkShuffleUtils.validateRssClientConf(sparkConf);
@@ -194,7 +195,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         sparkConf.getLong(RssSparkConfig.RSS_HEARTBEAT_TIMEOUT.key(), heartbeatInterval / 2);
     final int retryMax = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX);
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
-    this.dynamicConfEnabled = sparkConf.get(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED);
     this.dataDistributionType = getDataDistributionType(sparkConf);
     RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
     this.maxConcurrencyPerPartitionToWrite = rssConf.get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -29,11 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.apache.uniffle.client.api.CoordinatorClient;
-import org.apache.uniffle.client.factory.CoordinatorClientFactory;
-import org.apache.uniffle.client.request.RssFetchClientConfRequest;
-import org.apache.uniffle.client.response.RssFetchClientConfResponse;
-import org.apache.uniffle.common.rpc.StatusCode;
 import scala.Tuple2;
 import scala.Tuple3;
 import scala.collection.Iterator;
@@ -65,12 +60,16 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
+import org.apache.uniffle.client.factory.CoordinatorClientFactory;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.client.request.RssFetchClientConfRequest;
 import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
+import org.apache.uniffle.client.response.RssFetchClientConfResponse;
 import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.RssClientConfig;
@@ -85,6 +84,7 @@ import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 import org.apache.uniffle.common.rpc.GrpcServer;
+import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -291,11 +291,13 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         coordinatorClientFactory.createCoordinatorClient(
             ClientType.valueOf(clientType), coordinators);
 
-    int timeoutMs = sparkConf.getInt(
-        RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.key(),
-        RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.defaultValue().get());
-    for (CoordinatorClient client: coordinatorClients) {
-      RssFetchClientConfResponse response = client.fetchClientConf(new RssFetchClientConfRequest(timeoutMs));
+    int timeoutMs =
+        sparkConf.getInt(
+            RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.key(),
+            RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.defaultValue().get());
+    for (CoordinatorClient client : coordinatorClients) {
+      RssFetchClientConfResponse response =
+          client.fetchClientConf(new RssFetchClientConfRequest(timeoutMs));
       if (response.getStatusCode() == StatusCode.SUCCESS) {
         LOG.info("Success to get conf from {}", client.getDesc());
         RssSparkShuffleUtils.applyDynamicClientConf(sparkConf, response.getClientConf());

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -304,6 +304,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         LOG.warn("Fail to get conf from {}", client.getDesc());
       }
     }
+
     coordinatorClients.forEach(CoordinatorClient::close);
   }
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -60,16 +60,12 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
-import org.apache.uniffle.client.factory.CoordinatorClientFactory;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
-import org.apache.uniffle.client.request.RssFetchClientConfRequest;
 import org.apache.uniffle.client.request.RssPartitionToShuffleServerRequest;
-import org.apache.uniffle.client.response.RssFetchClientConfResponse;
 import org.apache.uniffle.client.response.RssPartitionToShuffleServerResponse;
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.RssClientConfig;
@@ -84,7 +80,6 @@ import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 import org.apache.uniffle.common.rpc.GrpcServer;
-import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
@@ -281,33 +276,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.failuresShuffleServerIds = Sets.newHashSet();
     this.serverAssignedInfos = JavaUtils.newConcurrentMap();
     this.reassignedFaultyServers = JavaUtils.newConcurrentMap();
-  }
-
-  private static void fetchAndApplyDynamicConf(SparkConf sparkConf) {
-    String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
-    String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM.key());
-    CoordinatorClientFactory coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    List<CoordinatorClient> coordinatorClients =
-        coordinatorClientFactory.createCoordinatorClient(
-            ClientType.valueOf(clientType), coordinators);
-
-    int timeoutMs =
-        sparkConf.getInt(
-            RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.key(),
-            RssSparkConfig.RSS_ACCESS_TIMEOUT_MS.defaultValue().get());
-    for (CoordinatorClient client : coordinatorClients) {
-      RssFetchClientConfResponse response =
-          client.fetchClientConf(new RssFetchClientConfRequest(timeoutMs));
-      if (response.getStatusCode() == StatusCode.SUCCESS) {
-        LOG.info("Success to get conf from {}", client.getDesc());
-        RssSparkShuffleUtils.applyDynamicClientConf(sparkConf, response.getClientConf());
-        break;
-      } else {
-        LOG.warn("Fail to get conf from {}", client.getDesc());
-      }
-    }
-
-    coordinatorClients.forEach(CoordinatorClient::close);
   }
 
   public CompletableFuture<Long> sendData(AddBlockEvent event) {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -78,6 +78,7 @@ public class DelegationRssShuffleManagerTest extends RssShuffleManagerTestBase {
     conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
     conf.set(RssSparkConfig.RSS_ACCESS_ID.key(), "mockId");
     conf.set(RssSparkConfig.RSS_ENABLED.key(), "true");
+    conf.set(RssSparkConfig.RSS_STORAGE_TYPE.key(), "MEMORY_LOCALFILE");
 
     // fall back to SortShuffleManager in driver
     assertCreateSortShuffleManager(conf);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fetches dynamic client config as early as possible, to be able to use dynamic client config to create the shuffle client with updated config.

### Why are the changes needed?
Providing config or the shuffle client via coordinator is operationally useful as cluster-wide settings can be deployed through the cluster and changed over time. Clients and apps do not need to change configs.

Fixes Spark part of #1554

### Does this PR introduce _any_ user-facing change?
More configs can be provided via coordinators.

### How was this patch tested?
Existing and [follow-up](https://github.com/apache/incubator-uniffle/pull/1528/files#diff-ea644edb1c0bf0e80f9a960adbc1615c99cb6a3a0d5fe24f788307f1daf22f46R127-R131) unit tests.