### PR TITLE
[#1472][FOLLOWUP] improvement(server): Release memory more accurately when failing to cache shuffle data

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -298,10 +298,13 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
           LOG.error(errorMsg);
           hasFailureOccurred = true;
           break;
+        } finally {
+          if (hasFailureOccurred) {
+            shuffleServer
+                .getShuffleBufferManager()
+                .releaseMemory(spd.getTotalBlockSize(), false, false);
+          }
         }
-      }
-      if (hasFailureOccurred) {
-        shuffleServer.getShuffleBufferManager().releaseMemory(info.getRequireSize(), false, false);
       }
       // since the required buffer id is only used once, the shuffle client would try to require
       // another buffer whether


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release memory more accurately when failing to cache shuffle data.

### Why are the changes needed?

A follow-up PR for: https://github.com/apache/incubator-uniffle/pull/1534.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
