### PR TITLE
[#1684] fix(server): use the diskSize obtained from periodic check to determine whether is writable

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -113,9 +113,9 @@ public class LocalStorageChecker extends Checker {
 
                 totalSpace.addAndGet(total);
                 wholeDiskUsedSpace.addAndGet(total - free);
-                long used = getServiceUsedSpace(storageInfo.storageDir);
-                serviceUsedSpace.addAndGet(used);
-                storageInfo.updateServiceUsedSpace(used);
+                long usedBytes = getServiceUsedSpace(storageInfo.storageDir);
+                serviceUsedSpace.addAndGet(usedBytes);
+                storageInfo.updateServiceUsedBytes(usedBytes);
                 storageInfo.updateStorageFreeSpace(free);
 
                 boolean isWritable = storageInfo.canWrite();
@@ -242,8 +242,8 @@ public class LocalStorageChecker extends Checker {
       storage.updateDiskFree(free);
     }
 
-    void updateServiceUsedSpace(long used) {
-      storage.updateServiceUsed(used);
+    void updateServiceUsedBytes(long used) {
+      storage.updateServiceUsedBytes(used);
     }
 
     boolean checkIsSpaceEnough(long total, long free) {

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -242,8 +242,8 @@ public class LocalStorageChecker extends Checker {
       storage.updateDiskFree(free);
     }
 
-    void updateServiceUsedBytes(long used) {
-      storage.updateServiceUsedBytes(used);
+    void updateServiceUsedBytes(long usedBytes) {
+      storage.updateServiceUsedBytes(usedBytes);
     }
 
     boolean checkIsSpaceEnough(long total, long free) {

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -239,7 +239,7 @@ public class LocalStorageChecker extends Checker {
     }
 
     void updateStorageFreeSpace(long free) {
-      storage.updateDiskFree(free);
+      storage.updateDiskAvailableBytes(free);
     }
 
     void updateServiceUsedBytes(long usedBytes) {

--- a/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
+++ b/server/src/main/java/org/apache/uniffle/server/LocalStorageChecker.java
@@ -113,8 +113,9 @@ public class LocalStorageChecker extends Checker {
 
                 totalSpace.addAndGet(total);
                 wholeDiskUsedSpace.addAndGet(total - free);
-                serviceUsedSpace.addAndGet(getServiceUsedSpace(storageInfo.storageDir));
-
+                long used = getServiceUsedSpace(storageInfo.storageDir);
+                serviceUsedSpace.addAndGet(used);
+                storageInfo.updateServiceUsedSpace(used);
                 storageInfo.updateStorageFreeSpace(free);
 
                 boolean isWritable = storageInfo.canWrite();
@@ -239,6 +240,10 @@ public class LocalStorageChecker extends Checker {
 
     void updateStorageFreeSpace(long free) {
       storage.updateDiskFree(free);
+    }
+
+    void updateServiceUsedSpace(long used) {
+      storage.updateServiceUsed(used);
     }
 
     boolean checkIsSpaceEnough(long total, long free) {

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -380,7 +380,7 @@ public class LocalStorageManager extends SingleStorageManager {
     for (LocalStorage storage : localStorages) {
       String mountPoint = storage.getMountPoint();
       long capacity = storage.getCapacity();
-      long wroteBytes = storage.getDiskSize();
+      long wroteBytes = storage.getServiceUsedSize();
       StorageStatus status = StorageStatus.NORMAL;
       if (storage.isCorrupted()) {
         status = StorageStatus.UNHEALTHY;

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -380,7 +380,7 @@ public class LocalStorageManager extends SingleStorageManager {
     for (LocalStorage storage : localStorages) {
       String mountPoint = storage.getMountPoint();
       long capacity = storage.getCapacity();
-      long wroteBytes = storage.getServiceUsedSize();
+      long wroteBytes = storage.getServiceUsedBytes();
       StorageStatus status = StorageStatus.NORMAL;
       if (storage.isCorrupted()) {
         status = StorageStatus.UNHEALTHY;

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -343,6 +343,7 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     int storageIndex1 = storagePaths.indexOf(flushEvent.getUnderStorage().getStoragePath());
     validateLocalMetadata(storageManager, storageIndex1, 1010L);
 
+    storageManager.getStorageChecker().checkIsHealthy();
     flushEvent = createShuffleDataFlushEvent(appId, 3, 1, 1, 10, 102, null);
     manager.addToFlushQueue(flushEvent);
     // wait for write data
@@ -737,6 +738,7 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     Thread.sleep(1000);
     assertTrue(event.getUnderStorage() instanceof LocalStorage);
 
+    storageManager.getStorageChecker().checkIsHealthy();
     // case2: huge event is written to cold storage directly
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100000);
     flushManager.addToFlushQueue(event);
@@ -753,6 +755,7 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ((HybridStorageManager) storageManager).getWarmStorageManager().selectStorage(event));
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
+    storageManager.getStorageChecker().checkIsHealthy();
     event = createShuffleDataFlushEvent(appId, 3, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
     Thread.sleep(1000);
@@ -793,6 +796,7 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
     assertEquals(0, event.getRetryTimes());
     assertEquals(1, ShuffleServerMetrics.counterLocalFileEventFlush.get());
 
+    storageManager.getStorageChecker().checkIsHealthy();
     // case2: huge event is written to cold storage directly
     event = createShuffleDataFlushEvent(appId, 1, 1, 1, null, 100000);
     flushManager.addToFlushQueue(event);
@@ -809,6 +813,7 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
         ((HybridStorageManager) storageManager).getWarmStorageManager().selectStorage(event));
     ((HybridStorageManager) storageManager).getWarmStorageManager().updateWriteMetrics(bigEvent, 0);
 
+    storageManager.getStorageChecker().checkIsHealthy();
     event = createShuffleDataFlushEvent(appId, 2, 1, 1, null, 100);
     flushManager.addToFlushQueue(event);
     waitForFlush(flushManager, appId, 2, 5);

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -46,7 +46,7 @@ public class LocalStorage extends AbstractStorage {
   public static final String STORAGE_HOST = "local";
 
   private final long diskCapacity;
-  private volatile long diskFree;
+  private volatile long diskAvailableBytes;
   private volatile long serviceUsedBytes;
   // for test cases
   private boolean enableDiskCapacityCheck = false;
@@ -82,7 +82,7 @@ public class LocalStorage extends AbstractStorage {
       throw new RssException(ioe);
     }
     this.diskCapacity = baseFolder.getTotalSpace();
-    this.diskFree = baseFolder.getUsableSpace();
+    this.diskAvailableBytes = baseFolder.getUsableSpace();
 
     if (capacity < 0L) {
       this.capacity = (long) (diskCapacity * builder.ratio);
@@ -92,7 +92,7 @@ public class LocalStorage extends AbstractStorage {
           builder.ratio,
           diskCapacity);
     } else {
-      final long freeSpace = diskFree;
+      final long freeSpace = diskAvailableBytes;
       if (freeSpace < capacity) {
         throw new IllegalArgumentException(
             "The Disk of "
@@ -170,11 +170,12 @@ public class LocalStorage extends AbstractStorage {
       serviceUsedCapacityCheck =
           (double) (serviceUsedBytes * 100) / capacity < highWaterMarkOfWrite;
       diskUsedCapacityCheck =
-          ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < highWaterMarkOfWrite;
+          ((double) (diskCapacity - diskAvailableBytes)) * 100 / diskCapacity
+              < highWaterMarkOfWrite;
     } else {
       serviceUsedCapacityCheck = (double) (serviceUsedBytes * 100) / capacity < lowWaterMarkOfWrite;
       diskUsedCapacityCheck =
-          ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < lowWaterMarkOfWrite;
+          ((double) (diskCapacity - diskAvailableBytes)) * 100 / diskCapacity < lowWaterMarkOfWrite;
     }
     isSpaceEnough =
         serviceUsedCapacityCheck && (enableDiskCapacityCheck ? diskUsedCapacityCheck : true);
@@ -262,8 +263,8 @@ public class LocalStorage extends AbstractStorage {
     return appIds;
   }
 
-  public void updateDiskFree(long free) {
-    this.diskFree = free;
+  public void updateDiskAvailableBytes(long bytes) {
+    this.diskAvailableBytes = bytes;
   }
 
   public void updateServiceUsedBytes(long usedBytes) {

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -47,6 +47,7 @@ public class LocalStorage extends AbstractStorage {
 
   private final long diskCapacity;
   private volatile long diskFree;
+  private volatile long serviceUsed;
   // for test cases
   private boolean enableDiskCapacityCheck = false;
 
@@ -166,13 +167,11 @@ public class LocalStorage extends AbstractStorage {
     boolean diskUsedCapacityCheck;
 
     if (isSpaceEnough) {
-      serviceUsedCapacityCheck =
-          metaData.getDiskSize().doubleValue() * 100 / capacity < highWaterMarkOfWrite;
+      serviceUsedCapacityCheck = (double) (serviceUsed * 100) / capacity < highWaterMarkOfWrite;
       diskUsedCapacityCheck =
           ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < highWaterMarkOfWrite;
     } else {
-      serviceUsedCapacityCheck =
-          metaData.getDiskSize().doubleValue() * 100 / capacity < lowWaterMarkOfWrite;
+      serviceUsedCapacityCheck = (double) (serviceUsed * 100) / capacity < lowWaterMarkOfWrite;
       diskUsedCapacityCheck =
           ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < lowWaterMarkOfWrite;
     }
@@ -203,8 +202,8 @@ public class LocalStorage extends AbstractStorage {
     metaData.updateShuffleLastReadTs(shuffleKey);
   }
 
-  public long getDiskSize() {
-    return metaData.getDiskSize().longValue();
+  public long getServiceUsedSize() {
+    return serviceUsed;
   }
 
   @VisibleForTesting
@@ -268,6 +267,10 @@ public class LocalStorage extends AbstractStorage {
 
   public void updateDiskFree(long free) {
     this.diskFree = free;
+  }
+
+  public void updateServiceUsed(long used) {
+    this.serviceUsed = used;
   }
 
   // Only for test

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -47,7 +47,7 @@ public class LocalStorage extends AbstractStorage {
 
   private final long diskCapacity;
   private volatile long diskFree;
-  private volatile long serviceUsed;
+  private volatile long serviceUsedBytes;
   // for test cases
   private boolean enableDiskCapacityCheck = false;
 
@@ -167,11 +167,12 @@ public class LocalStorage extends AbstractStorage {
     boolean diskUsedCapacityCheck;
 
     if (isSpaceEnough) {
-      serviceUsedCapacityCheck = (double) (serviceUsed * 100) / capacity < highWaterMarkOfWrite;
+      serviceUsedCapacityCheck =
+          (double) (serviceUsedBytes * 100) / capacity < highWaterMarkOfWrite;
       diskUsedCapacityCheck =
           ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < highWaterMarkOfWrite;
     } else {
-      serviceUsedCapacityCheck = (double) (serviceUsed * 100) / capacity < lowWaterMarkOfWrite;
+      serviceUsedCapacityCheck = (double) (serviceUsedBytes * 100) / capacity < lowWaterMarkOfWrite;
       diskUsedCapacityCheck =
           ((double) (diskCapacity - diskFree)) * 100 / diskCapacity < lowWaterMarkOfWrite;
     }
@@ -200,10 +201,6 @@ public class LocalStorage extends AbstractStorage {
 
   public void updateShuffleLastReadTs(String shuffleKey) {
     metaData.updateShuffleLastReadTs(shuffleKey);
-  }
-
-  public long getServiceUsedSize() {
-    return serviceUsed;
   }
 
   @VisibleForTesting
@@ -269,12 +266,12 @@ public class LocalStorage extends AbstractStorage {
     this.diskFree = free;
   }
 
-  public void updateServiceUsed(long used) {
-    this.serviceUsed = used;
+  public void updateServiceUsedBytes(long used) {
+    this.serviceUsedBytes = used;
   }
 
-  public long getServiceUsed() {
-    return serviceUsed;
+  public long getServiceUsedBytes() {
+    return serviceUsedBytes;
   }
 
   // Only for test

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -273,6 +273,10 @@ public class LocalStorage extends AbstractStorage {
     this.serviceUsed = used;
   }
 
+  public long getServiceUsed() {
+    return serviceUsed;
+  }
+
   // Only for test
   @VisibleForTesting
   public void markSpaceFull() {

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -266,8 +266,8 @@ public class LocalStorage extends AbstractStorage {
     this.diskFree = free;
   }
 
-  public void updateServiceUsedBytes(long used) {
-    this.serviceUsedBytes = used;
+  public void updateServiceUsedBytes(long usedBytes) {
+    this.serviceUsedBytes = usedBytes;
   }
 
   public long getServiceUsedBytes() {

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -184,10 +184,10 @@ public class LocalStorageTest {
     assertTrue(localStorage.canWrite());
 
     final long diskCapacity = localStorage.getDiskCapacity();
-    localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.96)));
+    localStorage.updateDiskAvailableBytes((long) (diskCapacity * (1 - 0.96)));
     assertFalse(localStorage.canWrite());
 
-    localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.60)));
+    localStorage.updateDiskAvailableBytes((long) (diskCapacity * (1 - 0.60)));
     assertFalse(localStorage.canWrite());
     localStorage.updateServiceUsedBytes(localStorage.getServiceUsedBytes() - 10);
     assertTrue(localStorage.canWrite());
@@ -203,10 +203,10 @@ public class LocalStorageTest {
             .enableDiskCapacityWatermarkCheck()
             .build();
 
-    localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.96)));
+    localStorage.updateDiskAvailableBytes((long) (diskCapacity * (1 - 0.96)));
     assertFalse(localStorage.canWrite());
 
-    localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.60)));
+    localStorage.updateDiskAvailableBytes((long) (diskCapacity * (1 - 0.60)));
     assertTrue(localStorage.canWrite());
   }
 }

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -76,15 +76,15 @@ public class LocalStorageTest {
   public void canWriteTest() {
     LocalStorage item = createTestStorage(testBaseDir);
 
-    item.getMetaData().updateDiskSize(20);
+    item.updateServiceUsed(20);
     assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(65);
+    item.updateServiceUsed(item.getServiceUsed() + 65);
     assertTrue(item.canWrite());
-    item.getMetaData().updateDiskSize(10);
+    item.updateServiceUsed(item.getServiceUsed() + 10);
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
+    item.updateServiceUsed(item.getServiceUsed() + -10);
     assertFalse(item.canWrite());
-    item.getMetaData().updateDiskSize(-10);
+    item.updateServiceUsed(item.getServiceUsed() + -10);
     assertTrue(item.canWrite());
   }
 
@@ -178,9 +178,9 @@ public class LocalStorageTest {
             .enableDiskCapacityWatermarkCheck()
             .build();
 
-    localStorage.getMetaData().updateDiskSize(20);
+    localStorage.updateServiceUsed(localStorage.getServiceUsed() + 20);
     assertTrue(localStorage.canWrite());
-    localStorage.getMetaData().updateDiskSize(65);
+    localStorage.updateServiceUsed(localStorage.getServiceUsed() + 65);
     assertTrue(localStorage.canWrite());
 
     final long diskCapacity = localStorage.getDiskCapacity();
@@ -189,7 +189,7 @@ public class LocalStorageTest {
 
     localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.60)));
     assertFalse(localStorage.canWrite());
-    localStorage.getMetaData().updateDiskSize(-10);
+    localStorage.updateServiceUsed(localStorage.getServiceUsed() - 10);
     assertTrue(localStorage.canWrite());
 
     // capacity = diskCapacity

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -76,15 +76,15 @@ public class LocalStorageTest {
   public void canWriteTest() {
     LocalStorage item = createTestStorage(testBaseDir);
 
-    item.updateServiceUsed(20);
+    item.updateServiceUsedBytes(20);
     assertTrue(item.canWrite());
-    item.updateServiceUsed(item.getServiceUsed() + 65);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 65);
     assertTrue(item.canWrite());
-    item.updateServiceUsed(item.getServiceUsed() + 10);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
     assertFalse(item.canWrite());
-    item.updateServiceUsed(item.getServiceUsed() + -10);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
     assertFalse(item.canWrite());
-    item.updateServiceUsed(item.getServiceUsed() + -10);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
     assertTrue(item.canWrite());
   }
 
@@ -178,9 +178,9 @@ public class LocalStorageTest {
             .enableDiskCapacityWatermarkCheck()
             .build();
 
-    localStorage.updateServiceUsed(localStorage.getServiceUsed() + 20);
+    localStorage.updateServiceUsedBytes(localStorage.getServiceUsedBytes() + 20);
     assertTrue(localStorage.canWrite());
-    localStorage.updateServiceUsed(localStorage.getServiceUsed() + 65);
+    localStorage.updateServiceUsedBytes(localStorage.getServiceUsedBytes() + 65);
     assertTrue(localStorage.canWrite());
 
     final long diskCapacity = localStorage.getDiskCapacity();
@@ -189,7 +189,7 @@ public class LocalStorageTest {
 
     localStorage.updateDiskFree((long) (diskCapacity * (1 - 0.60)));
     assertFalse(localStorage.canWrite());
-    localStorage.updateServiceUsed(localStorage.getServiceUsed() - 10);
+    localStorage.updateServiceUsedBytes(localStorage.getServiceUsedBytes() - 10);
     assertTrue(localStorage.canWrite());
 
     // capacity = diskCapacity

--- a/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/common/LocalStorageTest.java
@@ -82,9 +82,9 @@ public class LocalStorageTest {
     assertTrue(item.canWrite());
     item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
     assertFalse(item.canWrite());
-    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() - 10);
     assertFalse(item.canWrite());
-    item.updateServiceUsedBytes(item.getServiceUsedBytes() + 10);
+    item.updateServiceUsedBytes(item.getServiceUsedBytes() - 10);
     assertTrue(item.canWrite());
   }
 


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Use the disk size obtained from periodic check to determine whether the disk can be written.

### Why are the changes needed?

The disk size obtained from metadata is unreliable.
Fix: #1684 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs
