### PR TITLE
[#1571] fix(server): Memory may leak when EventInvalidException occurs

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
@@ -40,7 +40,6 @@ public class ShuffleDataFlushEvent {
   private final long size;
   private final List<ShufflePartitionedBlock> shuffleBlocks;
   private final Supplier<Boolean> valid;
-
   private final ShuffleBuffer shuffleBuffer;
   private final AtomicInteger retryTimes = new AtomicInteger();
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDataFlushEvent.java
@@ -40,6 +40,7 @@ public class ShuffleDataFlushEvent {
   private final long size;
   private final List<ShufflePartitionedBlock> shuffleBlocks;
   private final Supplier<Boolean> valid;
+
   private final ShuffleBuffer shuffleBuffer;
   private final AtomicInteger retryTimes = new AtomicInteger();
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -81,7 +81,8 @@ public class ShuffleFlushManager {
     storageBasePaths = RssUtils.getConfiguredLocalDirs(shuffleServerConf);
     pendingEventTimeoutSec = shuffleServerConf.getLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC);
     eventHandler =
-        new DefaultFlushEventHandler(shuffleServerConf, storageManager, this::processFlushEvent);
+        new DefaultFlushEventHandler(
+            shuffleServerConf, storageManager, shuffleServer, this::processFlushEvent);
   }
 
   public void addToFlushQueue(ShuffleDataFlushEvent event) {

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerOnKerberizedHadoopTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerOnKerberizedHadoopTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -104,6 +105,12 @@ public class ShuffleFlushManagerOnKerberizedHadoopTest extends KerberizedHadoopB
 
     when(mockShuffleServer.getShuffleTaskManager().getUserByAppId(appId1)).thenReturn("alex");
     when(mockShuffleServer.getShuffleTaskManager().getUserByAppId(appId2)).thenReturn("alex");
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId1))
+        .thenReturn(rsLock.readLock());
+    ReentrantReadWriteLock rsLock2 = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId2))
+        .thenReturn(rsLock2.readLock());
 
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -139,6 +140,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ShuffleServerConf.SERVER_MAX_CONCURRENCY_OF_ONE_PARTITION, maxConcurrency);
 
     String appId = "concurrentWrite2HdfsWriteOneByOne_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     storageManager.registerRemoteStorage(appId, remoteStorage);
@@ -171,6 +175,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ShuffleServerConf.SERVER_MAX_CONCURRENCY_OF_ONE_PARTITION, maxConcurrency);
 
     String appId = "concurrentWrite2HdfsWriteOfSinglePartition_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     storageManager.registerRemoteStorage(appId, remoteStorage);
@@ -198,6 +205,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
   @Test
   public void writeTest() throws Exception {
     String appId = "writeTest_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     storageManager.registerRemoteStorage(appId, remoteStorage);
@@ -263,6 +273,8 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     // test case for process event whose related app was cleared already
     assertEquals(0, ShuffleServerMetrics.gaugeWriteHandler.get(), 0.5);
     ShuffleDataFlushEvent fakeEvent = createShuffleDataFlushEvent("fakeAppId", 1, 1, 1, null);
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock("fakeAppId"))
+        .thenReturn(rsLock.readLock());
     manager.addToFlushQueue(fakeEvent);
     waitForQueueClear(manager);
     waitForMetrics(ShuffleServerMetrics.gaugeWriteHandler, 0, 0.5);
@@ -276,6 +288,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE.name());
 
     String appId = "localMetricsTest_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     ShuffleFlushManager manager =
@@ -306,6 +321,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
 
     String appId = "localMetricsTest_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     ShuffleFlushManager manager =
@@ -355,6 +373,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     String appId = "complexWriteTest_appId";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     storageManager.registerRemoteStorage(appId, remoteStorage);
     List<ShufflePartitionedBlock> expectedBlocks = Lists.newArrayList();
     List<ShuffleDataFlushEvent> flushEvents1 = Lists.newArrayList();
@@ -399,6 +420,12 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     String appId1 = "complexWriteTest_appId1";
     String appId2 = "complexWriteTest_appId2";
+    ReentrantReadWriteLock rsLock1 = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId1))
+        .thenReturn(rsLock1.readLock());
+    ReentrantReadWriteLock rsLock2 = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId2))
+        .thenReturn(rsLock2.readLock());
     storageManager.registerRemoteStorage(appId1, remoteStorage);
     storageManager.registerRemoteStorage(appId2, remoteStorage);
     ShuffleFlushManager manager =
