### PR TITLE
[#1569] fix(rust): flaky test for `test_ticket_manager`

### DIFF
--- a/rust/experimental/server/src/store/mem/ticket.rs
+++ b/rust/experimental/server/src/store/mem/ticket.rs
@@ -47,7 +47,7 @@ impl Ticket {
     }
 
     pub fn is_timeout(&self, timeout_sec: i64) -> bool {
-        crate::util::current_timestamp_sec() - self.created_time > timeout_sec as u64
+        (crate::util::current_timestamp_sec() - self.created_time) as i64 > timeout_sec
     }
 
     pub fn get_id(&self) -> i64 {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `i64` to fix overflow rather than `u64`

### Why are the changes needed?

Fix: #1569. to fix `test_ticket_manager`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing uts
