### PR TITLE
[#1713] Improvement: Don't log some errors on exit

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -915,8 +915,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               LOG.warn("Failed to send heartbeat to " + shuffleServerInfo);
             }
           } catch (Exception e) {
-            if (!closed) {
-              // this client has been closed, so we are not interested in failing heartbeat calls
+            if (closed) {
+              // this client has been closed, so failing heartbeat calls are expected
+              LOG.info(
+                  "Error happened when send heartbeat to "
+                      + shuffleServerInfo
+                      + " after shuffle write client has been closed",
+                  e);
+            } else {
               LOG.warn("Error happened when send heartbeat to " + shuffleServerInfo, e);
             }
           }
@@ -937,8 +943,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               LOG.info("Successfully send heartbeat to " + coordinatorClient.getDesc());
             }
           } catch (Exception e) {
-            if (!closed) {
-              // this client has been closed, so we are not interested in failing heartbeat calls
+            if (closed) {
+              // this client has been closed, so failing heartbeat calls are expected
+              LOG.info(
+                  "Error happened when send heartbeat to "
+                      + coordinatorClient.getDesc()
+                      + " after shuffle write client has been closed",
+                  e);
+            } else {
               LOG.warn("Error happened when send heartbeat to " + coordinatorClient.getDesc(), e);
             }
           }
@@ -988,8 +1000,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                 LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
               }
             } catch (Exception e) {
-              if (!closed) {
-                // this client has been closed, so we are not interested in failing unregister calls
+              if (closed) {
+                // this client has been closed, so failing unregister calls are expected
+                LOG.info(
+                    "Error happened when unregistering to "
+                        + shuffleServerInfo
+                        + " after shuffle write client has been closed",
+                    e);
+              } else {
                 LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
               }
             }
@@ -1039,8 +1057,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                 LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
               }
             } catch (Exception e) {
-              if (!closed) {
-                // this client has been closed, so we are not interested in failing unregister calls
+              if (closed) {
+                // this client has been closed, so failing unregister calls are expected
+                LOG.info(
+                    "Error happened when unregistering to "
+                        + shuffleServerInfo
+                        + " after shuffle write client has been closed",
+                    e);
+              } else {
                 LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
               }
             }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -467,18 +467,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                             if (response.getStatusCode() == StatusCode.SUCCESS) {
                               int commitCount = response.getCommitCount();
                               LOG.info(
-                                  "Successfully sendCommit for appId["
-                                      + appId
-                                      + "], shuffleId["
-                                      + shuffleId
-                                      + "] to ShuffleServer["
-                                      + ssi.getId()
-                                      + "], cost "
-                                      + (System.currentTimeMillis() - startTime)
-                                      + " ms, got committed maps["
-                                      + commitCount
-                                      + "], map number of stage is "
-                                      + numMaps);
+                                  "Successfully sendCommit for appId[{}], shuffleId[{}] to ShuffleServer[{}], cost {} ms, got committed maps[{}], map number of stage is {}",
+                                      appId, shuffleId, ssi.getId(), (System.currentTimeMillis() - startTime), commitCount, numMaps);
                               if (commitCount >= numMaps) {
                                 RssFinishShuffleResponse rfsResponse =
                                     getShuffleServerClient(ssi)
@@ -496,11 +486,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                                   throw new Exception(msg);
                                 } else {
                                   LOG.info(
-                                      "Successfully finish shuffle to "
-                                          + ssi
-                                          + " for shuffleId["
-                                          + shuffleId
-                                          + "]");
+                                      "Successfully finish shuffle to {} for shuffleId[{}]",
+                                      ssi, shuffleId
+                                  );
                                 }
                               }
                             } else {
@@ -707,34 +695,20 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             getShuffleServerClient(ssi).reportShuffleResult(request);
         if (response.getStatusCode() == StatusCode.SUCCESS) {
           LOG.info(
-              "Report shuffle result to "
-                  + ssi
-                  + " for appId["
-                  + appId
-                  + "], shuffleId["
-                  + shuffleId
-                  + "] successfully");
+              "Report shuffle result to {} for appId[{}], shuffleId[{}] successfully",
+              ssi, appId, shuffleId
+          );
         } else {
           LOG.warn(
-              "Report shuffle result to "
-                  + ssi
-                  + " for appId["
-                  + appId
-                  + "], shuffleId["
-                  + shuffleId
-                  + "] failed with "
-                  + response.getStatusCode());
+              "Report shuffle result to {} for appId[{}], shuffleId[{}] failed with {}",
+                  ssi, appId, shuffleId, response.getStatusCode());
           recordFailedBlockIds(blockReportTracker, requestBlockIds);
         }
       } catch (Exception e) {
         LOG.warn(
-            "Report shuffle result is failed to "
-                + ssi
-                + " for appId["
-                + appId
-                + "], shuffleId["
-                + shuffleId
-                + "]");
+            "Report shuffle result is failed to {} for appId[{}], shuffleId[{}]",
+            ssi, appId, shuffleId
+        );
         recordFailedBlockIds(blockReportTracker, requestBlockIds);
       }
     }