@@ -456,6 +483,12 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
   public void clearLocalTest(@TempDir File tempDir) throws Exception {
     final String appId1 = "clearLocalTest_appId1";
     final String appId2 = "clearLocalTest_appId12";
+    ReentrantReadWriteLock rsLock1 = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId1))
+        .thenReturn(rsLock1.readLock());
+    ReentrantReadWriteLock rsLock2 = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId2))
+        .thenReturn(rsLock2.readLock());
     ShuffleServerConf serverConf = new ShuffleServerConf();
     serverConf.set(
         ShuffleServerConf.RSS_STORAGE_BASE_PATH, Arrays.asList(tempDir.getAbsolutePath()));
@@ -690,6 +723,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     String appId = "fallbackWrittenWhenMultiStorageManagerEnableTest";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     storageManager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage.getPath()));
 
     ShuffleFlushManager flushManager =
@@ -740,6 +776,9 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     StorageManager storageManager =
         StorageManagerFactory.getInstance().createStorageManager(shuffleServerConf);
     String appId = "fallbackWrittenWhenMultiStorageManagerEnableTest";
+    ReentrantReadWriteLock rsLock = new ReentrantReadWriteLock();
+    when(mockShuffleServer.getShuffleTaskManager().getAppReadLock(appId))
+        .thenReturn(rsLock.readLock());
     storageManager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage.getPath()));
 
     ShuffleFlushManager flushManager =

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.google.common.collect.RangeMap;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -85,6 +86,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     mockShuffleTaskManager = mock(ShuffleTaskManager.class);
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager = new ShuffleBufferManager(conf, mockShuffleFlushManager, false);
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
   }
 
   @Test
@@ -115,6 +117,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   @Test
   public void getShuffleDataWithExpectedTaskIdsTest() {
     String appId = "getShuffleDataWithExpectedTaskIdsTest";
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, 1, 0, 1);
     ShufflePartitionedData spd1 = createData(0, 1, 68);
     ShufflePartitionedData spd2 = createData(0, 2, 68);
@@ -146,6 +152,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   @Test
   public void getShuffleDataTest() {
     String appId = "getShuffleDataTest";
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, 1, 0, 1);
     shuffleBufferManager.registerBuffer(appId, 2, 0, 1);
     shuffleBufferManager.registerBuffer(appId, 3, 0, 1);
@@ -209,6 +219,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   public void shuffleIdToSizeTest() {
     String appId1 = "shuffleIdToSizeTest1";
     String appId2 = "shuffleIdToSizeTest2";
+    ReentrantReadWriteLock rwLock1 = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId1)).thenReturn(rwLock1.readLock());
+    ReentrantReadWriteLock rwLock2 = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId2)).thenReturn(rwLock2.readLock());
     shuffleBufferManager.registerBuffer(appId1, 1, 0, 0);
     shuffleBufferManager.registerBuffer(appId1, 2, 0, 0);
     shuffleBufferManager.registerBuffer(appId2, 1, 0, 0);
@@ -255,7 +269,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   public void cacheShuffleDataTest() {
     String appId = "cacheShuffleDataTest";
     int shuffleId = 1;
-
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     int startPartitionNum = (int) ShuffleServerMetrics.gaugeTotalPartitionNum.get();
     StatusCode sc =
         shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 16));
@@ -323,7 +340,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   public void cacheShuffleDataWithPreAllocationTest() {
     String appId = "cacheShuffleDataWithPreAllocationTest";
     int shuffleId = 1;
-
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     // pre allocate memory
     shuffleBufferManager.requireMemory(48, true);
@@ -394,7 +414,11 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
 
     String appId = "bufferSizeTest";
     int shuffleId = 1;
-
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 4, 5);
@@ -524,7 +548,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
 
     String appId = "bufferSizeTest";
     int shuffleId = 1;
-
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 64));
@@ -555,10 +582,14 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     shuffleBufferManager = new ShuffleBufferManager(serverConf, shuffleFlushManager, false);
 
     String appId = "shuffleFlushTest";
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+
     int shuffleId = 0;
     int smallShuffleId = 1;
     int smallShuffleIdTwo = 2;
-
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.registerBuffer(appId, smallShuffleId, 0, 1);
@@ -677,6 +708,10 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
 
     String appId = "bufferSizeTest";
     int shuffleId = 1;
+    shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
+    ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 64));

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -268,12 +268,12 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   @Test
   public void cacheShuffleDataTest() {
     String appId = "cacheShuffleDataTest";
-    int shuffleId = 1;
     shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
     ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
     when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     int startPartitionNum = (int) ShuffleServerMetrics.gaugeTotalPartitionNum.get();
+    int shuffleId = 1;
     StatusCode sc =
         shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 16));
     assertEquals(StatusCode.NO_REGISTER, sc);
