### PR TITLE
[#1706] improvement: Upgrade the default NodeJS and npm versions of dashboard.

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -53,8 +53,8 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v14.21.3</nodeVersion>
-                            <npmVersion>6.14.18</npmVersion>
+                            <nodeVersion>v16.20.2</nodeVersion>
+                            <npmVersion>8.19.4</npmVersion>
                             <nodeDownloadRoot>${nodeRepositoryUrl}</nodeDownloadRoot>
                             <npmDownloadRoot>${npmRepositoryUrl}</npmDownloadRoot>
                         </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade the versions of NodeJS and npm.

### Why are the changes needed?

The dashboard on MacOS does not support the M-chip of Node14, resulting in a local compilation failure, and you need to upgrade to Node16 or npm8 or later.

Fix: #1706 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No testing required.