@@ -796,13 +770,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         }
       } catch (Exception e) {
         LOG.warn(
-            "Get shuffle result is failed from "
-                + ssi
-                + " for appId["
-                + appId
-                + "], shuffleId["
-                + shuffleId
-                + "]");
+            "Get shuffle result is failed from {} for appId[{}], shuffleId[{}]",
+            ssi, appId, shuffleId
+        );
       }
     }
     if (!isSuccessful) {
@@ -883,9 +853,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             RssApplicationInfoResponse response =
                 coordinatorClient.registerApplicationInfo(request);
             if (response.getStatusCode() != StatusCode.SUCCESS) {
-              LOG.error("Failed to send applicationInfo to " + coordinatorClient.getDesc());
+              LOG.error("Failed to send applicationInfo to {}", coordinatorClient.getDesc());
             } else {
-              LOG.info("Successfully send applicationInfo to " + coordinatorClient.getDesc());
+              LOG.info("Successfully send applicationInfo to {}", coordinatorClient.getDesc());
             }
           } catch (Exception e) {
             LOG.warn(
@@ -912,7 +882,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                     .getShuffleServerClient(clientType, shuffleServerInfo, rssConf);
             RssAppHeartBeatResponse response = client.sendHeartBeat(request);
             if (response.getStatusCode() != StatusCode.SUCCESS) {
-              LOG.warn("Failed to send heartbeat to " + shuffleServerInfo);
+              LOG.warn("Failed to send heartbeat to {}", shuffleServerInfo);
             }
           } catch (Exception e) {
             if (closed) {
@@ -938,9 +908,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           try {
             RssAppHeartBeatResponse response = coordinatorClient.sendAppHeartBeat(request);
             if (response.getStatusCode() != StatusCode.SUCCESS) {
-              LOG.warn("Failed to send heartbeat to " + coordinatorClient.getDesc());
+              LOG.warn("Failed to send heartbeat to {}", coordinatorClient.getDesc());
             } else {
-              LOG.info("Successfully send heartbeat to " + coordinatorClient.getDesc());
+              LOG.info("Successfully send heartbeat to {}", coordinatorClient.getDesc());
             }
           } catch (Exception e) {
             if (closed) {
@@ -997,7 +967,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                       .getShuffleServerClient(clientType, shuffleServerInfo, rssConf);
               RssUnregisterShuffleResponse response = client.unregisterShuffle(request);
               if (response.getStatusCode() != StatusCode.SUCCESS) {
-                LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
+                LOG.warn("Failed to unregister shuffle to {}", shuffleServerInfo);
               }
             } catch (Exception e) {
               if (closed) {
@@ -1054,7 +1024,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               RssUnregisterShuffleByAppIdResponse response =
                   client.unregisterShuffleByAppId(request);
               if (response.getStatusCode() != StatusCode.SUCCESS) {
-                LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
+                LOG.warn("Failed to unregister shuffle to {}", shuffleServerInfo);
               }
             } catch (Exception e) {
               if (closed) {

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -468,7 +468,12 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                               int commitCount = response.getCommitCount();
                               LOG.info(
                                   "Successfully sendCommit for appId[{}], shuffleId[{}] to ShuffleServer[{}], cost {} ms, got committed maps[{}], map number of stage is {}",
-                                      appId, shuffleId, ssi.getId(), (System.currentTimeMillis() - startTime), commitCount, numMaps);
+                                  appId,
+                                  shuffleId,
+                                  ssi.getId(),
+                                  (System.currentTimeMillis() - startTime),
+                                  commitCount,
+                                  numMaps);
                               if (commitCount >= numMaps) {
                                 RssFinishShuffleResponse rfsResponse =
                                     getShuffleServerClient(ssi)
@@ -487,8 +492,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                                 } else {
                                   LOG.info(
                                       "Successfully finish shuffle to {} for shuffleId[{}]",
-                                      ssi, shuffleId
-                                  );
+                                      ssi,
+                                      shuffleId);
                                 }
                               }
                             } else {
@@ -696,19 +701,24 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         if (response.getStatusCode() == StatusCode.SUCCESS) {
           LOG.info(
               "Report shuffle result to {} for appId[{}], shuffleId[{}] successfully",
-              ssi, appId, shuffleId
-          );
+              ssi,
+              appId,
+              shuffleId);
         } else {
           LOG.warn(
               "Report shuffle result to {} for appId[{}], shuffleId[{}] failed with {}",
-                  ssi, appId, shuffleId, response.getStatusCode());
+              ssi,
+              appId,
+              shuffleId,
+              response.getStatusCode());
           recordFailedBlockIds(blockReportTracker, requestBlockIds);
         }
       } catch (Exception e) {
         LOG.warn(
             "Report shuffle result failed to {} for appId[{}], shuffleId[{}]",
-            ssi, appId, shuffleId
-        );
+            ssi,
+            appId,
+            shuffleId);
         recordFailedBlockIds(blockReportTracker, requestBlockIds);
       }
     }
@@ -771,8 +781,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       } catch (Exception e) {
         LOG.warn(
             "Get shuffle result failed from {} for appId[{}], shuffleId[{}]",
-            ssi, appId, shuffleId
-        );
+            ssi,
+            appId,
+            shuffleId);
       }
     }
     if (!isSuccessful) {
@@ -921,7 +932,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                       + " after shuffle write client has been closed",
                   e);
             } else {
-              LOG.warn("Error happened when sending heartbeat to " + coordinatorClient.getDesc(), e);
+              LOG.warn(
+                  "Error happened when sending heartbeat to " + coordinatorClient.getDesc(), e);
             }
           }
           return null;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -168,7 +168,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       return true;
     }
 
-    // If one or more servers is failed, the sending is not totally successful.
+    // If one or more servers failed, the sending is not totally successful.
     List<CompletableFuture<Boolean>> futures = new ArrayList<>();
     for (Map.Entry<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> entry :
         serverToBlocks.entrySet()) {
@@ -400,7 +400,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     // we do not apply complicated skipping logic, because server crash is rare in production
     // environment.
     if (!isAllSuccess && !secondaryServerToBlocks.isEmpty() && !needCancelRequest.get()) {
-      LOG.info("The sending of primary round is failed partially, so start the secondary round");
+      LOG.info("The sending of primary round failed partially, so start the secondary round");
       sendShuffleDataAsync(
           appId,
           secondaryServerToBlocks,
@@ -706,7 +706,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         }
       } catch (Exception e) {
         LOG.warn(
-            "Report shuffle result is failed to {} for appId[{}], shuffleId[{}]",
+            "Report shuffle result failed to {} for appId[{}], shuffleId[{}]",
             ssi, appId, shuffleId
         );
         recordFailedBlockIds(blockReportTracker, requestBlockIds);
@@ -714,7 +714,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     }
     if (blockReportTracker.values().stream().anyMatch(cnt -> cnt < replicaWrite)) {
       throw new RssException(
-          "Quorum check of report shuffle result is failed for appId["
+          "Quorum check of report shuffle result failed for appId["
               + appId
               + "], shuffleId["
               + shuffleId
@@ -770,14 +770,14 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         }
       } catch (Exception e) {
         LOG.warn(
-            "Get shuffle result is failed from {} for appId[{}], shuffleId[{}]",
+            "Get shuffle result failed from {} for appId[{}], shuffleId[{}]",
             ssi, appId, shuffleId
         );
       }
     }
     if (!isSuccessful) {
       throw new RssFetchFailedException(
-          "Get shuffle result is failed for appId[" + appId + "], shuffleId[" + shuffleId + "]");
+          "Get shuffle result failed for appId[" + appId + "], shuffleId[" + shuffleId + "]");
     }
     return blockIdBitmap;
   }
