### PR TITLE
[MINOR] improvement(client): Override getClientInfo method in ShuffleServerGrpcNettyClient and remove unused getDesc method

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleServerClient.java
@@ -74,8 +74,6 @@ public interface ShuffleServerClient {
   RssGetInMemoryShuffleDataResponse getInMemoryShuffleData(
       RssGetInMemoryShuffleDataRequest request);
 
-  String getDesc();
-
   void close();
 
   String getClientInfo();

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -152,11 +152,6 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
     return blockingStub.withDeadlineAfter(rpcTimeout, TimeUnit.MILLISECONDS);
   }
 
-  @Override
-  public String getDesc() {
-    return "Shuffle server grpc client ref " + host + ":" + port;
-  }
-
   private ShuffleRegisterResponse doRegisterShuffle(
       String appId,
       int shuffleId,

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -86,6 +86,17 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
   }
 
   @Override
+  public String getClientInfo() {
+    return "ShuffleServerGrpcNettyClient for host["
+        + host
+        + "], port["
+        + port
+        + "], nettyPort["
+        + nettyPort
+        + "]";
+  }
+
+  @Override
   public RssSendShuffleDataResponse sendShuffleData(RssSendShuffleDataRequest request) {
     Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks =
         request.getShuffleIdToBlocks();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Override the `getClientInfo` method in `ShuffleServerGrpcNettyClient` and remove the unused `getDesc` method.

### Why are the changes needed?

The code is cleaner, and the returned value of `getClientInfo` is more accurate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
