### PR TITLE
[#1459][FOLLOWUP] improvement(server): Print an error log when an event is dropped

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -111,7 +111,7 @@ public class ShuffleFlushManager {
       }
 
       if (reachRetryMax(event)) {
-        LOG.warn("The event:{] has been reached to max retry times, it will be dropped.", event);
+        LOG.error("The event:{] has been reached to max retry times, it will be dropped.", event);
         throw new EventDiscardException();
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Print an error log when an event is dropped.

### Why are the changes needed?

A follow-up PR for: https://github.com/apache/incubator-uniffle/pull/1461.
This way, it's easier to find error logs in the log, making it convenient for troubleshooting.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unnecessary.