@@ -819,7 +819,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       } catch (Exception e) {
         failedPartitions.addAll(requestPartitions);
         LOG.warn(
-            "Get shuffle result is failed from "
+            "Get shuffle result failed from "
                 + shuffleServerInfo
                 + " for appId["
                 + appId
@@ -836,7 +836,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     if (!isSuccessful) {
       LOG.error("Failed to meet replica requirement: {}", replicaRequirementTracking);
       throw new RssFetchFailedException(
-          "Get shuffle result is failed for appId[" + appId + "], shuffleId[" + shuffleId + "]");
+          "Get shuffle result failed for appId[" + appId + "], shuffleId[" + shuffleId + "]");
     }
     return blockIdBitmap;
   }
@@ -859,7 +859,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             }
           } catch (Exception e) {
             LOG.warn(
-                "Error happened when send applicationInfo to " + coordinatorClient.getDesc(), e);
+                "Error happened when sending applicationInfo to " + coordinatorClient.getDesc(), e);
           }
           return null;
         },
@@ -888,12 +888,12 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             if (closed) {
               // this client has been closed, so failing heartbeat calls are expected
               LOG.info(
-                  "Error happened when send heartbeat to "
+                  "Error happened when sending heartbeat to "
                       + shuffleServerInfo
                       + " after shuffle write client has been closed",
                   e);
             } else {
-              LOG.warn("Error happened when send heartbeat to " + shuffleServerInfo, e);
+              LOG.warn("Error happened when sending heartbeat to " + shuffleServerInfo, e);
             }
           }
           return null;
@@ -916,12 +916,12 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             if (closed) {
               // this client has been closed, so failing heartbeat calls are expected
               LOG.info(
-                  "Error happened when send heartbeat to "
+                  "Error happened when sending heartbeat to "
                       + coordinatorClient.getDesc()
                       + " after shuffle write client has been closed",
                   e);
             } else {
-              LOG.warn("Error happened when send heartbeat to " + coordinatorClient.getDesc(), e);
+              LOG.warn("Error happened when sending heartbeat to " + coordinatorClient.getDesc(), e);
             }
           }
           return null;

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -119,6 +119,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
   private Set<ShuffleServerInfo> defectiveServers;
   private RssConf rssConf;
   private BlockIdLayout blockIdLayout;
+  private volatile boolean closed = false;
 
   public ShuffleWriteClientImpl(ShuffleClientFactory.WriteClientBuilder builder) {
     // set default value
@@ -914,7 +915,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               LOG.warn("Failed to send heartbeat to " + shuffleServerInfo);
             }
           } catch (Exception e) {
-            LOG.warn("Error happened when send heartbeat to " + shuffleServerInfo, e);
+            if (!closed) {
+              // this client has been closed, so we are not interested in failing heartbeat calls
+              LOG.warn("Error happened when send heartbeat to " + shuffleServerInfo, e);
+            }
           }
           return null;
         },
@@ -933,7 +937,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
               LOG.info("Successfully send heartbeat to " + coordinatorClient.getDesc());
             }
           } catch (Exception e) {
-            LOG.warn("Error happened when send heartbeat to " + coordinatorClient.getDesc(), e);
+            if (!closed) {
+              // this client has been closed, so we are not interested in failing heartbeat calls
+              LOG.warn("Error happened when send heartbeat to " + coordinatorClient.getDesc(), e);
+            }
           }
           return null;
         },
@@ -946,6 +953,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     heartBeatExecutorService.shutdownNow();
     coordinatorClients.forEach(CoordinatorClient::close);
     dataTransferPool.shutdownNow();
+    closed = true;
   }
 
   @Override
@@ -980,7 +988,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                 LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
               }
             } catch (Exception e) {
-              LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
+              if (!closed) {
+                // this client has been closed, so we are not interested in failing unregister calls
+                LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
+              }
             }
             return null;
           },
@@ -1028,7 +1039,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                 LOG.warn("Failed to unregister shuffle to " + shuffleServerInfo);
               }
             } catch (Exception e) {
-              LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
+              if (!closed) {
+                // this client has been closed, so we are not interested in failing unregister calls
+                LOG.warn("Error happened when unregistering to " + shuffleServerInfo, e);
+              }
             }
             return null;
           },

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -640,7 +640,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       try {
         response = coordinatorClient.getShuffleAssignments(request);
       } catch (Exception e) {
-        LOG.error(e.getMessage());
+        LOG.error("Failed to get shuffle assignment via " + coordinatorClient.getDesc(), e);
       }
 
       if (response.getStatusCode() == StatusCode.SUCCESS) {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/QuorumTest.java
@@ -250,7 +250,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
 
-    // case1: When only 1 server is failed, the block sending should success
+    // case1: When only 1 server failed, the block sending should success
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(
             0,
@@ -312,7 +312,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     assertEquals(blockIdBitmap, failedBlockIdBitmap);
     assertEquals(0, succBlockIdBitmap.getLongCardinality());
 
-    // The client should not read any data, because write is failed
+    // The client should not read any data, because write failed
     assertEquals(readClient.readShuffleBlockData(), null);
   }
 
@@ -472,7 +472,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
       shuffleWriteClientImpl.reportShuffleResult(serverToPartitionToBlockIds, testAppId, 0, 0L, 1);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Quorum check of report shuffle result is failed"));
+      assertTrue(e.getMessage().startsWith("Quorum check of report shuffle result failed"));
     }
     //  get result should also fail
     try {
@@ -484,7 +484,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
           0);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Get shuffle result is failed"));
+      assertTrue(e.getMessage().startsWith("Get shuffle result failed"));
     }
   }
 
@@ -496,7 +496,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     disableTimeout((MockedShuffleServer) grpcShuffleServers.get(1));
     disableTimeout((MockedShuffleServer) grpcShuffleServers.get(2));
 
-    // When 1 server is timeout and 1 server is failed after sending, the block sending should fail
+    // When 1 server is timeout and 1 server failed after sending, the block sending should fail
     enableTimeout((MockedShuffleServer) grpcShuffleServers.get(2), 500);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
@@ -553,7 +553,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
               0);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Get shuffle result is failed"));
+      assertTrue(e.getMessage().startsWith("Get shuffle result failed"));
     }
 
     // When the timeout of one server is recovered, the block sending should success
@@ -677,7 +677,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
               0);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Get shuffle result is failed"));
+      assertTrue(e.getMessage().startsWith("Get shuffle result failed"));
     }
   }
 
