### PR TITLE
chore(rust): disable flaky test of test_ticket_manager

### DIFF
--- a/rust/experimental/server/src/store/mem/ticket.rs
+++ b/rust/experimental/server/src/store/mem/ticket.rs
@@ -193,6 +193,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_ticket_manager() {
         let released_size = Arc::new(Mutex::new(0));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable flaky test of test_ticket_manager

### Why are the changes needed?

I haven't found the root cause of test flaky. so disable it until I fix this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

needn't
