### PR TITLE
[#1341] fix(mr): Fix MR Combiner ArrayIndexOutOfBoundsException Bug.

### DIFF
--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -373,8 +373,7 @@ public class SortWriteBufferManagerTest {
             jobConf, new TaskAttemptID(), combineInputCounter, reporter, null);
 
     SortWriteBuffer<Text, IntWritable> buffer =
-        new SortWriteBuffer<Text, IntWritable>(
-            1, comparator, 10000, keySerializer, valueSerializer);
+        new SortWriteBuffer<Text, IntWritable>(1, comparator, 3072, keySerializer, valueSerializer);
 
     List<String> wordTable =
         Lists.newArrayList(
@@ -383,7 +382,7 @@ public class SortWriteBufferManagerTest {
     for (int i = 0; i < 8; i++) {
       buffer.addRecord(new Text(wordTable.get(i)), new IntWritable(1));
     }
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 10000; i++) {
       int index = random.nextInt(wordTable.size());
       buffer.addRecord(new Text(wordTable.get(index)), new IntWritable(1));
     }
@@ -429,7 +428,7 @@ public class SortWriteBufferManagerTest {
     while (kvIterator2.next()) {
       count2++;
     }
-    assertEquals(108, count1);
+    assertEquals(10008, count1);
     assertEquals(8, count2);
   }
 

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
@@ -157,7 +157,7 @@ public class SortWriteBufferTest {
     assertEquals(bigWritableValue, valueRead);
   }
 
-  @org.junit.Test
+  @Test
   public void testSortBufferIterator() throws IOException {
     SerializationFactory serializationFactory =
         new SerializationFactory(new JobConf(new Configuration()));

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.mapred;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.serializer.Deserializer;
@@ -151,6 +155,55 @@ public class SortWriteBufferTest {
     valueRead = valDeserializer.deserialize(null);
     assertEquals(bigWritableKey, keyRead);
     assertEquals(bigWritableValue, valueRead);
+  }
+
+  @org.junit.Test
+  public void testSortBufferIterator() throws IOException {
+    SerializationFactory serializationFactory =
+        new SerializationFactory(new JobConf(new Configuration()));
+    Serializer<Text> keySerializer = serializationFactory.getSerializer(Text.class);
+    Deserializer<Text> keyDeserializer = serializationFactory.getDeserializer(Text.class);
+    Serializer<IntWritable> valueSerializer = serializationFactory.getSerializer(IntWritable.class);
+    Deserializer<IntWritable> valueDeserializer =
+        serializationFactory.getDeserializer(IntWritable.class);
+
+    SortWriteBuffer<Text, IntWritable> buffer =
+        new SortWriteBuffer<Text, IntWritable>(1, null, 3072, keySerializer, valueSerializer);
+
+    List<String> wordTable =
+        Lists.newArrayList(
+            "apple", "banana", "fruit", "cherry", "Chinese", "America", "Japan", "tomato");
+
+    List<String> keys = Lists.newArrayList();
+
+    Random random = new Random();
+    for (int i = 0; i < 8; i++) {
+      buffer.addRecord(new Text(wordTable.get(i)), new IntWritable(1));
+      keys.add(wordTable.get(i));
+    }
+    for (int i = 0; i < 10000; i++) {
+      int index = random.nextInt(wordTable.size());
+      buffer.addRecord(new Text(wordTable.get(index)), new IntWritable(1));
+      keys.add(wordTable.get(index));
+    }
+
+    SortWriteBuffer.SortBufferIterator<Text, IntWritable> iterator =
+        new SortWriteBuffer.SortBufferIterator<>(buffer);
+
+    int ind = 0;
+
+    Text key = new Text();
+    IntWritable value = new IntWritable();
+    while (iterator.next()) {
+      iterator.getKey().getData();
+      iterator.getValue().getData();
+      keyDeserializer.open(iterator.getKey());
+      valueDeserializer.open(iterator.getValue());
+      keyDeserializer.deserialize(key);
+      valueDeserializer.deserialize(value);
+      assertEquals(keys.get(ind), key.toString());
+      ind++;
+    }
   }
 
   int readInt(DataInputStream dStream) throws IOException {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

The current implementation of the SortBufferIterator.getKey() and .getValue() methods in the SortWriteBuffer class assumes that keys and values are always stored within a single buffer. This assumption can lead to runtime exceptions, specifically ArrayIndexOutOfBoundsException, when keys or values span multiple WrappedBuffer instances.

In the current implementation, due to the execution of the `compact()`, the data of the key will not span buffers. However, the data of the value may be located on different buffers from the key and may span multiple buffers.

This PR update getKey() to use fetchDataFromBuffers() to retrieve the key data. And this PR update getValue() to first adjust the starting index and offset based on the length of the key and then use fetchDataFromBuffers() to retrieve the value data.

Another solution to this bug is to modify `addRecord()` method by keeping key and value in the same WrappedBuffer.

### Why are the changes needed?

Fix: #1341

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested manually. I'll submit a new integration test later.