@@ -737,12 +737,12 @@ public class QuorumTest extends ShuffleReadWriteBase {
     partitionToBlockIds2.put(2, Sets.newHashSet(blockIdBitmap2.stream().iterator()));
     serverToPartitionToBlockIds.put(shuffleServerInfo3, partitionToBlockIds2);
     serverToPartitionToBlockIds.put(shuffleServerInfo4, partitionToBlockIds2);
-    // report result should fail because partition2 is failed to report server 3,4
+    // report result should fail because partition2 failed to report server 3,4
     try {
       shuffleWriteClientImpl.reportShuffleResult(serverToPartitionToBlockIds, testAppId, 0, 0L, 1);
       fail(EXPECTED_EXCEPTION_MESSAGE);
     } catch (Exception e) {
-      assertTrue(e.getMessage().startsWith("Quorum check of report shuffle result is failed"));
+      assertTrue(e.getMessage().startsWith("Quorum check of report shuffle result failed"));
     }
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -49,6 +49,7 @@ public class RegisterHeartBeat {
   private final ScheduledExecutorService service =
       ThreadUtils.getDaemonSingleThreadScheduledExecutor("startHeartBeat");
   private final ExecutorService heartBeatExecutorService;
+  private volatile boolean shutdown = false;
 
   public RegisterHeartBeat(ShuffleServer shuffleServer) {
     ShuffleServerConf conf = shuffleServer.getShuffleServerConf();
@@ -87,7 +88,9 @@ public class RegisterHeartBeat {
                 shuffleServer.getStorageManager().getStorageInfo(),
                 shuffleServer.getNettyPort());
           } catch (Exception e) {
-            LOG.warn("Error happened when send heart beat to coordinator");
+            if (!shutdown) {
+              LOG.warn("Error happened when send heart beat to coordinator");
+            }
           }
         };
     service.scheduleAtFixedRate(
@@ -137,7 +140,9 @@ public class RegisterHeartBeat {
               sendSuccessfully.set(true);
             }
           } catch (Exception e) {
-            LOG.error(e.getMessage());
+            if (!shutdown) {
+              LOG.error(e.getMessage());
+            }
             return null;
           }
           return null;
@@ -149,5 +154,6 @@ public class RegisterHeartBeat {
   public void shutdown() {
     heartBeatExecutorService.shutdownNow();
     service.shutdownNow();
+    shutdown = true;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Once `ShuffleWriteClientImpl.close()` / `RegisterHeartBeat.shutdown()` is called, failing async calls should not be logged as `WARN` log level as those calls are expected to fail in that situation.

### Why are the changes needed?

Some async calls may not have finished on close / shutdown, which raises warnings in the log. This pollutes logs and makes tracing unrelated issues harder:

```
WARN impl.ShuffleWriteClientImpl: Error happened when unregistering to ShuffleServerInfo{host[10.109.9.45], grpc port[19999]}
io.grpc.StatusRuntimeException: CANCELLED: Thread interrupted
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:268)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:249)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:167)
        at org.apache.uniffle.proto.ShuffleServerGrpc$ShuffleServerBlockingStub.unregisterShuffleByAppId(ShuffleServerGrpc.java:772)
        at org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient.doUnregisterShuffleByAppId(ShuffleServerGrpcClient.java:345)
        at org.apache.uniffle.client.impl.grpc.ShuffleServerGrpcClient.unregisterShuffleByAppId(ShuffleServerGrpcClient.java:352)
        at org.apache.uniffle.client.impl.ShuffleWriteClientImpl.lambda$unregisterShuffle$28(ShuffleWriteClientImpl.java:1020)
        at org.apache.uniffle.common.util.ThreadUtils.lambda$executeTasks$0(ThreadUtils.java:110)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.InterruptedException
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.throwIfInterrupted(ClientCalls.java:750)
        at io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:718)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:159)
        ... 9 more
```
Fix: #1713

### Does this PR introduce _any_ user-facing change?

Yes, log messages are more specific on the situation when async calls fail after close / shutdown has been called.

### How was this patch tested?
No.