### PR TITLE
[#1579][part-2] feat(spark): allow to register shuffle in parallel

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -370,6 +370,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     this.heartBeatScheduledExecutorService = null;
     this.taskToFailedBlockSendTracker = taskToFailedBlockSendTracker;
     this.dataPusher = dataPusher;
+    this.registerShuffleMaxParallelism = rssConf.get(RSS_CLIENT_REGISTER_SHUFFLE_MAX_PARALLELISM);
   }
 
   // This method is called in Spark driver side,

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -209,4 +209,10 @@ public class RssClientConf {
           .defaultValue(false)
           .withDescription(
               "Whether to support task write failed retry internal, default value is false.");
+
+  public static final ConfigOption<Integer> RSS_CLIENT_REGISTER_SHUFFLE_MAX_PARALLELISM =
+      ConfigOptions.key("rss.client.registerShuffle.maxParallelism")
+          .intType()
+          .defaultValue(5)
+          .withDescription("The max parallelism of register shuffles to several shuffle-servers.");
 }

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -211,7 +211,7 @@ public class RssClientConf {
               "Whether to support task write failed retry internal, default value is false.");
 
   public static final ConfigOption<Integer> RSS_CLIENT_REGISTER_SHUFFLE_MAX_PARALLELISM =
-      ConfigOptions.key("rss.client.registerShuffle.maxParallelism")
+      ConfigOptions.key("rss.client.rpc.registerShuffleMaxParallelism")
           .intType()
           .defaultValue(5)
           .withDescription("The max parallelism of register shuffles to several shuffle-servers.");


### PR DESCRIPTION
### What changes were proposed in this pull request?

allow to register shuffle in parallel

### Why are the changes needed?

this is the subtask for #1579

After the #1584, the registerShuffle operation may be slow compared with the previous operation due to the previous stage data purge. Based on this, it's necessary to register shuffle in parallel.

### Does this PR introduce _any_ user-facing change?

Yes. `rss.client.registerShuffle.maxParallelism=5` will be added.

### How was this patch tested?

Existing tests are enough

