### PR TITLE
[#1608][part-6] improvement(spark): verify the sent blocks count

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -67,6 +67,8 @@ public class WriteBufferManager extends MemoryConsumer {
   private AtomicLong inSendListBytes = new AtomicLong(0);
   /** An atomic counter used to keep track of the number of records */
   private AtomicLong recordCounter = new AtomicLong(0);
+  /** An atomic counter used to keep track of the number of blocks */
+  private AtomicLong blockCounter = new AtomicLong(0);
   // it's part of blockId
   private Map<Integer, Integer> partitionToSeqNo = Maps.newHashMap();
   private long askExecutorMemory;
@@ -366,6 +368,7 @@ public class WriteBufferManager extends MemoryConsumer {
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     final long blockId =
         blockIdLayout.getBlockId(getNextSeqNo(partitionId), partitionId, taskAttemptId);
+    blockCounter.incrementAndGet();
     uncompressedDataLen += data.length;
     shuffleWriteMetrics.incBytesWritten(compressed.length);
     // add memory to indicate bytes which will be sent to shuffle server
@@ -538,6 +541,10 @@ public class WriteBufferManager extends MemoryConsumer {
 
   protected long getRecordCount() {
     return recordCounter.get();
+  }
+
+  public long getBlockCount() {
+    return blockCounter.get();
   }
 
   public void freeAllocatedMemory(long freeMemory) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -266,6 +266,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     final long start = System.currentTimeMillis();
     shuffleBlockInfos = bufferManager.clear();
     processShuffleBlockInfos(shuffleBlockInfos);
+    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     long s = System.currentTimeMillis();
     checkSentRecordCount(recordCount);
     checkSentBlockCount();
@@ -309,12 +310,11 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void checkSentBlockCount() {
     long tracked = 0;
     if (serverToPartitionToBlockIds != null) {
-      tracked =
-          serverToPartitionToBlockIds.values().stream()
-              .flatMap(x -> x.values().stream())
-              .map(x -> x.size())
-              .reduce((a, b) -> a + b)
-              .orElse(0);
+      Set<Long> blockIds = new HashSet<>();
+      for (Map<Integer, Set<Long>> partitionBlockIds : serverToPartitionToBlockIds.values()) {
+        partitionBlockIds.values().forEach(x -> blockIds.addAll(x));
+      }
+      tracked = blockIds.size();
     }
     if (tracked != bufferManager.getBlockCount()) {
       throw new RssSendFailedException(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -311,6 +311,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     if (shuffleBlockInfos != null && !shuffleBlockInfos.isEmpty()) {
       processShuffleBlockInfos(shuffleBlockInfos);
     }
+    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     long checkStartTs = System.currentTimeMillis();
     checkSentRecordCount(recordCount);
     checkSentBlockCount();
@@ -352,12 +353,11 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private void checkSentBlockCount() {
     long tracked = 0;
     if (serverToPartitionToBlockIds != null) {
-      tracked =
-          serverToPartitionToBlockIds.values().stream()
-              .flatMap(x -> x.values().stream())
-              .map(x -> x.size())
-              .reduce((a, b) -> a + b)
-              .orElse(0);
+      Set<Long> blockIds = new HashSet<>();
+      for (Map<Integer, Set<Long>> partitionBlockIds : serverToPartitionToBlockIds.values()) {
+        partitionBlockIds.values().forEach(x -> blockIds.addAll(x));
+      }
+      tracked = blockIds.size();
     }
     if (tracked != bufferManager.getBlockCount()) {
       throw new RssSendFailedException(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -313,6 +313,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
     long checkStartTs = System.currentTimeMillis();
     checkSentRecordCount(recordCount);
+    checkSentBlockCount();
     checkBlockSendResult(blockIds);
     long commitStartTs = System.currentTimeMillis();
     long checkDuration = commitStartTs - checkStartTs;
@@ -345,6 +346,22 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
               + taskId
               + "]";
       throw new RssSendFailedException(errorMsg);
+    }
+  }
+
+  private void checkSentBlockCount() {
+    long tracked = 0;
+    if (serverToPartitionToBlockIds != null) {
+      tracked =
+          serverToPartitionToBlockIds.values().stream()
+              .flatMap(x -> x.values().stream())
+              .map(x -> x.size())
+              .reduce((a, b) -> a + b)
+              .orElse(0);
+    }
+    if (tracked != bufferManager.getBlockCount()) {
+      throw new RssSendFailedException(
+          "Potential block loss may occur when preparing to send blocks for task[" + taskId + "]");
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Verify the sent blocks count in write tasks for spark

### Why are the changes needed?

For #1608.
After introducing the reassign menchanism, the blocks' stored location will be dynamiclly changed. 
To ensure possible or potenial bugs, it's necessary to introduce the block count.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests are enough to ensure safe
