### PR TITLE
fix(spark): add all faulty servers into blacklist while writing for stage recomputing 

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.shuffle.manager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -350,17 +349,16 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                 });
             List<Map.Entry<String, AtomicInteger>> list =
                 new ArrayList(shuffleServerFailureRecordCount.entrySet());
-            if (!list.isEmpty()) {
-              Collections.sort(list, (o1, o2) -> (o1.getValue().get() - o2.getValue().get()));
-              Map.Entry<String, AtomicInteger> shuffleServerInfoIntegerEntry = list.get(0);
+            boolean retry = false;
+            for (Map.Entry<String, AtomicInteger> shuffleServerInfoIntegerEntry : list) {
               if (shuffleServerInfoIntegerEntry.getValue().get()
                   > shuffleManager.getMaxFetchFailures()) {
                 shuffleManager.addFailuresShuffleServerInfos(
                     shuffleServerInfoIntegerEntry.getKey());
-                return true;
+                retry = true;
               }
             }
-            return false;
+            return retry;
           });
     }
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -183,18 +183,21 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     }
   }
 
-  protected static void createMockedShuffleServer(ShuffleServerConf serverConf) throws Exception {
+  protected static MockedShuffleServer createMockedShuffleServer(ShuffleServerConf serverConf)
+      throws Exception {
     ServerType serverType = serverConf.get(ShuffleServerConf.RPC_SERVER_TYPE);
+    MockedShuffleServer server = new MockedShuffleServer(serverConf);
     switch (serverType) {
       case GRPC:
-        grpcShuffleServers.add(new MockedShuffleServer(serverConf));
+        grpcShuffleServers.add(server);
         break;
       case GRPC_NETTY:
-        nettyShuffleServers.add(new MockedShuffleServer(serverConf));
+        nettyShuffleServers.add(server);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported server type " + serverType);
     }
+    return server;
   }
 
   protected static void createAndStartServers(

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageDynamicServerReWriteTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageDynamicServerReWriteTest.java
@@ -36,6 +36,7 @@ import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.MockedGrpcServer;
+import org.apache.uniffle.server.MockedShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -52,10 +53,10 @@ public class RSSStageDynamicServerReWriteTest extends SparkTaskFailureIntegratio
     addDynamicConf(coordinatorConf, dynamicConf);
     createCoordinatorServer(coordinatorConf);
     createServer(0, tmpDir, true, ServerType.GRPC);
-    createServer(1, tmpDir, false, ServerType.GRPC);
+    createServer(1, tmpDir, true, ServerType.GRPC);
     createServer(2, tmpDir, false, ServerType.GRPC);
     createServer(3, tmpDir, true, ServerType.GRPC_NETTY);
-    createServer(4, tmpDir, false, ServerType.GRPC_NETTY);
+    createServer(4, tmpDir, true, ServerType.GRPC_NETTY);
     createServer(5, tmpDir, false, ServerType.GRPC_NETTY);
     startServers();
   }
@@ -74,32 +75,25 @@ public class RSSStageDynamicServerReWriteTest extends SparkTaskFailureIntegratio
         shuffleServerConf.getInteger(ShuffleServerConf.RPC_SERVER_PORT) + id);
     shuffleServerConf.setInteger("rss.jetty.http.port", 19081 + id * 100);
     shuffleServerConf.setString("rss.storage.basePath", basePath);
+
+    MockedShuffleServer server = createMockedShuffleServer(shuffleServerConf);
     if (abnormalFlag) {
-      createMockedShuffleServer(shuffleServerConf);
       // Set the sending block data timeout for the first shuffleServer
       switch (serverType) {
         case GRPC:
-          ((MockedGrpcServer) grpcShuffleServers.get(0).getServer())
-              .getService()
-              .enableMockSendDataFailed(true);
-          break;
         case GRPC_NETTY:
-          ((MockedGrpcServer) nettyShuffleServers.get(0).getServer())
-              .getService()
-              .enableMockSendDataFailed(true);
+          ((MockedGrpcServer) server.getServer()).getService().enableMockSendDataFailed(true);
           break;
         default:
           throw new UnsupportedOperationException("Unsupported server type " + serverType);
       }
-    } else {
-      createShuffleServer(shuffleServerConf);
     }
   }
 
   @Override
   public Map runTest(SparkSession spark, String fileName) throws Exception {
     List<Row> rows =
-        spark.range(0, 1000, 1, 4).repartition(2).groupBy("id").count().collectAsList();
+        spark.range(0, 1000, 1, 4).repartition(3).groupBy("id").count().collectAsList();
     Map<String, Long> result = Maps.newHashMap();
     for (Row row : rows) {
       result.put(row.get(0).toString(), row.getLong(1));


### PR DESCRIPTION
### What changes were proposed in this pull request?

add all faulty servers into blacklist while writing for stage recomputing

### Why are the changes needed?

It will fail on retry when only one server is added into blacklist. 
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.