### PR TITLE
[MINOR] fix: Correct the log file name for GC while using java11

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -81,7 +81,7 @@ JVM_ARGS=" -server \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
-          -Xlog:gc:tags,time,uptime,level"
+          -Xlog:gc=trace:file=${RSS_LOG_DIR}/gc-%t.log:tags,time,uptime,level:filecount=10,filesize=100m"
 
 ARGS=""
 

--- a/bin/start-dashboard.sh
+++ b/bin/start-dashboard.sh
@@ -68,7 +68,7 @@ JVM_ARGS=" -server \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
-          -Xlog:gc:tags,time,uptime,level"
+           -Xlog:gc=trace:file=${RSS_LOG_DIR}/gc-%t.log:tags,time,uptime,level:filecount=10,filesize=100m"
 
 ARGS=""
 

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -118,7 +118,7 @@ JVM_ARGS=" -server \
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
 JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
-          -Xlog:gc:tags,time,uptime,level"
+          -Xlog:gc=trace:file=${RSS_LOG_DIR}/gc-%t.log:tags,time,uptime,level:filecount=10,filesize=100m"
 
 ARGS=""
 

--- a/bin/uniffle
+++ b/bin/uniffle
@@ -69,7 +69,7 @@ function uniffle_cmd_case
           -Xloggc:${RSS_LOG_DIR}/gc-%t.log"
 
       JAVA11_EXTRA_ARGS=" -XX:+IgnoreUnrecognizedVMOptions \
-          -Xlog:gc:tags,time,uptime,level"
+                -Xlog:gc=trace:file=${RSS_LOG_DIR}/gc-%t.log:tags,time,uptime,level:filecount=10,filesize=100m"
       UNIFFLE_OPTS="$UNIFFLE_OPTS $JVM_ARGS $JAVA11_EXTRA_ARGS"
 
       UNIFFLE_SUBCMD_SUPPORT_DAEMONIZATION="true"


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Correct the log file name for GC. 

### Why are the changes needed?

Currently, the file name is `tags,time,uptime,level`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual testing