### PR TITLE
[#731][FOLLOWUP] feat(Spark): Configure blockIdLayout for Spark based on max partitions

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -373,6 +373,15 @@ public class RssSparkConfig {
                   .doc("Whether to enable the resubmit stage."))
           .createWithDefault(false);
 
+  public static final ConfigEntry<Integer> RSS_MAX_PARTITIONS =
+      createIntegerBuilder(
+              new ConfigBuilder("spark.rss.blockId.maxPartitions")
+                  .doc(
+                      "Sets the maximum number of partitions to be supported by block ids. "
+                          + "This determines the bits reserved in block ids for the "
+                          + "sequence number, the partition id and the task attempt id."))
+          .createWithDefault(1048576);
+
   // spark2 doesn't have this key defined
   public static final String SPARK_SHUFFLE_COMPRESS_KEY = "spark.shuffle.compress";
 

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -61,7 +61,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
 
   /**
    * Derives block id layout config from maximum number of allowed partitions. This value can be set
-   * in either of SparkConf or RssConf via RssSparkConfig.RSS_MAX_PARTITIONS, where SparkConf has
+   * in either SparkConf or RssConf via RssSparkConfig.RSS_MAX_PARTITIONS, where SparkConf has
    * precedence.
    *
    * <p>Computes the number of required bits for partition id and task attempt id and reserves

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
@@ -31,6 +31,8 @@ import org.apache.uniffle.common.config.RssConf;
  */
 public class BlockIdLayout {
 
+  // historic default values, client-specific config defaults may vary
+  // see RssSparkConfig.RSS_MAX_PARTITIONS
   public static final BlockIdLayout DEFAULT = BlockIdLayout.from(18, 24, 21);
 
   public final int sequenceNoBits;

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -22,7 +22,7 @@ public final class Constants {
   private Constants() {}
 
   // the value is used for client/server compatible, eg, online upgrade
-  public static final String SHUFFLE_SERVER_VERSION = "ss_v4";
+  public static final String SHUFFLE_SERVER_VERSION = "ss_v5";
   public static final String METRICS_TAG_LABEL_NAME = "tags";
   public static final String COORDINATOR_TAG = "coordinator";
   public static final String SHUFFLE_DATA_FILE_SUFFIX = ".data";

--- a/docs/client_guide/spark_client_guide.md
+++ b/docs/client_guide/spark_client_guide.md
@@ -90,7 +90,8 @@ The important configuration is listed as following.
 
 ### Block id bits
 
-If you observe an error like
+The default bits reserved in the block id are client-type agnostic. To maximize the bit utilization for Spark3 clients,
+adopt the following considerations. Also, if you observe an error like
 
     Don't support sequenceNo[…], the max value should be …
     Don't support partitionId[…], the max value should be …

--- a/docs/client_guide/spark_client_guide.md
+++ b/docs/client_guide/spark_client_guide.md
@@ -90,8 +90,7 @@ The important configuration is listed as following.
 
 ### Block id bits
 
-The default bits reserved in the block id are client-type agnostic. To maximize the bit utilization for Spark3 clients,
-adopt the following considerations. Also, if you observe an error like
+If you observe an error like
 
     Don't support sequenceNo[…], the max value should be …
     Don't support partitionId[…], the max value should be …
@@ -102,7 +101,22 @@ adopt the following considerations. Also, if you observe an error like
 
 you should consider increasing the bits reserved in the blockId for that number / id (while decreasing the other number of bits).
 
-The bits reserved for sequence number, partition id and task attempt id are best specified for Spark clients as follows:
+Using the Spark client, configuring the blockId bits is as easy as defining a maximum number of supported partitions only:
+
+| Property Name                   | Default | Description                                                                                                                                                         |
+|---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| spark.rss.blockId.maxPartitions | 1048576 | Number of partitions supported by the Spark client (`[2..2,147,483,648]`). |
+
+The Spark client derives the optimal values for the following properties.
+Alternatively, these properties can be configured instead of `spark.rss.blockId.maxPartitions`:
+
+| Property Name                       | Default | Description                                                                                                                                                         |
+|-------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| spark.rss.blockId.sequenceNoBits    | 18      | Number of bits reserved in the blockId for the sequence number (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`. |
+| spark.rss.blockId.partitionIdBits   | 24      | Number of bits reserved in the blockId for the partition id (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`.    |
+| spark.rss.blockId.taskAttemptIdBits | 21      | Number of bits reserved in the blockId for the task attempt id (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`. |
+
+The bits reserved for sequence number, partition id and task attempt id are best specified for Spark clients as follows (done automatically if `spark.rss.blockId.maxPartitions` is set):
 
 1. Reserve the bits required to support the largest number of partitions that you anticipate. Pick `ceil( log(max number of partitions) / log(2) )` bits.
    For instance, `20` bits support `1,048,576` partitions.
@@ -111,12 +125,6 @@ The bits reserved for sequence number, partition id and task attempt id are best
    speculative execution enabled via Spark conf `spark.speculation` (default is false), that `max attempts` has to be incremented by one.
    For example: `22` bits is sufficient for `taskAttemptIdBits` with `partitionIdBits=20`, and Spark conf `spark.task.maxFailures=4` and `spark.speculation=false`.
 3. Reserve the remaining bits to `sequenceNoBits`: `sequenceNoBits = 63 - partitionIdBits - taskAttemptIdBits`.
-
-| Property Name                       | Default | Description                                                                                                                                                         |
-|-------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| spark.rss.blockId.sequenceNoBits    | 18      | Number of bits reserved in the blockId for the sequence number (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`. |
-| spark.rss.blockId.partitionIdBits   | 24      | Number of bits reserved in the blockId for the partition id (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`.    |
-| spark.rss.blockId.taskAttemptIdBits | 21      | Number of bits reserved in the blockId for the task attempt id (`[1..31]`). Note that `sequenceNoBits + partitionIdBits + taskAttemptIdBits` has to sum up to `63`. |
 
 ### Adaptive Remote Shuffle Enabling 
 Currently, this feature only supports Spark. 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerGrpcTest.java
@@ -75,7 +75,6 @@ import org.apache.uniffle.common.metrics.TestUtils;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
-import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
@@ -418,20 +417,6 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
     blockIdBitmap = result.getBlockIdBitmap();
     expectedP3 = Roaring64NavigableMap.bitmapOf();
     addExpectedBlockIds(expectedP3, blockIds3);
-    assertEquals(expectedP3, blockIdBitmap);
-
-    // get same shuffle result without block id layout (legacy clients)
-    RssProtos.GetShuffleResultRequest rpcRequest =
-        RssProtos.GetShuffleResultRequest.newBuilder()
-            .setAppId("shuffleResultTest")
-            .setShuffleId(4)
-            .setPartitionId(3)
-            // deliberately not setting block id layout through .setBlockIdLayout
-            .build();
-    RssProtos.GetShuffleResultResponse rpcResponse =
-        grpcShuffleServerClient.getBlockingStub().getShuffleResult(rpcRequest);
-    assertEquals(RssProtos.StatusCode.SUCCESS, rpcResponse.getStatus());
-    blockIdBitmap = RssUtils.deserializeBitMap(rpcResponse.getSerializedBitmap().toByteArray());
     assertEquals(expectedP3, blockIdBitmap);
 
     // wait resources are deleted

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
@@ -103,6 +103,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
     return new HashMap();
   }
 
+  private static final BlockIdLayout DEFAULT = BlockIdLayout.from(21, 20, 22);
   private static final BlockIdLayout CUSTOM1 = BlockIdLayout.from(20, 21, 22);
   private static final BlockIdLayout CUSTOM2 = BlockIdLayout.from(22, 18, 23);
 
@@ -113,7 +114,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testRssShuffleManager(boolean enableDynamicClientConf) throws Exception {
-    doTestRssShuffleManager(null, null, BlockIdLayout.DEFAULT, enableDynamicClientConf);
+    doTestRssShuffleManager(null, null, DEFAULT, enableDynamicClientConf);
   }
 
   @ParameterizedTest
@@ -187,6 +188,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
       // get written block ids (we know there is one shuffle where two task attempts wrote two
       // partitions)
       RssConf rssConf = RssSparkConfig.toRssConf(conf);
+      shuffleManager.configureBlockIdLayout(conf, rssConf);
       ShuffleWriteClient shuffleWriteClient =
           ShuffleClientFactory.newWriteBuilder()
               .clientType(ClientType.GRPC.name())

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -529,15 +529,11 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     String appId = request.getAppId();
     int shuffleId = request.getShuffleId();
     int partitionId = request.getPartitionId();
-    BlockIdLayout blockIdLayout = BlockIdLayout.DEFAULT;
-    // legacy clients might send request without block id layout, we fall back to DEFAULT then
-    if (request.hasBlockIdLayout()) {
-      blockIdLayout =
-          BlockIdLayout.from(
-              request.getBlockIdLayout().getSequenceNoBits(),
-              request.getBlockIdLayout().getPartitionIdBits(),
-              request.getBlockIdLayout().getTaskAttemptIdBits());
-    }
+    BlockIdLayout blockIdLayout =
+        BlockIdLayout.from(
+            request.getBlockIdLayout().getSequenceNoBits(),
+            request.getBlockIdLayout().getPartitionIdBits(),
+            request.getBlockIdLayout().getTaskAttemptIdBits());
     StatusCode status = StatusCode.SUCCESS;
     String msg = "OK";
     GetShuffleResultResponse reply;
@@ -581,15 +577,11 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     String appId = request.getAppId();
     int shuffleId = request.getShuffleId();
     List<Integer> partitionsList = request.getPartitionsList();
-    BlockIdLayout blockIdLayout = BlockIdLayout.DEFAULT;
-    // legacy clients might send request without block id layout, we fall back to DEFAULT then
-    if (request.hasBlockIdLayout()) {
-      blockIdLayout =
-          BlockIdLayout.from(
-              request.getBlockIdLayout().getSequenceNoBits(),
-              request.getBlockIdLayout().getPartitionIdBits(),
-              request.getBlockIdLayout().getTaskAttemptIdBits());
-    }
+    BlockIdLayout blockIdLayout =
+        BlockIdLayout.from(
+            request.getBlockIdLayout().getSequenceNoBits(),
+            request.getBlockIdLayout().getPartitionIdBits(),
+            request.getBlockIdLayout().getTaskAttemptIdBits());
 
     StatusCode status = StatusCode.SUCCESS;
     String msg = "OK";


### PR DESCRIPTION
### What changes were proposed in this pull request?
The configuration of the block id layout for Spark2 and Spark3 can be simplified by only providing the maximal number of partitions. Increments `SHUFFLE_SERVER_VERSION` as the "new" Spark client requires to connect to a "new" shuffle server.

### Why are the changes needed?
Currently, optimally configuring the block id layout for Spark is quite complex: https://github.com/apache/incubator-uniffle/pull/1528/files#diff-09ce7eaa98815d62ca00b2a8b0a45b0a922b047014c1f91dc17081b3fef8e7a8R106-R112

Three values have to be provided: the number of bits for sequence number, partition id and task attempt id. The task attempt id has to provide more bits than the partition id, in the sense that the maximal number of attempts can be stored. This requires to also account for speculative execution.

The RssShuffleManager can do the computation and derive the optimal block id layout configuration from the maximal number of partitions only.

### Does this PR introduce _any_ user-facing change?
Adds optional configuration `spark.rss.blockId.maxPartitions`.

### How was this patch tested?
Unit and integration tests.