### PR TITLE
[#1576] feat(doc): server deploy guide without hadoop-home env

### DIFF
--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
@@ -63,7 +63,8 @@ public class RssShuffleManagerBaseTest {
   @Test
   public void testGetDefaultRemoteStorageInfo() {
     SparkConf sparkConf = new SparkConf();
-    sparkConf.set("spark." + RssClientConf.RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED.key(), "false");
+    sparkConf.set(
+        "spark." + RssClientConf.RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED.key(), "false");
     RemoteStorageInfo remoteStorageInfo =
         RssShuffleManagerBase.getDefaultRemoteStorageInfo(sparkConf);
     assertTrue(remoteStorageInfo.getConfItems().isEmpty());

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
@@ -63,6 +63,7 @@ public class RssShuffleManagerBaseTest {
   @Test
   public void testGetDefaultRemoteStorageInfo() {
     SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark." + RssClientConf.RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED.key(), "false");
     RemoteStorageInfo remoteStorageInfo =
         RssShuffleManagerBase.getDefaultRemoteStorageInfo(sparkConf);
     assertTrue(remoteStorageInfo.getConfItems().isEmpty());

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -198,7 +198,7 @@ public class RssClientConf {
   public static final ConfigOption<Boolean> RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED =
       ConfigOptions.key("rss.client.remote.storage.useLocalConfAsDefault")
           .booleanType()
-          .defaultValue(true)
+          .defaultValue(false)
           .withDescription(
               "This option is only valid when the remote storage path is specified. If ture, "
                   + "the remote storage conf will use the client side hadoop configuration loaded from the classpath.");

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -198,7 +198,7 @@ public class RssClientConf {
   public static final ConfigOption<Boolean> RSS_CLIENT_REMOTE_STORAGE_USE_LOCAL_CONF_ENABLED =
       ConfigOptions.key("rss.client.remote.storage.useLocalConfAsDefault")
           .booleanType()
-          .defaultValue(false)
+          .defaultValue(true)
           .withDescription(
               "This option is only valid when the remote storage path is specified. If ture, "
                   + "the remote storage conf will use the client side hadoop configuration loaded from the classpath.");

--- a/docs/server_guide.md
+++ b/docs/server_guide.md
@@ -35,7 +35,7 @@ This document will introduce how to deploy Uniffle shuffle servers.
    
    For the following cases, you don't need to specify `HADOOP_HOME` that will simplify the server deployment.
    1. using the storage type without HDFS like `MEMORY_LOCALFILE
-   2. using HDFS and package with hadoop jars, like this: `./build_distribution.sh --hadoop-profile 'hadoop3.2' -Phadoop-dependencies-included`
+   2. using HDFS and package with hadoop jars, like this: `./build_distribution.sh --hadoop-profile 'hadoop3.2' -Phadoop-dependencies-included`. But you need to explicitly set the `spark.rss.client.remote.storage.useLocalConfAsDefault=true`
 
 3. update RSS_HOME/conf/server.conf, eg,
    ```

--- a/docs/server_guide.md
+++ b/docs/server_guide.md
@@ -32,6 +32,11 @@ This document will introduce how to deploy Uniffle shuffle servers.
      HADOOP_HOME=<hadoop home>
      XMX_SIZE="80g"
    ```
+   
+   For the following cases, you don't need to specify `HADOOP_HOME` that will simplify the server deployment.
+   1. using the storage type without HDFS like `MEMORY_LOCALFILE
+   2. using HDFS and package with hadoop jars, like this: `./build_distribution.sh --hadoop-profile 'hadoop3.2' -Phadoop-dependencies-included`
+
 3. update RSS_HOME/conf/server.conf, eg,
    ```
      rss.rpc.server.port 19999


### PR DESCRIPTION

### What changes were proposed in this pull request?

Provide the uniffle server deploy guide for those machines without hadoop env.

### Why are the changes needed?

Leveraging from the #1379 and #1370 , we could setup uniffle shuffle-server without hadoop env.
This will simplify the quick start process.

Fix: #1576

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests
