### PR TITLE
[#1701] improvement(Netty): Bump Netty from 4.1.106.Final to 4.1.109.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <spotless-maven-plugin.version>2.30.0</spotless-maven-plugin.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>3.12.4</mockito.version>
-    <netty.version>4.1.106.Final</netty.version>
+    <netty.version>4.1.109.Final</netty.version>
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <prometheus.simpleclient.version>0.9.0</prometheus.simpleclient.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Netty from 4.1.106.Final to 4.1.109.Final.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/1701.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