@@ -339,11 +339,11 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   @Test
   public void cacheShuffleDataWithPreAllocationTest() {
     String appId = "cacheShuffleDataWithPreAllocationTest";
-    int shuffleId = 1;
     shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
     ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
     when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+    int shuffleId = 1;
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     // pre allocate memory
     shuffleBufferManager.requireMemory(48, true);
@@ -413,11 +413,11 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mock(ShuffleTaskManager.class));
 
     String appId = "bufferSizeTest";
-    int shuffleId = 1;
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
     ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
     when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
+    int shuffleId = 1;
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
@@ -547,11 +547,11 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mock(ShuffleTaskManager.class));
 
     String appId = "bufferSizeTest";
-    int shuffleId = 1;
     shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
     ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
     when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+    int shuffleId = 1;
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 64));
@@ -707,11 +707,11 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mock(ShuffleTaskManager.class));
 
     String appId = "bufferSizeTest";
-    int shuffleId = 1;
     shuffleBufferManager.setShuffleTaskManager(mockShuffleTaskManager);
     ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
     when(mockShuffleTaskManager.getAppReadLock(appId)).thenReturn(rwLock.readLock());
     when(mockShuffleServer.getShuffleTaskManager()).thenReturn(mockShuffleTaskManager);
+    int shuffleId = 1;
     shuffleBufferManager.registerBuffer(appId, shuffleId, 0, 1);
     shuffleBufferManager.registerBuffer(appId, shuffleId, 2, 3);
     shuffleBufferManager.cacheShuffleData(appId, shuffleId, false, createData(0, 64));


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the implementation of the methods `flushBuffer`, `handleEventAndUpdateMetrics`, and `removeBufferByShuffleId`, read-write locks have been added to manage concurrency. This ensures that a `ShuffleBuffer` successfully converted into a `flushEvent` won't be cleaned up again by `removeBufferByShuffleId`, and a `ShuffleBuffer` already cleaned up by `removeBufferByShuffleId` won't be transformed back into a `flushEvent`. This effectively resolves the concurrency issue.

### Why are the changes needed?

Fix https://github.com/apache/incubator-uniffle/issues/1571 & https://github.com/apache/incubator-uniffle/issues/1560 & https://github.com/apache/incubator-uniffle/issues/1542

The key logic of the PR is as follows:

Before this PR:
1. A `ShuffleBuffer` is turned into a `FlushEvent`, and **_its blocks and size are cleared_**
→
2. The `FlushEvent` is added to the flushing queue
→
3. The method `removeBufferByShuffleId` is executed, which causes the following things to happen:

3.1. Running the following code snippet, but please note that in the code below, `buffer.getBlocks()` **_is empty and size is 0_**, because of the step 1 above:
```
for (ShuffleBuffer buffer : buffers) {
  buffer.getBlocks().forEach(spb -> spb.getData().release());
  ShuffleServerMetrics.gaugeTotalPartitionNum.dec();
  size += buffer.getSize();
}
```

3.2. `appId` is removed from the `bufferPool`
→
4. The `FlushEvent` is taken out from the queue and encounters an `EventInvalidException` because the `appId` was removed before
→
5. When handling the `EventInvalidException`, nothing is done and the `event.doCleanup()` method **_is not called, causing a memory leak_**.
Of course, this is just one scenario of concurrency exceptions. In the previous code, without locking, in the `processFlushEvent` method, it is possible that the event may become invalid at any time when continuing executing in `processFlushEvent` method, which is why there is https://github.com/apache/incubator-uniffle/issues/1542. Also, there is https://github.com/apache/incubator-uniffle/issues/1560.

---

After this PR:
We will set a read lock for steps 1 and 2 above, a write lock for step 3, a read lock for step 4, and when encountering an `EventInvalidException` in step 5, we will call the `event.doCleanup()` method to release the memory.

In this way, we can ensure the following things when resources are being cleaned up:
1. `ShuffleBuffers` that have not yet been converted to `FlushEvents` will not be converted in the future, but will be directly cleaned up.
2. `FlushEvents` that have been converted from `ShuffleBuffers` will definitely encounter an `EventInvalidException`, and we will eventually handle this exception correctly, releasing memory.
3. If there is already a `FlushEvent` being processed and it is about to be flushed to disk, the resource cleanup task will wait for all `FlushEvents` related to the `appId` to be completed before starting the cleanup task, ensuring that the cleanup and flushing tasks are completely independent and do not interfere with each other.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.