### PR TITLE
[MINOR] fix(typo): Correct the removeShuffle method name

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorage.java
@@ -230,7 +230,7 @@ public class LocalStorage extends AbstractStorage {
     LOG.info("Start to remove resource of {}", shuffleKey);
     try {
       metaData.updateDiskSize(-metaData.getShuffleSize(shuffleKey));
-      metaData.remoteShuffle(shuffleKey);
+      metaData.removeShuffle(shuffleKey);
       LOG.info(
           "Finish remove resource of {}, disk size is {} and {} shuffle metadata",
           shuffleKey,

--- a/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorageMeta.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/LocalStorageMeta.java
@@ -71,7 +71,7 @@ public class LocalStorageMeta {
     }
   }
 
-  public void remoteShuffle(String shuffleKey) {
+  public void removeShuffle(String shuffleKey) {
     shuffleMetaMap.remove(shuffleKey);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

remoteShuffle -> removeShuffle

### Why are the changes needed?

Fix spelling errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
