### PR TITLE
[#1572] fix(spark): Exceptions might be discarded when spilling buffers

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -482,6 +482,9 @@ public class WriteBufferManager extends MemoryConsumer {
     } catch (TimeoutException timeoutException) {
       // A best effort strategy to wait.
       // If timeout exception occurs, the underlying tasks won't be cancelled.
+      LOG.warn("[taskId: {}] Spill tasks timeout after {} seconds", taskId, memorySpillTimeoutSec);
+    } catch (Exception e) {
+      LOG.warn("[taskId: {}] Failed to spill buffers due to ", taskId, e);
     } finally {
       long releasedSize =
           futures.stream()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Handle all the exceptions when spilling buffers.
Let users know when a TimeoutException occurs.

### Why are the changes needed?

Fix https://github.com/apache/incubator-uniffle/issues/1572.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
