### PR TITLE
[#1634] fix(server): remove app folder if app is expired

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -763,22 +763,19 @@ public class ShuffleTaskManager {
         return;
       }
       final long start = System.currentTimeMillis();
-      String user = getUserByAppId(appId);
       ShuffleTaskInfo shuffleTaskInfo = shuffleTaskInfos.remove(appId);
       if (shuffleTaskInfo == null) {
         LOG.info("Resource for appId[" + appId + "] had been removed before.");
         return;
       }
 
-      final Map<Integer, Roaring64NavigableMap> shuffleToCachedBlockIds =
-          shuffleTaskInfo.getCachedBlockIds();
       partitionsToBlockIds.remove(appId);
       shuffleBufferManager.removeBuffer(appId);
       shuffleFlushManager.removeResources(appId);
-      if (!shuffleToCachedBlockIds.isEmpty()) {
-        storageManager.removeResources(
-            new AppPurgeEvent(appId, user, new ArrayList<>(shuffleToCachedBlockIds.keySet())));
-      }
+
+      String user = getUserByAppId(appId);
+      storageManager.removeResources(new AppPurgeEvent(appId, user));
+
       if (shuffleTaskInfo.hasHugePartition()) {
         ShuffleServerMetrics.gaugeAppWithHugePartitionNum.dec();
         ShuffleServerMetrics.gaugeHugePartitionNum.dec(shuffleTaskInfo.getHugePartitionSize());

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -772,8 +772,7 @@ public class ShuffleTaskManager {
       shuffleBufferManager.removeBuffer(appId);
       shuffleFlushManager.removeResources(appId);
 
-      String user = getUserByAppId(appId);
-      storageManager.removeResources(new AppPurgeEvent(appId, user));
+      storageManager.removeResources(new AppPurgeEvent(appId, shuffleTaskInfo.getUser()));
 
       if (shuffleTaskInfo.hasHugePartition()) {
         ShuffleServerMetrics.gaugeAppWithHugePartitionNum.dec();

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -771,9 +771,7 @@ public class ShuffleTaskManager {
       partitionsToBlockIds.remove(appId);
       shuffleBufferManager.removeBuffer(appId);
       shuffleFlushManager.removeResources(appId);
-
       storageManager.removeResources(new AppPurgeEvent(appId, shuffleTaskInfo.getUser()));
-
       if (shuffleTaskInfo.hasHugePartition()) {
         ShuffleServerMetrics.gaugeAppWithHugePartitionNum.dec();
         ShuffleServerMetrics.gaugeHugePartitionNum.dec(shuffleTaskInfo.getHugePartitionSize());

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -18,7 +18,6 @@
 package org.apache.uniffle.server;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -470,7 +470,11 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     assertTrue(fs.exists(new Path(appBasePath)));
     assertNull(shuffleBufferManager.getBufferPool().get(appId).get(0));
     assertNotNull(shuffleBufferManager.getBufferPool().get(appId).get(1));
+
+    // the shufflePurgeEvent only will delete the children folders
+    // Once the app is expired, all the app folder should be deleted.
     shuffleTaskManager.removeResources(appId, false);
+    assertFalse(fs.exists(new Path(appBasePath)));
   }
 
   @Test
@@ -527,6 +531,14 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
       if (files != null) {
         assertEquals(0, files.length);
       }
+    }
+
+    // the shufflePurgeEvent only will delete the children folders
+    // Once the app is expired, all the app folder should be deleted.
+    shuffleTaskManager.removeResources(appId, false);
+    for (String path : conf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH)) {
+      String appPath = path + "/" + appId;
+      assertFalse(new File(appPath).exists());
     }
   }
 

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -472,7 +472,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     assertNotNull(shuffleBufferManager.getBufferPool().get(appId).get(1));
 
     // the shufflePurgeEvent only will delete the children folders
-    // Once the app is expired, all the app folder should be deleted.
+    // Once the app is expired, all the app folders should be deleted.
     shuffleTaskManager.removeResources(appId, false);
     assertFalse(fs.exists(new Path(appBasePath)));
   }
@@ -534,7 +534,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     }
 
     // the shufflePurgeEvent only will delete the children folders
-    // Once the app is expired, all the app folder should be deleted.
+    // Once the app is expired, all the app folders should be deleted.
     shuffleTaskManager.removeResources(appId, false);
     for (String path : conf.get(ShuffleServerConf.RSS_STORAGE_BASE_PATH)) {
       String appPath = path + "/" + appId;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Always executing the removeResources no matter whether blockIds remain.

### Why are the changes needed?

Fix: #1634 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Using existing unit tests, but additionally checking the app folder after app is expired.
