### PR TITLE
[#1608][part-2] fix(spark): avoid releasing block in advance when enable block resend

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -59,14 +59,14 @@ public class AddBlockEvent {
     return "AddBlockEvent: TaskId[" + taskId + "], " + shuffleDataInfoList;
   }
 
-  public void callbackOnBlockFailure(ShuffleBlockInfo block) {
+  public void triggerBlockFailureCallback(ShuffleBlockInfo block) {
     if (block == null || blockFailureCallback == null) {
       return;
     }
     blockFailureCallback.onBlockFailure(block);
   }
 
-  public void callbackOnBlockSuccess(ShuffleBlockInfo block) {
+  public void triggerBlockSuccessCallback(ShuffleBlockInfo block) {
     if (block == null || blockSuccessCallback == null) {
       return;
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -28,7 +28,7 @@ public class AddBlockEvent {
   private String taskId;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
-  private TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback;
+  private TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback;
 
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
     this.taskId = taskId;
@@ -39,9 +39,9 @@ public class AddBlockEvent {
   public AddBlockEvent(
       String taskId,
       List<ShuffleBlockInfo> blocks,
-      TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback) {
+      TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback) {
     this(taskId, blocks);
-    this.blockProcessedCallback = blockProcessedCallback;
+    this.blockSentCallback = blockSentCallback;
   }
 
   /** @param callback, should not throw any exception and execute fast. */
@@ -61,13 +61,12 @@ public class AddBlockEvent {
     return processedCallbackChain;
   }
 
-  public void withBlockProcessedCallback(
-      TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback) {
-    this.blockProcessedCallback = blockProcessedCallback;
+  public void withBlockSentCallback(TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback) {
+    this.blockSentCallback = blockSentCallback;
   }
 
-  public TupleConsumer<ShuffleBlockInfo, Boolean> getBlockProcessedCallback() {
-    return blockProcessedCallback;
+  public TupleConsumer<ShuffleBlockInfo, Boolean> getBlockSentCallback() {
+    return blockSentCallback;
   }
 
   @Override

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -21,27 +21,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
-import org.apache.uniffle.common.function.TupleConsumer;
 
 public class AddBlockEvent {
 
   private String taskId;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
-  private TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback;
+
+  private BlockFailureCallback blockFailureCallback;
+  private BlockSuccessCallback blockSuccessCallback;
 
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
     this.taskId = taskId;
     this.shuffleDataInfoList = shuffleDataInfoList;
     this.processedCallbackChain = new ArrayList<>();
-  }
-
-  public AddBlockEvent(
-      String taskId,
-      List<ShuffleBlockInfo> blocks,
-      TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback) {
-    this(taskId, blocks);
-    this.blockSentCallback = blockSentCallback;
   }
 
   /** @param callback, should not throw any exception and execute fast. */
@@ -61,16 +54,30 @@ public class AddBlockEvent {
     return processedCallbackChain;
   }
 
-  public void withBlockSentCallback(TupleConsumer<ShuffleBlockInfo, Boolean> blockSentCallback) {
-    this.blockSentCallback = blockSentCallback;
-  }
-
-  public TupleConsumer<ShuffleBlockInfo, Boolean> getBlockSentCallback() {
-    return blockSentCallback;
-  }
-
   @Override
   public String toString() {
     return "AddBlockEvent: TaskId[" + taskId + "], " + shuffleDataInfoList;
+  }
+
+  public void callbackOnBlockFailure(ShuffleBlockInfo block) {
+    if (block == null) {
+      return;
+    }
+    this.blockFailureCallback.onBlockFailure(block);
+  }
+
+  public void callbackOnBlockSuccess(ShuffleBlockInfo block) {
+    if (block == null) {
+      return;
+    }
+    this.blockSuccessCallback.onBlockSuccess(block);
+  }
+
+  public void withBlockFailureCallback(BlockFailureCallback blockFailureCallback) {
+    this.blockFailureCallback = blockFailureCallback;
+  }
+
+  public void withBlockSuccessCallback(BlockSuccessCallback blockSuccessCallback) {
+    this.blockSuccessCallback = blockSuccessCallback;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -60,17 +60,17 @@ public class AddBlockEvent {
   }
 
   public void callbackOnBlockFailure(ShuffleBlockInfo block) {
-    if (block == null) {
+    if (block == null || blockFailureCallback == null) {
       return;
     }
-    this.blockFailureCallback.onBlockFailure(block);
+    blockFailureCallback.onBlockFailure(block);
   }
 
   public void callbackOnBlockSuccess(ShuffleBlockInfo block) {
-    if (block == null) {
+    if (block == null || blockSuccessCallback == null) {
       return;
     }
-    this.blockSuccessCallback.onBlockSuccess(block);
+    blockSuccessCallback.onBlockSuccess(block);
   }
 
   public void withBlockFailureCallback(BlockFailureCallback blockFailureCallback) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -28,12 +28,6 @@ public class AddBlockEvent {
   private String taskId;
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
-
-  // The var is to indicate if the blocks fail to send, whether the writer will resend to
-  // re-assignment servers.
-  // if so, the failure blocks will not be released.
-  private boolean isResendEnabled = false;
-
   private TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback;
 
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
@@ -74,14 +68,6 @@ public class AddBlockEvent {
 
   public TupleConsumer<ShuffleBlockInfo, Boolean> getBlockProcessedCallback() {
     return blockProcessedCallback;
-  }
-
-  public void enableBlockResend() {
-    this.isResendEnabled = true;
-  }
-
-  public boolean isBlockResendEnabled() {
-    return isResendEnabled;
   }
 
   @Override

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -28,9 +28,6 @@ public class AddBlockEvent {
   private List<ShuffleBlockInfo> shuffleDataInfoList;
   private List<Runnable> processedCallbackChain;
 
-  private BlockFailureCallback blockFailureCallback;
-  private BlockSuccessCallback blockSuccessCallback;
-
   public AddBlockEvent(String taskId, List<ShuffleBlockInfo> shuffleDataInfoList) {
     this.taskId = taskId;
     this.shuffleDataInfoList = shuffleDataInfoList;
@@ -57,27 +54,5 @@ public class AddBlockEvent {
   @Override
   public String toString() {
     return "AddBlockEvent: TaskId[" + taskId + "], " + shuffleDataInfoList;
-  }
-
-  public void triggerBlockFailureCallback(ShuffleBlockInfo block) {
-    if (block == null || blockFailureCallback == null) {
-      return;
-    }
-    blockFailureCallback.onBlockFailure(block);
-  }
-
-  public void triggerBlockSuccessCallback(ShuffleBlockInfo block) {
-    if (block == null || blockSuccessCallback == null) {
-      return;
-    }
-    blockSuccessCallback.onBlockSuccess(block);
-  }
-
-  public void withBlockFailureCallback(BlockFailureCallback blockFailureCallback) {
-    this.blockFailureCallback = blockFailureCallback;
-  }
-
-  public void withBlockSuccessCallback(BlockSuccessCallback blockSuccessCallback) {
-    this.blockSuccessCallback = blockSuccessCallback;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -42,6 +42,14 @@ public class AddBlockEvent {
     this.processedCallbackChain = new ArrayList<>();
   }
 
+  public AddBlockEvent(
+      String taskId,
+      List<ShuffleBlockInfo> blocks,
+      TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback) {
+    this(taskId, blocks);
+    this.blockProcessedCallback = blockProcessedCallback;
+  }
+
   /** @param callback, should not throw any exception and execute fast. */
   public void addCallback(Runnable callback) {
     processedCallbackChain.add(callback);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BlockFailureCallback.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BlockFailureCallback.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.writer;
+
+import org.apache.uniffle.common.ShuffleBlockInfo;
+
+public interface BlockFailureCallback {
+  void onBlockFailure(ShuffleBlockInfo block);
+}

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BlockSuccessCallback.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BlockSuccessCallback.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.writer;
+
+import org.apache.uniffle.common.ShuffleBlockInfo;
+
+public interface BlockSuccessCallback {
+  void onBlockSuccess(ShuffleBlockInfo block);
+}

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -102,10 +102,11 @@ public class DataPusher implements Closeable {
                     ? Collections.emptySet()
                     : result.getSuccessBlockIds();
             for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-              Optional.ofNullable(event.getBlockSentCallback())
-                  .ifPresent(
-                      callback ->
-                          callback.accept(block, succeedBlockIds.contains(block.getBlockId())));
+              if (succeedBlockIds.contains(block.getBlockId())) {
+                event.callbackOnBlockSuccess(block);
+              } else {
+                event.callbackOnBlockFailure(block);
+              }
             }
 
             List<Runnable> callbackChain =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -98,10 +98,12 @@ public class DataPusher implements Closeable {
                 taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
           } finally {
             Set<Long> succeedBlockIds = result.getSuccessBlockIds();
-            for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-              event
-                  .getBlockProcessedCallback()
-                  .accept(block, succeedBlockIds.contains(block.getBlockId()));
+            if (succeedBlockIds != null && !succeedBlockIds.isEmpty()) {
+              for (ShuffleBlockInfo block : shuffleBlockInfoList) {
+                event
+                    .getBlockProcessedCallback()
+                    .accept(block, succeedBlockIds.contains(block.getBlockId()));
+              }
             }
 
             List<Runnable> callbackChain =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -97,14 +97,15 @@ public class DataPusher implements Closeable {
             putFailedBlockSendTracker(
                 taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
           } finally {
-            Set<Long> succeedBlockIds = result.getSuccessBlockIds();
-            if (succeedBlockIds != null && !succeedBlockIds.isEmpty()) {
-              for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-                Optional.ofNullable(event.getBlockProcessedCallback())
-                    .ifPresent(
-                        callback ->
-                            callback.accept(block, succeedBlockIds.contains(block.getBlockId())));
-              }
+            Set<Long> succeedBlockIds =
+                result.getSuccessBlockIds() == null
+                    ? Collections.emptySet()
+                    : result.getSuccessBlockIds();
+            for (ShuffleBlockInfo block : shuffleBlockInfoList) {
+              Optional.ofNullable(event.getBlockProcessedCallback())
+                  .ifPresent(
+                      callback ->
+                          callback.accept(block, succeedBlockIds.contains(block.getBlockId())));
             }
 
             List<Runnable> callbackChain =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -102,7 +102,7 @@ public class DataPusher implements Closeable {
                     ? Collections.emptySet()
                     : result.getSuccessBlockIds();
             for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-              Optional.ofNullable(event.getBlockProcessedCallback())
+              Optional.ofNullable(event.getBlockSentCallback())
                   .ifPresent(
                       callback ->
                           callback.accept(block, succeedBlockIds.contains(block.getBlockId())));

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -103,9 +103,9 @@ public class DataPusher implements Closeable {
                     : result.getSuccessBlockIds();
             for (ShuffleBlockInfo block : shuffleBlockInfoList) {
               if (succeedBlockIds.contains(block.getBlockId())) {
-                event.callbackOnBlockSuccess(block);
+                event.triggerBlockSuccessCallback(block);
               } else {
-                event.callbackOnBlockFailure(block);
+                event.triggerBlockFailureCallback(block);
               }
             }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -102,11 +102,7 @@ public class DataPusher implements Closeable {
                     ? Collections.emptySet()
                     : result.getSuccessBlockIds();
             for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-              if (succeedBlockIds.contains(block.getBlockId())) {
-                event.triggerBlockSuccessCallback(block);
-              } else {
-                event.triggerBlockFailureCallback(block);
-              }
+              block.executeCompletionCallback(succeedBlockIds.contains(block.getBlockId()));
             }
 
             List<Runnable> callbackChain =

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -100,9 +100,10 @@ public class DataPusher implements Closeable {
             Set<Long> succeedBlockIds = result.getSuccessBlockIds();
             if (succeedBlockIds != null && !succeedBlockIds.isEmpty()) {
               for (ShuffleBlockInfo block : shuffleBlockInfoList) {
-                event
-                    .getBlockProcessedCallback()
-                    .accept(block, succeedBlockIds.contains(block.getBlockId()));
+                Optional.ofNullable(event.getBlockProcessedCallback())
+                    .ifPresent(
+                        callback ->
+                            callback.accept(block, succeedBlockIds.contains(block.getBlockId())));
               }
             }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -425,7 +425,14 @@ public class WriteBufferManager extends MemoryConsumer {
                   + totalSize
                   + " bytes");
         }
-        events.add(new AddBlockEvent(taskId, shuffleBlockInfosPerEvent));
+        events.add(
+            new AddBlockEvent(
+                taskId,
+                shuffleBlockInfosPerEvent,
+                (block, isSuccessful) -> {
+                  this.freeAllocatedMemory(block.getFreeMemory());
+                  block.getData().release();
+                }));
         shuffleBlockInfosPerEvent = Lists.newArrayList();
         totalSize = 0;
       }
@@ -440,7 +447,14 @@ public class WriteBufferManager extends MemoryConsumer {
                 + " bytes");
       }
       // Use final temporary variables for closures
-      events.add(new AddBlockEvent(taskId, shuffleBlockInfosPerEvent));
+      events.add(
+          new AddBlockEvent(
+              taskId,
+              shuffleBlockInfosPerEvent,
+              (block, isSuccessful) -> {
+                this.freeAllocatedMemory(block.getFreeMemory());
+                block.getData().release();
+              }));
     }
     return events;
   }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -372,7 +372,7 @@ public class WriteBufferManagerTest {
           List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
           for (AddBlockEvent event : events) {
             for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-              event.triggerBlockSuccessCallback(block);
+              block.executeCompletionCallback(true);
             }
             event.getProcessedCallbackChain().stream().forEach(x -> x.run());
             sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
@@ -417,7 +417,7 @@ public class WriteBufferManagerTest {
                           }
                         }
                         for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-                          event.triggerBlockSuccessCallback(block);
+                          block.executeCompletionCallback(true);
                         }
                         event.getProcessedCallbackChain().stream().forEach(x -> x.run());
                         sum +=

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
-import org.apache.uniffle.common.function.TupleConsumer;
 import org.apache.uniffle.common.util.BlockIdLayout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -372,10 +371,8 @@ public class WriteBufferManagerTest {
           long sum = 0L;
           List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
           for (AddBlockEvent event : events) {
-            TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
-                event.getBlockSentCallback();
             for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-              blockProcessedCallback.accept(block, true);
+              event.callbackOnBlockSuccess(block);
             }
             event.getProcessedCallbackChain().stream().forEach(x -> x.run());
             sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
@@ -419,10 +416,8 @@ public class WriteBufferManagerTest {
                             // ignore.
                           }
                         }
-                        TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
-                            event.getBlockSentCallback();
                         for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-                          blockProcessedCallback.accept(block, true);
+                          event.callbackOnBlockSuccess(block);
                         }
                         event.getProcessedCallbackChain().stream().forEach(x -> x.run());
                         sum +=

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -373,7 +373,7 @@ public class WriteBufferManagerTest {
           List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
           for (AddBlockEvent event : events) {
             TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
-                event.getBlockProcessedCallback();
+                event.getBlockSentCallback();
             for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
               blockProcessedCallback.accept(block, true);
             }
@@ -420,7 +420,7 @@ public class WriteBufferManagerTest {
                           }
                         }
                         TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
-                            event.getBlockProcessedCallback();
+                            event.getBlockSentCallback();
                         for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
                           blockProcessedCallback.accept(block, true);
                         }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -372,7 +372,7 @@ public class WriteBufferManagerTest {
           List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
           for (AddBlockEvent event : events) {
             for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-              event.callbackOnBlockSuccess(block);
+              event.triggerBlockSuccessCallback(block);
             }
             event.getProcessedCallbackChain().stream().forEach(x -> x.run());
             sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
@@ -417,7 +417,7 @@ public class WriteBufferManagerTest {
                           }
                         }
                         for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
-                          event.callbackOnBlockSuccess(block);
+                          event.triggerBlockSuccessCallback(block);
                         }
                         event.getProcessedCallbackChain().stream().forEach(x -> x.run());
                         sum +=

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.function.TupleConsumer;
 import org.apache.uniffle.common.util.BlockIdLayout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -371,6 +372,11 @@ public class WriteBufferManagerTest {
           long sum = 0L;
           List<AddBlockEvent> events = wbm.buildBlockEvents(blocks);
           for (AddBlockEvent event : events) {
+            TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
+                event.getBlockProcessedCallback();
+            for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
+              blockProcessedCallback.accept(block, true);
+            }
             event.getProcessedCallbackChain().stream().forEach(x -> x.run());
             sum += event.getShuffleDataInfoList().stream().mapToLong(x -> x.getFreeMemory()).sum();
           }
@@ -412,6 +418,11 @@ public class WriteBufferManagerTest {
                           } catch (InterruptedException interruptedException) {
                             // ignore.
                           }
+                        }
+                        TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
+                            event.getBlockProcessedCallback();
+                        for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
+                          blockProcessedCallback.accept(block, true);
                         }
                         event.getProcessedCallbackChain().stream().forEach(x -> x.run());
                         sum +=

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -1264,4 +1264,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   public boolean isRssResubmitStage() {
     return rssResubmitStage;
   }
+
+  @VisibleForTesting
+  public void setDataPusher(DataPusher dataPusher) {
+    this.dataPusher = dataPusher;
+  }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -274,7 +274,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     while (records.hasNext()) {
       recordCount++;
 
-      dataCheckOrRetry();
+      checkDataIfAnyFailure();
 
       Product2<K, V> record = records.next();
       K key = record._1();
@@ -399,7 +399,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       while (true) {
         try {
           finishEventQueue.clear();
-          dataCheckOrRetry();
+          checkDataIfAnyFailure();
           Set<Long> successBlockIds = shuffleManager.getSuccessBlockIds(taskId);
           blockIds.removeAll(successBlockIds);
           if (blockIds.isEmpty()) {
@@ -435,9 +435,9 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void dataCheckOrRetry() {
+  private void checkDataIfAnyFailure() {
     if (isBlockFailSentRetryEnabled) {
-      collectBlocksToResendOrFastFail();
+      collectFailedBlocksToResend();
     } else {
       if (hasAnyBlockFailure()) {
         throw new RssSendFailedException("Send fail");
@@ -458,7 +458,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     return false;
   }
 
-  private void collectBlocksToResendOrFastFail() {
+  private void collectFailedBlocksToResend() {
     if (!isBlockFailSentRetryEnabled) {
       return;
     }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -480,7 +480,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             taskId,
             retryRecords.stream().map(x -> x.getShuffleServerInfo()).collect(Collectors.toSet()));
         // fast fail if any blocks failure with multiple retry times
-        throw new RssSendFailedException();
+        throw new RssSendFailedException("Errors on resending the blocks data to the remote shuffle-server.");
       }
 
       // todo: if setting multi replica and another replica is succeed to send, no need to resend

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -650,6 +650,16 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         return Option.empty();
       }
     } finally {
+      if (blockFailSentRetryEnabled) {
+        if (success) {
+          if (CollectionUtils.isNotEmpty(shuffleManager.getFailedBlockIds(taskId))) {
+            LOG.error("Errors on stopping writer due to the remaining failed blockIds. This should not happen.");
+            return Option.empty();
+          }
+        } else {
+          shuffleManager.getBlockIdsFailedSendTracker(taskId).clearAndReleaseBlockResources();
+        }
+      }
       // free all memory & metadata, or memory leak happen in executor
       if (bufferManager != null) {
         bufferManager.freeAllMemory();

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -437,7 +437,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       collectBlocksToResendOrFastFail();
     } else {
       if (hasAnyBlockFailure()) {
-        throw new RssSendFailedException();
+        throw new RssSendFailedException("Send fail");
       }
     }
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -528,7 +528,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       ShuffleServerInfo replacement = replacementShuffleServers.get(entry.getKey().getId());
       if (replacement == null) {
         // todo: merge multiple requests into one.
-        replacement = reAssignFaultyShuffleServer(partitionIds, entry.getKey().getId());
+        replacement = reassignFaultyShuffleServer(partitionIds, entry.getKey().getId());
         replacementShuffleServers.put(entry.getKey().getId(), replacement);
       }
 
@@ -578,7 +578,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         });
   }
 
-  private ShuffleServerInfo reAssignFaultyShuffleServer(
+  private ShuffleServerInfo reassignFaultyShuffleServer(
       Set<Integer> partitionIds, String faultyServerId) {
     RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
     String driver = rssConf.getString("driver.host", "");

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -653,7 +653,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       if (blockFailSentRetryEnabled) {
         if (success) {
           if (CollectionUtils.isNotEmpty(shuffleManager.getFailedBlockIds(taskId))) {
-            LOG.error("Errors on stopping writer due to the remaining failed blockIds. This should not happen.");
+            LOG.error(
+                "Errors on stopping writer due to the remaining failed blockIds. This should not happen.");
             return Option.empty();
           }
         } else {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -480,7 +480,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             taskId,
             retryRecords.stream().map(x -> x.getShuffleServerInfo()).collect(Collectors.toSet()));
         // fast fail if any blocks failure with multiple retry times
-        throw new RssSendFailedException("Errors on resending the blocks data to the remote shuffle-server.");
+        throw new RssSendFailedException(
+            "Errors on resending the blocks data to the remote shuffle-server.");
       }
 
       // todo: if setting multi replica and another replica is succeed to send, no need to resend

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -559,23 +559,6 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     partitionLengths[block.getPartitionId()] -= block.getLength();
   }
 
-  private void clearFailedBlockStates(
-      List<ShuffleBlockInfo> failedBlockInfoList, Map<String, ShuffleServerInfo> faultyServers) {
-    failedBlockInfoList.forEach(
-        shuffleBlockInfo -> {
-          shuffleManager.getBlockIdsFailedSendTracker(taskId).remove(shuffleBlockInfo.getBlockId());
-          shuffleBlockInfo.getShuffleServerInfos().stream()
-              .filter(s -> faultyServers.containsKey(s.getId()))
-              .forEach(
-                  s ->
-                      serverToPartitionToBlockIds
-                          .get(s)
-                          .get(shuffleBlockInfo.getPartitionId())
-                          .remove(shuffleBlockInfo.getBlockId()));
-          partitionLengths[shuffleBlockInfo.getPartitionId()] -= shuffleBlockInfo.getLength();
-        });
-  }
-
   private ShuffleServerInfo reassignFaultyShuffleServer(
       Set<Integer> partitionIds, String faultyServerId) {
     RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -355,7 +355,6 @@ public class RssShuffleWriterTest {
         assertThrows(
             RuntimeException.class,
             () -> rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
-    System.out.println(e3.getMessage());
     assertTrue(e3.getMessage().startsWith("Fail to send the block"));
     successBlocks.clear();
     taskToFailedBlockSendTracker.clear();

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -123,11 +123,7 @@ public class RssShuffleWriterTest {
                   successBlockIds.get(event.getTaskId()).add(block.getBlockId());
                   shuffleBlockInfos.add(block);
                 }
-                if (isSuccessful) {
-                  event.triggerBlockSuccessCallback(block);
-                } else {
-                  event.triggerBlockFailureCallback(block);
-                }
+                block.executeCompletionCallback(isSuccessful);
               }
               return new CompletableFuture<>();
             });
@@ -254,11 +250,7 @@ public class RssShuffleWriterTest {
                   successBlockIds.putIfAbsent(event.getTaskId(), Sets.newConcurrentHashSet());
                   successBlockIds.get(event.getTaskId()).add(block.getBlockId());
                 }
-                if (isSuccessful) {
-                  event.triggerBlockSuccessCallback(block);
-                } else {
-                  event.triggerBlockFailureCallback(block);
-                }
+                block.executeCompletionCallback(isSuccessful);
               }
               return new CompletableFuture<>();
             });

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -124,9 +124,9 @@ public class RssShuffleWriterTest {
                   shuffleBlockInfos.add(block);
                 }
                 if (isSuccessful) {
-                  event.callbackOnBlockSuccess(block);
+                  event.triggerBlockSuccessCallback(block);
                 } else {
-                  event.callbackOnBlockFailure(block);
+                  event.triggerBlockFailureCallback(block);
                 }
               }
               return new CompletableFuture<>();
@@ -255,9 +255,9 @@ public class RssShuffleWriterTest {
                   successBlockIds.get(event.getTaskId()).add(block.getBlockId());
                 }
                 if (isSuccessful) {
-                  event.callbackOnBlockSuccess(block);
+                  event.triggerBlockSuccessCallback(block);
                 } else {
-                  event.callbackOnBlockFailure(block);
+                  event.triggerBlockFailureCallback(block);
                 }
               }
               return new CompletableFuture<>();

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -102,7 +102,7 @@ public class RssShuffleWriterTest {
               assertEquals("taskId", event.getTaskId());
               FailedBlockSendTracker tracker = taskToFailedBlockSendTracker.get(event.getTaskId());
               TupleConsumer<ShuffleBlockInfo, Boolean> blockProcessedCallback =
-                  event.getBlockProcessedCallback();
+                  event.getBlockSentCallback();
               for (ShuffleBlockInfo block : event.getShuffleDataInfoList()) {
                 boolean isSuccessful = true;
                 ShuffleServerInfo shuffleServer = block.getShuffleServerInfos().get(0);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -74,6 +74,11 @@ import static org.mockito.Mockito.when;
 public class RssShuffleWriterTest {
 
   @Test
+  public void blockFailureResendTest() {
+    SparkConf conf = new SparkConf();
+  }
+
+  @Test
   public void checkBlockSendResultTest() {
     SparkConf conf = new SparkConf();
     conf.setAppName("testApp")
@@ -161,8 +166,8 @@ public class RssShuffleWriterTest {
         assertThrows(
             RuntimeException.class,
             () -> rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
-    System.out.println(e2.getMessage());
-    assertTrue(e3.getMessage().startsWith("Send failed:"));
+    System.out.println(e3.getMessage());
+    assertTrue(e3.getMessage().startsWith("Send fail"));
     successBlocks.clear();
     taskToFailedBlockSendTracker.clear();
   }

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -62,9 +62,7 @@ public class FailedBlockSendTracker {
   }
 
   public void clearAndReleaseBlockResources() {
-    trackingBlockStatusMap
-        .values()
-        .stream()
+    trackingBlockStatusMap.values().stream()
         .flatMap(x -> x.stream())
         .forEach(x -> x.getShuffleBlockInfo().executeCompletionCallback(true));
     trackingBlockStatusMap.clear();

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -32,6 +32,12 @@ import org.apache.uniffle.common.rpc.StatusCode;
 
 public class FailedBlockSendTracker {
 
+  /**
+   * blockId -> list(trackingStatus)
+   *
+   * <p>This indicates the blockId latest sending status, and it will not store the resending
+   * history. The list data structure is to describe the multiple servers for the multiple replica
+   */
   private Map<Long, List<TrackingBlockStatus>> trackingBlockStatusMap;
 
   public FailedBlockSendTracker() {

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -61,7 +61,12 @@ public class FailedBlockSendTracker {
     trackingBlockStatusMap.remove(blockId);
   }
 
-  public void clear() {
+  public void clearAndReleaseBlockResources() {
+    trackingBlockStatusMap
+        .values()
+        .stream()
+        .flatMap(x -> x.stream())
+        .forEach(x -> x.getShuffleBlockInfo().executeCompletionCallback(true));
     trackingBlockStatusMap.clear();
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/BlockCompletionCallback.java
+++ b/common/src/main/java/org/apache/uniffle/common/BlockCompletionCallback.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+public interface BlockCompletionCallback {
+  void onBlockCompletion(ShuffleBlockInfo block, boolean isSuccessful);
+}

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -37,6 +37,8 @@ public class ShuffleBlockInfo {
   private int uncompressLength;
   private long freeMemory;
 
+  private int retryCounter = 0;
+
   public ShuffleBlockInfo(
       int shuffleId,
       int partitionId,
@@ -82,6 +84,14 @@ public class ShuffleBlockInfo {
     this.uncompressLength = uncompressLength;
     this.freeMemory = freeMemory;
     this.taskAttemptId = taskAttemptId;
+  }
+
+  public int getRetryCounter() {
+    return retryCounter;
+  }
+
+  public void setRetryCounter(int retryCounter) {
+    this.retryCounter = retryCounter;
   }
 
   public long getBlockId() {

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -38,6 +38,8 @@ public class ShuffleBlockInfo {
   private long freeMemory;
   private int retryCnt = 0;
 
+  private transient BlockCompletionCallback completionCallback;
+
   public ShuffleBlockInfo(
       int shuffleId,
       int partitionId,
@@ -168,5 +170,16 @@ public class ShuffleBlockInfo {
 
   public synchronized void copyDataTo(ByteBuf to) {
     ByteBufUtils.copyByteBuf(data, to);
+  }
+
+  public void withCompletionCallback(BlockCompletionCallback callback) {
+    this.completionCallback = callback;
+  }
+
+  public void executeCompletionCallback(boolean isSuccessful) {
+    if (completionCallback == null) {
+      return;
+    }
+    completionCallback.onBlockCompletion(this, isSuccessful);
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -37,8 +37,6 @@ public class ShuffleBlockInfo {
   private int uncompressLength;
   private long freeMemory;
 
-  private int retryCounter = 0;
-
   public ShuffleBlockInfo(
       int shuffleId,
       int partitionId,
@@ -84,14 +82,6 @@ public class ShuffleBlockInfo {
     this.uncompressLength = uncompressLength;
     this.freeMemory = freeMemory;
     this.taskAttemptId = taskAttemptId;
-  }
-
-  public int getRetryCounter() {
-    return retryCounter;
-  }
-
-  public void setRetryCounter(int retryCounter) {
-    this.retryCounter = retryCounter;
   }
 
   public long getBlockId() {

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -36,6 +36,7 @@ public class ShuffleBlockInfo {
   private List<ShuffleServerInfo> shuffleServerInfos;
   private int uncompressLength;
   private long freeMemory;
+  private int retryCnt = 0;
 
   public ShuffleBlockInfo(
       int shuffleId,
@@ -151,6 +152,18 @@ public class ShuffleBlockInfo {
     }
 
     return sb.toString();
+  }
+
+  public void incrRetryCnt() {
+    this.retryCnt += 1;
+  }
+
+  public int getRetryCnt() {
+    return retryCnt;
+  }
+
+  public void reassignShuffleServers(List<ShuffleServerInfo> replacements) {
+    this.shuffleServerInfos = replacements;
   }
 
   public synchronized void copyDataTo(ByteBuf to) {

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
@@ -18,7 +18,6 @@
 package org.apache.uniffle.common.exception;
 
 public class RssSendFailedException extends RssException {
-
   public RssSendFailedException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
+++ b/common/src/main/java/org/apache/uniffle/common/exception/RssSendFailedException.java
@@ -19,10 +19,6 @@ package org.apache.uniffle.common.exception;
 
 public class RssSendFailedException extends RssException {
 
-  public RssSendFailedException() {
-    super("");
-  }
-
   public RssSendFailedException(String message) {
     super(message);
   }

--- a/common/src/main/java/org/apache/uniffle/common/function/TupleConsumer.java
+++ b/common/src/main/java/org/apache/uniffle/common/function/TupleConsumer.java
@@ -15,23 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.common.exception;
+package org.apache.uniffle.common.function;
 
-public class RssSendFailedException extends RssException {
-
-  public RssSendFailedException() {
-    super("");
-  }
-
-  public RssSendFailedException(String message) {
-    super(message);
-  }
-
-  public RssSendFailedException(Throwable e) {
-    super(e);
-  }
-
-  public RssSendFailedException(String message, Throwable e) {
-    super(message, e);
-  }
+@FunctionalInterface
+public interface TupleConsumer<T, F> {
+  void accept(T t, F f);
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. avoid releasing block previously when enable block resend
2. introduce the block max retry times

### Why are the changes needed?

For: #1608

In the current codebase for partition reassignment, it has some bugs as follows
1. data has been released when resending.
2. if the blocks fail to resend, it may fast fail without retry again

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`RssShuffleWriterTest#blockFailureResendTest` is to test the resending block mechanism.
