### PR TITLE
fix:read inconsistent when local file read handler init before flushing event to disk

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandler.java
@@ -41,6 +41,9 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
   private String appId;
   private int shuffleId;
   private int partitionId;
+  private int partitionNumPerRange;
+  private int partitionNum;
+  private String path;
 
   public LocalFileServerReadHandler(
       String appId,
@@ -52,6 +55,9 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
+    this.partitionNumPerRange = partitionNumPerRange;
+    this.partitionNum = partitionNum;
+    this.path = path;
     init(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, path);
   }
 
@@ -138,6 +144,21 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
 
   @Override
   public ShuffleIndexResult getShuffleIndex() {
+    if (indexFileName.isEmpty()) {
+      LOG.warn(
+          "index file is empty, appId: {}, shuffleId: {}, partitionId: {}, partitionNumPerRange: {}, partitionNum: {}, path: {}",
+          appId,
+          shuffleId,
+          partitionId,
+          partitionNumPerRange,
+          partitionNum,
+          path);
+      try {
+        prepareFilePath(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, path);
+      } catch (Exception e) {
+        LOG.error("prepare file path error ", e);
+      }
+    }
     File indexFile = new File(indexFileName);
     long indexFileSize = indexFile.length();
     int indexNum = (int) (indexFileSize / FileBasedShuffleSegment.SEGMENT_SIZE);


### PR DESCRIPTION
### What changes were proposed in this pull request?

re init local file read handler when index file name is empty

### Why are the changes needed?

some case  will cause app to fail because of blocks read inconsistent

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
