### PR TITLE
[#1658] fix(server): FileSegmentManagedBuffer#nioByteBuffer read result cacheable

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBufferTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBufferTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.netty.buffer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FileSegmentManagedBufferTest {
+  @Test
+  void testNioByteBuffer(@TempDir File tmpDir) {
+    File dataFile = new File(tmpDir, "data_file_1");
+    String str = "Hello";
+    byte[] strToBytes = str.getBytes();
+    try (FileOutputStream outputStream = new FileOutputStream(dataFile)) {
+      outputStream.write(strToBytes);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    FileSegmentManagedBuffer fileSegmentManagedBuffer =
+        new FileSegmentManagedBuffer(dataFile, 0, strToBytes.length);
+    ByteBuffer byteBuffer1 = fileSegmentManagedBuffer.nioByteBuffer();
+    assertEquals(new String(byteBuffer1.array()), str);
+
+    ByteBuffer byteBuffer2 = fileSegmentManagedBuffer.nioByteBuffer();
+    assertTrue(byteBuffer1 == byteBuffer2);
+    fileSegmentManagedBuffer.release();
+
+    fileSegmentManagedBuffer = new FileSegmentManagedBuffer(dataFile, 0, strToBytes.length);
+    ByteBuffer byteBuffer3 = fileSegmentManagedBuffer.nioByteBuffer();
+    assertFalse(byteBuffer3 == byteBuffer2);
+    assertFalse(byteBuffer3 == byteBuffer1);
+
+    fileSegmentManagedBuffer.release();
+  }
+}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

FileSegmentManagedBuffer#nioByteBuffer add a buffer to hold read file result to avoid multiple read file

### Why are the changes needed?
Fix: #1658 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

existed  UT
