### PR TITLE
[#1591] feat(spark): Support Spark 3.5.1

### DIFF
--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -296,8 +296,8 @@ public class GetReaderTest extends IntegrationTestBase {
     public boolean isCompleted() {
       return false;
     }
-    
-    // The following method is only available after Spark 3.5.1, and in order to be compatible 
+
+    // The following method is only available after Spark 3.5.1, and in order to be compatible
     // with the version before Spark 3.5.1, the annotation @Override is not added.
     public boolean isFailed() {
       return false;

--- a/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/org/apache/uniffle/test/GetReaderTest.java
@@ -296,6 +296,12 @@ public class GetReaderTest extends IntegrationTestBase {
     public boolean isCompleted() {
       return false;
     }
+    
+    // The following method is only available after Spark 3.5.1, and in order to be compatible 
+    // with the version before Spark 3.5.1, the annotation @Override is not added.
+    public boolean isFailed() {
+      return false;
+    }
 
     @Override
     public Properties getLocalProperties() {

--- a/pom.xml
+++ b/pom.xml
@@ -1761,7 +1761,7 @@
       <id>spark3.5</id>
       <properties>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.5.0</spark.version>
+        <spark.version>3.5.1</spark.version>
         <client.type>3</client.type>
         <jackson.version>2.15.2</jackson.version>
         <log4j.version>2.20.0</log4j.version>


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support Spark 3.5.1

The abstract class `TaskContext` introduced a new method `isFailed()` after Spark version 3.5.1. Due to this addition, it is not possible to compile the `MockTaskContext` class using Spark 3.5.1 without modifying the code. Consequently, we also added the `isFailed()` method to `MockTaskContext`. However, to maintain compatibility with versions of Spark prior to 3.5.1, we did not annotate this method with `@Override`.

Compiling old code with Spark 3.5.1 results in the following error: 
```error: MockTaskContext is not abstract and does not override abstract method isFailed() in TaskContext.```
Additionally, adding the `@Override` annotation leads to another error: 
```error: method does not override or implement a method from a supertype.```

### Why are the changes needed?

Fix: #1591 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.