### PR TITLE
[#1608][part-8] feat(spark3): add a limit to the number of retries when block access is denied

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -90,6 +90,14 @@ public class RssSparkConfig {
           .defaultValue(1)
           .withDescription("The block retry max times when partition reassign is enabled.");
 
+  public static final ConfigOption<Integer>
+      RSS_PARTITION_REASSIGN_BLOCK_ACCESS_DENIED_RETRY_MAX_TIMES =
+          ConfigOptions.key("rss.client.reassign.blockAccessDeniedRetryMaxTimes")
+              .intType()
+              .defaultValue(1)
+              .withDescription(
+                  "The block access denied retry max times when partition reassign is enabled.");
+
   public static final String SPARK_RSS_CONFIG_PREFIX = "spark.";
 
   public static final ConfigEntry<Integer> RSS_PARTITION_NUM_PER_RANGE =

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -37,6 +37,7 @@ public class ShuffleBlockInfo {
   private int uncompressLength;
   private long freeMemory;
   private int retryCnt = 0;
+  private int accessDeniedRetryCnt = 0;
 
   private transient BlockCompletionCallback completionCallback;
 
@@ -162,6 +163,14 @@ public class ShuffleBlockInfo {
 
   public int getRetryCnt() {
     return retryCnt;
+  }
+
+  public void incrAccessDeniedRetryCnt() {
+    this.accessDeniedRetryCnt += 1;
+  }
+
+  public int getAccessDeniedRetryCnt() {
+    return accessDeniedRetryCnt;
   }
 
   public void reassignShuffleServers(List<ShuffleServerInfo> replacements) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -355,6 +355,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
               + ", errorMsg:"
               + rpcResponse.getRetMsg();
       throw new NotRetryException(msg);
+    } else if (rpcResponse.getStatus() == RssProtos.StatusCode.ACCESS_DENIED) {
+      failedStatusCodeRef.set(StatusCode.fromCode(rpcResponse.getStatus().getNumber()));
     }
     return result;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In https://github.com/apache/incubator-uniffle/issues/1617
If the servers in the cluster  is unhealthy very frequently, such as high load or high network card traffic or disk utilization triggering thresholds, etc,  this may easily trigger the restriction of blockFailSentRetryMaxTimes in reassign. therefore, add a limit to the number of retries when block access is denied.


### Why are the changes needed?

Add a limit to the number of retries when block access is denied.

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

