### PR TITLE
[#1600] feat(netty): Support for allocating direct memory when reading local data files and index files

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
@@ -63,7 +63,8 @@ public class FileSegmentManagedBuffer extends ManagedBuffer {
     FileChannel channel = null;
     try {
       channel = new RandomAccessFile(file, "r").getChannel();
-      ByteBuffer buf = preferDirect ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
+      ByteBuffer buf =
+          preferDirect ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
       channel.position(offset);
       while (buf.remaining() != 0) {
         if (channel.read(buf) == -1) {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -292,7 +292,11 @@ public class ShuffleServer {
         new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager, nettyServerEnabled);
     shuffleTaskManager =
         new ShuffleTaskManager(
-            shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager, nettyServerEnabled);
+            shuffleServerConf,
+            shuffleFlushManager,
+            shuffleBufferManager,
+            storageManager,
+            nettyServerEnabled);
     shuffleTaskManager.start();
 
     setServer();

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -292,7 +292,7 @@ public class ShuffleServer {
         new ShuffleBufferManager(shuffleServerConf, shuffleFlushManager, nettyServerEnabled);
     shuffleTaskManager =
         new ShuffleTaskManager(
-            shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager);
+            shuffleServerConf, shuffleFlushManager, shuffleBufferManager, storageManager, nettyServerEnabled);
     shuffleTaskManager.start();
 
     setServer();

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -639,7 +639,9 @@ public class ShuffleTaskManager {
       throw new FileNotFoundException("No such data stored in current storage manager.");
     }
 
-    return storage.getOrCreateReadHandler(request).getShuffleData(offset, length, nettyServerEnabled);
+    return storage
+        .getOrCreateReadHandler(request)
+        .getShuffleData(offset, length, nettyServerEnabled);
   }
 
   public ShuffleIndexResult getShuffleIndex(

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -98,7 +98,11 @@ public class ShuffleBufferManager {
     this.readCapacity = conf.getSizeAsBytes(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY);
     if (this.readCapacity < 0) {
       this.readCapacity =
-          (long) (heapSize * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO));
+          nettyServerEnabled
+              ? (long)
+                  (NettyUtils.getMaxDirectMemory()
+                      * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO))
+              : (long) (heapSize * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO));
     }
     LOG.info(
         "Init shuffle buffer manager with capacity: {}, read buffer capacity: {}.",

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -102,7 +102,8 @@ public class ShuffleBufferManager {
               ? (long)
                   (NettyUtils.getMaxDirectMemory()
                       * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO))
-              : (long) (heapSize * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO));
+              : (long)
+                  (heapSize * conf.getDouble(ShuffleServerConf.SERVER_READ_BUFFER_CAPACITY_RATIO));
     }
     LOG.info(
         "Init shuffle buffer manager with capacity: {}, read buffer capacity: {}.",

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -819,7 +819,8 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     StorageManager storageManager = shuffleServer.getStorageManager();
     ShuffleTaskManager shuffleTaskManager =
-        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
+        new ShuffleTaskManager(
+            conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
 
     int startPartition = 6;
     int endPartition = 9;
@@ -895,7 +896,8 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     StorageManager storageManager = shuffleServer.getStorageManager();
     ShuffleTaskManager shuffleTaskManager =
-        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
+        new ShuffleTaskManager(
+            conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
     Map<Integer, long[]> blockIdsToReport = Maps.newHashMap();
     try {
       shuffleTaskManager.addFinishedBlockIds(appId, shuffleId, blockIdsToReport, bitNum);

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -708,7 +708,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
   public void getBlockIdsByPartitionIdTest() {
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
     ShuffleServerConf conf = new ShuffleServerConf();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf, null, null, null);
+    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf, null, null, null, false);
 
     Roaring64NavigableMap expectedBlockIds = Roaring64NavigableMap.bitmapOf();
     int expectedPartitionId = 5;
@@ -754,7 +754,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
   public void getBlockIdsByMultiPartitionTest() {
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
     ShuffleServerConf conf = new ShuffleServerConf();
-    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf, null, null, null);
+    ShuffleTaskManager shuffleTaskManager = new ShuffleTaskManager(conf, null, null, null, false);
 
     Roaring64NavigableMap expectedBlockIds = Roaring64NavigableMap.bitmapOf();
     int startPartition = 3;
@@ -819,7 +819,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     StorageManager storageManager = shuffleServer.getStorageManager();
     ShuffleTaskManager shuffleTaskManager =
-        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager);
+        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
 
     int startPartition = 6;
     int endPartition = 9;
@@ -895,7 +895,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     StorageManager storageManager = shuffleServer.getStorageManager();
     ShuffleTaskManager shuffleTaskManager =
-        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager);
+        new ShuffleTaskManager(conf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
     Map<Integer, long[]> blockIdsToReport = Maps.newHashMap();
     try {
       shuffleTaskManager.addFinishedBlockIds(appId, shuffleId, blockIdsToReport, bitNum);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -483,7 +483,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     shuffleBufferManager = new ShuffleBufferManager(shuffleConf, shuffleFlushManager, false);
     ShuffleTaskManager shuffleTaskManager =
         new ShuffleTaskManager(
-            shuffleConf, shuffleFlushManager, shuffleBufferManager, storageManager);
+            shuffleConf, shuffleFlushManager, shuffleBufferManager, storageManager, false);
 
     when(mockShuffleServer.getShuffleFlushManager()).thenReturn(shuffleFlushManager);
     when(mockShuffleServer.getShuffleBufferManager()).thenReturn(shuffleBufferManager);

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/api/ServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/api/ServerReadHandler.java
@@ -22,7 +22,7 @@ import org.apache.uniffle.common.ShuffleIndexResult;
 
 public interface ServerReadHandler {
 
-  ShuffleDataResult getShuffleData(long offset, int length);
+  ShuffleDataResult getShuffleData(long offset, int length, boolean preferDirect);
 
-  ShuffleIndexResult getShuffleIndex();
+  ShuffleIndexResult getShuffleIndex(boolean preferDirect);
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
@@ -149,6 +149,7 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
     }
     // get dataFileSize for read segment generation in DataSkippableReadHandler#readShuffleData
     long dataFileSize = new File(dataFileName).length();
-    return new ShuffleIndexResult(new FileSegmentManagedBuffer(indexFile, 0, len, preferDirect), dataFileSize);
+    return new ShuffleIndexResult(
+        new FileSegmentManagedBuffer(indexFile, 0, len, preferDirect), dataFileSize);
   }
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
@@ -131,13 +131,13 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
   }
 
   @Override
-  public ShuffleDataResult getShuffleData(long offset, int length) {
+  public ShuffleDataResult getShuffleData(long offset, int length, boolean preferDirect) {
     return new ShuffleDataResult(
-        new FileSegmentManagedBuffer(new File(dataFileName), offset, length));
+        new FileSegmentManagedBuffer(new File(dataFileName), offset, length, preferDirect));
   }
 
   @Override
-  public ShuffleIndexResult getShuffleIndex() {
+  public ShuffleIndexResult getShuffleIndex(boolean preferDirect) {
     File indexFile = new File(indexFileName);
     long indexFileSize = indexFile.length();
     int indexNum = (int) (indexFileSize / FileBasedShuffleSegment.SEGMENT_SIZE);
@@ -149,6 +149,6 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
     }
     // get dataFileSize for read segment generation in DataSkippableReadHandler#readShuffleData
     long dataFileSize = new File(dataFileName).length();
-    return new ShuffleIndexResult(new FileSegmentManagedBuffer(indexFile, 0, len), dataFileSize);
+    return new ShuffleIndexResult(new FileSegmentManagedBuffer(indexFile, 0, len, preferDirect), dataFileSize);
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTestBase.java
@@ -99,7 +99,7 @@ public class LocalFileHandlerTestBase {
   }
 
   public static ShuffleIndexResult readIndex(ServerReadHandler readHandler) {
-    ShuffleIndexResult shuffleIndexResult = readHandler.getShuffleIndex();
+    ShuffleIndexResult shuffleIndexResult = readHandler.getShuffleIndex(false);
     return shuffleIndexResult;
   }
 
@@ -116,7 +116,7 @@ public class LocalFileHandlerTestBase {
     for (ShuffleDataSegment shuffleDataSegment : shuffleDataSegments) {
       byte[] shuffleData =
           readHandler
-              .getShuffleData(shuffleDataSegment.getOffset(), shuffleDataSegment.getLength())
+              .getShuffleData(shuffleDataSegment.getOffset(), shuffleDataSegment.getLength(), false)
               .getData();
       ShuffleDataResult sdr =
           new ShuffleDataResult(shuffleData, shuffleDataSegment.getBufferSegments());


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Set `readCapacity` dynamically according to `nettyServerEnabled`.
2. When enabling Netty for reading local data files and index files, allocate direct memory.

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1600.
A detailed performance report for a cluster of 10 shuffle servers:
| Concurrency | RPC Type| Read Performance per Shuffle Server | Total Time Across All Tasks | Improvement |
|-------------|----------|------------------------------------|------------|-------------|
| 1400        | Netty    | 1.5GB/s                          | 145.5h     | Almost the same           |
|             | gRPC | 1.6GB/s                          | 145.3h     | -           |
| 2800        | Netty    | 2.5GB/s                            | 179.7h     | 7.32% |
|             | gRPC | 2.3GB/s                          | 193.9h     | -           |
| 5600        | Netty    | 2.8GB/s                          | 303.4h     | 11.22% |
|             | gRPC | 1.8GB/s                          | 341.8h     | -           |
| 11200       | Netty    | 2.6GB/s                          | 583.3h     | 12.43% |
|             | gRPC | 1.9GB/s                          | 666.0h     | -           |

Total Shuffle Read Size: 6.4TiB
Peak IO: Can reach up to 3.5GB/s
Shuffle Server capacity: 140g

We compare gRPC and Netty while keeping other influencing factors (such as shuffle servers' configurations and machines'  specifications) constant. We can observe that as the concurrency increases, the read performance improvement from using off-heap memory in Netty mode becomes more noticeable.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested in our env.