### PR TITLE
[WIP][RFC] Blockid hide long

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/DataPusher.java
@@ -39,6 +39,7 @@ import org.apache.uniffle.client.impl.FailedBlockSendTracker;
 import org.apache.uniffle.client.response.SendShuffleDataResult;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ThreadUtils;
 
 /**
@@ -52,7 +53,7 @@ public class DataPusher implements Closeable {
 
   private final ShuffleWriteClient shuffleWriteClient;
   // Must be thread safe
-  private final Map<String, Set<Long>> taskToSuccessBlockIds;
+  private final Map<String, Set<BlockId>> taskToSuccessBlockIds;
   // Must be thread safe
   Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker;
   private String rssAppId;
@@ -61,7 +62,7 @@ public class DataPusher implements Closeable {
 
   public DataPusher(
       ShuffleWriteClient shuffleWriteClient,
-      Map<String, Set<Long>> taskToSuccessBlockIds,
+      Map<String, Set<BlockId>> taskToSuccessBlockIds,
       Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker,
       Set<String> failedTaskIds,
       int threadPoolSize,
@@ -97,7 +98,7 @@ public class DataPusher implements Closeable {
             putFailedBlockSendTracker(
                 taskToFailedBlockSendTracker, taskId, result.getFailedBlockSendTracker());
           } finally {
-            Set<Long> succeedBlockIds =
+            Set<BlockId> succeedBlockIds =
                 result.getSuccessBlockIds() == null
                     ? Collections.emptySet()
                     : result.getSuccessBlockIds();
@@ -120,7 +121,7 @@ public class DataPusher implements Closeable {
   }
 
   private synchronized void putBlockId(
-      Map<String, Set<Long>> taskToBlockIds, String taskAttemptId, Set<Long> blockIds) {
+      Map<String, Set<BlockId>> taskToBlockIds, String taskAttemptId, Set<BlockId> blockIds) {
     if (blockIds == null || blockIds.isEmpty()) {
       return;
     }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -50,6 +50,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
 
@@ -382,8 +383,8 @@ public class WriteBufferManager extends MemoryConsumer {
       compressTime += System.currentTimeMillis() - start;
     }
     final long crc32 = ChecksumUtils.getCrc32(compressed);
-    final long blockId =
-        blockIdLayout.getBlockId(getNextSeqNo(partitionId), partitionId, taskAttemptId);
+    final BlockId blockId =
+        blockIdLayout.asBlockId(getNextSeqNo(partitionId), partitionId, taskAttemptId);
     blockCounter.incrementAndGet();
     uncompressedDataLen += data.length;
     shuffleWriteMetrics.incBytesWritten(compressed.length);

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.spark.serializer.SerializerInstance;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -156,7 +157,7 @@ public abstract class AbstractRssReaderTest extends HadoopTestBase {
         expectedData.put(key, value);
         writeData(serializeStream, key, value);
       }
-      long blockId = layout.getBlockId(atomicInteger.getAndIncrement(), partitionID, 0);
+      BlockId blockId = layout.asBlockId(atomicInteger.getAndIncrement(), partitionID, 0);
       blockIdBitmap.add(blockId);
       blocks.add(createShuffleBlock(output.toBytes(), blockId, compress));
       serializeStream.close();
@@ -164,12 +165,12 @@ public abstract class AbstractRssReaderTest extends HadoopTestBase {
     handler.write(blocks);
   }
 
-  protected ShufflePartitionedBlock createShuffleBlock(byte[] data, long blockId) {
+  protected ShufflePartitionedBlock createShuffleBlock(byte[] data, BlockId blockId) {
     return createShuffleBlock(data, blockId, true);
   }
 
   protected ShufflePartitionedBlock createShuffleBlock(
-      byte[] data, long blockId, boolean compress) {
+      byte[] data, BlockId blockId, boolean compress) {
     byte[] compressData = data;
     if (compress) {
       compressData = Codec.newInstance(new RssConf()).compress(data);

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -93,7 +93,7 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
 
     validateResult(rssShuffleDataIterator, expectedData, 10);
 
-    blockIdBitmap.add(layout.getBlockId(layout.maxSequenceNo, 0, 0));
+    blockIdBitmap.add(layout.asBlockId(layout.maxSequenceNo, 0, 0));
     rssShuffleDataIterator =
         getDataIterator(basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(ssi1));
     int recNum = 0;

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -48,7 +48,9 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -144,7 +146,7 @@ public class WriteBufferManagerTest {
     result = wbm.addRecord(0, testKey, testValue);
     // single buffer is full
     assertEquals(1, result.size());
-    assertEquals(layout.asBlockId(0, 0, 0), layout.asBlockId(result.get(0).getBlockId()));
+    assertEquals(layout.asBlockId(0, 0, 0), result.get(0).getBlockId().withLayoutIfOpaque(layout));
     assertEquals(512, wbm.getAllocatedBytes());
     assertEquals(96, wbm.getUsedBytes());
     assertEquals(96, wbm.getInSendListBytes());
@@ -162,12 +164,12 @@ public class WriteBufferManagerTest {
     wbm.addRecord(4, testKey, testValue);
     result = wbm.addRecord(5, testKey, testValue);
     assertEquals(6, result.size());
-    assertEquals(layout.asBlockId(1, 0, 0), layout.asBlockId(result.get(0).getBlockId()));
-    assertEquals(layout.asBlockId(0, 1, 0), layout.asBlockId(result.get(1).getBlockId()));
-    assertEquals(layout.asBlockId(0, 2, 0), layout.asBlockId(result.get(2).getBlockId()));
-    assertEquals(layout.asBlockId(0, 3, 0), layout.asBlockId(result.get(3).getBlockId()));
-    assertEquals(layout.asBlockId(0, 4, 0), layout.asBlockId(result.get(4).getBlockId()));
-    assertEquals(layout.asBlockId(0, 5, 0), layout.asBlockId(result.get(5).getBlockId()));
+    assertEquals(layout.asBlockId(1, 0, 0), result.get(0).getBlockId().withLayoutIfOpaque(layout));
+    assertEquals(layout.asBlockId(0, 1, 0), result.get(1).getBlockId().withLayoutIfOpaque(layout));
+    assertEquals(layout.asBlockId(0, 2, 0), result.get(2).getBlockId().withLayoutIfOpaque(layout));
+    assertEquals(layout.asBlockId(0, 3, 0), result.get(3).getBlockId().withLayoutIfOpaque(layout));
+    assertEquals(layout.asBlockId(0, 4, 0), result.get(4).getBlockId().withLayoutIfOpaque(layout));
+    assertEquals(layout.asBlockId(0, 5, 0), result.get(5).getBlockId().withLayoutIfOpaque(layout));
     assertEquals(512, wbm.getAllocatedBytes());
     assertEquals(288, wbm.getUsedBytes());
     assertEquals(288, wbm.getInSendListBytes());
@@ -271,19 +273,19 @@ public class WriteBufferManagerTest {
     ShuffleBlockInfo sbi = wbm.createShuffleBlock(0, mockWriterBuffer);
 
     // seqNo = 0, partitionId = 0, taskId = 0
-    assertEquals(layout.asBlockId(0, 0, 0), layout.asBlockId(sbi.getBlockId()));
+    assertEquals(layout.asBlockId(0, 0, 0), sbi.getBlockId().withLayoutIfOpaque(layout));
 
     // seqNo = 1, partitionId = 0, taskId = 0
     sbi = wbm.createShuffleBlock(0, mockWriterBuffer);
-    assertEquals(layout.asBlockId(1, 0, 0), layout.asBlockId(sbi.getBlockId()));
+    assertEquals(layout.asBlockId(1, 0, 0), sbi.getBlockId().withLayoutIfOpaque(layout));
 
     // seqNo = 0, partitionId = 1, taskId = 0
     sbi = wbm.createShuffleBlock(1, mockWriterBuffer);
-    assertEquals(layout.asBlockId(0, 1, 0), layout.asBlockId(sbi.getBlockId()));
+    assertEquals(layout.asBlockId(0, 1, 0), sbi.getBlockId().withLayoutIfOpaque(layout));
 
     // seqNo = 1, partitionId = 1, taskId = 0
     sbi = wbm.createShuffleBlock(1, mockWriterBuffer);
-    assertEquals(layout.asBlockId(1, 1, 0), layout.asBlockId(sbi.getBlockId()));
+    assertEquals(layout.asBlockId(1, 1, 0), sbi.getBlockId().withLayoutIfOpaque(layout));
   }
 
   @Test
@@ -306,9 +308,10 @@ public class WriteBufferManagerTest {
             RssSparkConfig.toRssConf(conf));
 
     // every block: length=4, memoryUsed=12
-    ShuffleBlockInfo info1 = new ShuffleBlockInfo(1, 1, 1, 4, 1, new byte[1], null, 1, 12, 1);
-    ShuffleBlockInfo info2 = new ShuffleBlockInfo(1, 1, 1, 4, 1, new byte[1], null, 1, 12, 1);
-    ShuffleBlockInfo info3 = new ShuffleBlockInfo(1, 1, 1, 4, 1, new byte[1], null, 1, 12, 1);
+    BlockId blockId = new OpaqueBlockId(1);
+    ShuffleBlockInfo info1 = new ShuffleBlockInfo(1, 1, blockId, 4, 1, new byte[1], null, 1, 12, 1);
+    ShuffleBlockInfo info2 = new ShuffleBlockInfo(1, 1, blockId, 4, 1, new byte[1], null, 1, 12, 1);
+    ShuffleBlockInfo info3 = new ShuffleBlockInfo(1, 1, blockId, 4, 1, new byte[1], null, 1, 12, 1);
     List<AddBlockEvent> events = wbm.buildBlockEvents(Arrays.asList(info1, info2, info3));
     assertEquals(3, events.size());
   }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -99,7 +99,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private String appId = "";
   private String clientType;
   private ShuffleWriteClient shuffleWriteClient;
-  private Map<String, Set<Long>> taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
+  private Map<String, Set<org.apache.uniffle.common.util.BlockId>> taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
   private Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker =
       JavaUtils.newConcurrentMap();
   private final int dataReplica;
@@ -694,7 +694,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return taskIdBitmap;
   }
 
-  public Set<Long> getFailedBlockIds(String taskId) {
+  public Set<org.apache.uniffle.common.util.BlockId> getFailedBlockIds(String taskId) {
     FailedBlockSendTracker blockIdsFailedSendTracker = getBlockIdsFailedSendTracker(taskId);
     if (blockIdsFailedSendTracker == null) {
       return Collections.emptySet();
@@ -702,8 +702,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return blockIdsFailedSendTracker.getFailedBlockIds();
   }
 
-  public Set<Long> getSuccessBlockIds(String taskId) {
-    Set<Long> result = taskToSuccessBlockIds.get(taskId);
+  public Set<org.apache.uniffle.common.util.BlockId> getSuccessBlockIds(String taskId) {
+    Set<org.apache.uniffle.common.util.BlockId> result = taskToSuccessBlockIds.get(taskId);
     if (result == null) {
       result = Collections.emptySet();
     }
@@ -711,7 +711,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   }
 
   @VisibleForTesting
-  public void addSuccessBlockIds(String taskId, Set<Long> blockIds) {
+  public void addSuccessBlockIds(String taskId, Set<org.apache.uniffle.common.util.BlockId> blockIds) {
     if (taskToSuccessBlockIds.get(taskId) == null) {
       taskToSuccessBlockIds.put(taskId, Sets.newHashSet());
     }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -116,7 +116,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
   private final boolean dataReplicaSkipEnabled;
   private final int dataTransferPoolSize;
   private final int dataCommitPoolSize;
-  private final Map<String, Set<Long>> taskToSuccessBlockIds;
+  private final Map<String, Set<org.apache.uniffle.common.util.BlockId>> taskToSuccessBlockIds;
   private final Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker;
   private ScheduledExecutorService heartBeatScheduledExecutorService;
   private boolean heartbeatStarted = false;
@@ -336,7 +336,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
       SparkConf conf,
       boolean isDriver,
       DataPusher dataPusher,
-      Map<String, Set<Long>> taskToSuccessBlockIds,
+      Map<String, Set<org.apache.uniffle.common.util.BlockId>> taskToSuccessBlockIds,
       Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker) {
     this.sparkConf = conf;
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
@@ -1002,7 +1002,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     }
   }
 
-  public Set<Long> getFailedBlockIds(String taskId) {
+  public Set<org.apache.uniffle.common.util.BlockId> getFailedBlockIds(String taskId) {
     FailedBlockSendTracker blockIdsFailedSendTracker = getBlockIdsFailedSendTracker(taskId);
     if (blockIdsFailedSendTracker == null) {
       return Collections.emptySet();
@@ -1010,8 +1010,8 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     return blockIdsFailedSendTracker.getFailedBlockIds();
   }
 
-  public Set<Long> getSuccessBlockIds(String taskId) {
-    Set<Long> result = taskToSuccessBlockIds.get(taskId);
+  public Set<org.apache.uniffle.common.util.BlockId> getSuccessBlockIds(String taskId) {
+    Set<org.apache.uniffle.common.util.BlockId> result = taskToSuccessBlockIds.get(taskId);
     if (result == null) {
       result = Collections.emptySet();
     }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -26,6 +26,7 @@ import org.apache.spark.shuffle.writer.DataPusher;
 
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.util.BlockId;
 
 public class TestUtils {
 
@@ -35,7 +36,7 @@ public class TestUtils {
       SparkConf conf,
       Boolean isDriver,
       DataPusher dataPusher,
-      Map<String, Set<Long>> successBlockIds,
+      Map<String, Set<BlockId>> successBlockIds,
       Map<String, FailedBlockSendTracker> taskToFailedBlockSendTracker) {
     return new RssShuffleManager(
         conf, isDriver, dataPusher, successBlockIds, taskToFailedBlockSendTracker);
@@ -45,7 +46,7 @@ public class TestUtils {
     return SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64");
   }
 
-  public static ShuffleBlockInfo createMockBlockOnlyBlockId(long blockId) {
+  public static ShuffleBlockInfo createMockBlockOnlyBlockId(BlockId blockId) {
     return new ShuffleBlockInfo(1, 1, blockId, 1, 1, new byte[1], null, 1, 100, 1);
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -30,6 +30,7 @@ import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 
 public interface ShuffleWriteClient {
@@ -62,7 +63,7 @@ public interface ShuffleWriteClient {
   RemoteStorageInfo fetchRemoteStorage(String appId);
 
   void reportShuffleResult(
-      Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds,
+      Map<ShuffleServerInfo, Map<Integer, Set<BlockId>>> serverToPartitionToBlockIds,
       String appId,
       int shuffleId,
       long taskAttemptId,

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Maps;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 
 public class FailedBlockSendTracker {
 
@@ -38,7 +39,7 @@ public class FailedBlockSendTracker {
    * <p>This indicates the blockId latest sending status, and it will not store the resending
    * history. The list data structure is to describe the multiple servers for the multiple replica
    */
-  private Map<Long, List<TrackingBlockStatus>> trackingBlockStatusMap;
+  private Map<BlockId, List<TrackingBlockStatus>> trackingBlockStatusMap;
 
   public FailedBlockSendTracker() {
     this.trackingBlockStatusMap = Maps.newConcurrentMap();
@@ -57,7 +58,7 @@ public class FailedBlockSendTracker {
     this.trackingBlockStatusMap.putAll(failedBlockSendTracker.trackingBlockStatusMap);
   }
 
-  public void remove(long blockId) {
+  public void remove(BlockId blockId) {
     trackingBlockStatusMap.remove(blockId);
   }
 
@@ -68,11 +69,11 @@ public class FailedBlockSendTracker {
     trackingBlockStatusMap.clear();
   }
 
-  public Set<Long> getFailedBlockIds() {
+  public Set<BlockId> getFailedBlockIds() {
     return trackingBlockStatusMap.keySet();
   }
 
-  public List<TrackingBlockStatus> getFailedBlockStatus(Long blockId) {
+  public List<TrackingBlockStatus> getFailedBlockStatus(BlockId blockId) {
     return trackingBlockStatusMap.get(blockId);
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/org/apache/uniffle/client/response/SendShuffleDataResult.java
@@ -20,23 +20,24 @@ package org.apache.uniffle.client.response;
 import java.util.Set;
 
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.common.util.BlockId;
 
 public class SendShuffleDataResult {
 
-  private Set<Long> successBlockIds;
+  private Set<BlockId> successBlockIds;
   private FailedBlockSendTracker failedBlockSendTracker;
 
   public SendShuffleDataResult(
-      Set<Long> successBlockIds, FailedBlockSendTracker failedBlockSendTracker) {
+      Set<BlockId> successBlockIds, FailedBlockSendTracker failedBlockSendTracker) {
     this.successBlockIds = successBlockIds;
     this.failedBlockSendTracker = failedBlockSendTracker;
   }
 
-  public Set<Long> getSuccessBlockIds() {
+  public Set<BlockId> getSuccessBlockIds() {
     return successBlockIds;
   }
 
-  public Set<Long> getFailedBlockIds() {
+  public Set<BlockId> getFailedBlockIds() {
     return failedBlockSendTracker.getFailedBlockIds();
   }
 

--- a/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.client.util.DefaultIdHelper;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.RssUtils;
@@ -56,7 +57,7 @@ public class ClientUtilsTest {
     for (int i = 0; i < taskSize; i++) {
       except[i] = i;
       for (int j = 0; j < 100; j++) {
-        long blockId = layout.getBlockId(j, partitionId, i);
+        BlockId blockId = layout.asBlockId(j, partitionId, i);
         blockIdMap.add(blockId);
       }
     }

--- a/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/ShuffleReadClientImplTest.java
@@ -84,7 +84,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 2, 30, 1, 0, expectedData, blockIdBitmap);
@@ -100,7 +100,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     readClient.close();
 
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
-    blockIdBitmap.add(layout.getBlockId(0, 0, layout.maxTaskAttemptId - 1));
+    blockIdBitmap.add(layout.asBlockId(0, 0, layout.maxTaskAttemptId - 1));
     taskIdBitmap.addLong(layout.maxTaskAttemptId - 1);
     readClient =
         baseReadBuilder()
@@ -129,7 +129,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler2 =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi2.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler1, 2, 30, 0, 0, expectedData, blockIdBitmap);
@@ -157,7 +157,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler2 =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi2.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     final BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler1, 2, 30, 0, 0, expectedData, blockIdBitmap);
@@ -214,7 +214,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 2, 30, 0, 0, expectedData, blockIdBitmap);
@@ -254,7 +254,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 2, 30, 0, 0, expectedData, blockIdBitmap);
@@ -281,8 +281,8 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData1 = Maps.newHashMap();
-    Map<Long, byte[]> expectedData2 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData1 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData2 = Maps.newHashMap();
     final BlockIdSet blockIdBitmap1 = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 10, 30, 0, 0, expectedData1, blockIdBitmap1);
@@ -323,7 +323,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 2, 30, 0, 0, expectedData, blockIdBitmap);
@@ -354,11 +354,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
         }
         fail(EXPECTED_EXCEPTION_MESSAGE);
       } catch (Exception e) {
-        assertTrue(
-            e.getMessage()
-                .startsWith(
-                    "Unexpected crc value for blockId[5800000000000 (seq: 44, part: 0, task: 0)]"),
-            e.getMessage());
+        assertTrue(e.getMessage().startsWith("Unexpected crc value for blockId"), e.getMessage());
       }
 
       CompressedShuffleBlock block = readClient2.readShuffleBlockData();
@@ -390,16 +386,17 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi1.getId(), conf);
 
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 5, 30, 0, 0, expectedData, blockIdBitmap);
     BlockIdSet wrongBlockIdBitmap = BlockIdSet.empty();
-    Iterator<Long> iter = blockIdBitmap.stream().iterator();
+    Iterator<BlockId> iter = blockIdBitmap.stream().iterator();
     while (iter.hasNext()) {
-      BlockId blockId = layout.asBlockId(iter.next());
+      BlockId blockId = iter.next().withLayoutIfOpaque(layout);
       wrongBlockIdBitmap.add(
-          layout.getBlockId(blockId.sequenceNo, blockId.partitionId + 1, blockId.taskAttemptId));
+          layout.asBlockId(
+              blockId.getSequenceNo(), blockId.getPartitionId() + 1, blockId.getTaskAttemptId()));
     }
 
     ShuffleReadClientImpl readClient =
@@ -425,7 +422,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 10, 30, 1, 0, expectedData, blockIdBitmap);
@@ -497,7 +494,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     final BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 1);
     writeTestData(writeHandler, 5, 30, 1, 0, expectedData, blockIdBitmap);
@@ -539,7 +536,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     final BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 3);
     writeTestData(writeHandler, 5, 30, 1, 0, expectedData, blockIdBitmap, layout);
@@ -596,7 +593,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     final BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 2);
     writeDuplicatedData(writeHandler, 5, 30, 1, 0, expectedData, blockIdBitmap);
@@ -623,7 +620,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, ssi1.getId(), conf);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     final BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     writeTestData(writeHandler, 5, 30, 1, 0, expectedData, blockIdBitmap);
@@ -654,8 +651,8 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler1 =
         new HadoopShuffleWriteHandler("appId", 0, 0, 1, basePath, ssi2.getId(), conf);
 
-    Map<Long, byte[]> expectedData0 = Maps.newHashMap();
-    Map<Long, byte[]> expectedData1 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData0 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData1 = Maps.newHashMap();
     BlockIdSet blockIdBitmap0 = BlockIdSet.empty();
     BlockIdSet blockIdBitmap1 = BlockIdSet.empty();
     writeTestData(writeHandler0, 2, 30, 0, 0, expectedData0, blockIdBitmap0);
@@ -694,7 +691,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
       int length,
       int partitionId,
       long taskAttemptId,
-      Map<Long, byte[]> expectedData,
+      Map<BlockId, byte[]> expectedData,
       BlockIdSet blockIdBitmap,
       BlockIdLayout layout)
       throws Exception {
@@ -702,7 +699,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId = layout.getBlockId(ATOMIC_INT.getAndIncrement(), partitionId, taskAttemptId);
+      BlockId blockId = layout.asBlockId(ATOMIC_INT.getAndIncrement(), partitionId, taskAttemptId);
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -718,7 +715,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
       int length,
       int partitionId,
       long taskAttemptId,
-      Map<Long, byte[]> expectedData,
+      Map<BlockId, byte[]> expectedData,
       BlockIdSet blockIdBitmap)
       throws Exception {
     writeTestData(
@@ -738,7 +735,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
       int length,
       int partitionId,
       long taskAttemptId,
-      Map<Long, byte[]> expectedData,
+      Map<BlockId, byte[]> expectedData,
       BlockIdSet blockIdBitmap)
       throws Exception {
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
@@ -746,7 +743,7 @@ public class ShuffleReadClientImplTest extends HadoopTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId = layout.getBlockId(ATOMIC_INT.getAndIncrement(), partitionId, taskAttemptId);
+      BlockId blockId = layout.asBlockId(ATOMIC_INT.getAndIncrement(), partitionId, taskAttemptId);
       ShufflePartitionedBlock spb =
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf);

--- a/common/src/main/java/org/apache/uniffle/common/BufferSegment.java
+++ b/common/src/main/java/org/apache/uniffle/common/BufferSegment.java
@@ -20,10 +20,11 @@ package org.apache.uniffle.common;
 import java.util.Objects;
 
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.BlockId;
 
 public class BufferSegment {
 
-  private long blockId;
+  private BlockId blockId;
   private long offset;
   private int length;
   private int uncompressLength;
@@ -31,7 +32,12 @@ public class BufferSegment {
   private long taskAttemptId;
 
   public BufferSegment(
-      long blockId, long offset, int length, int uncompressLength, long crc, long taskAttemptId) {
+      BlockId blockId,
+      long offset,
+      int length,
+      int uncompressLength,
+      long crc,
+      long taskAttemptId) {
     this.blockId = blockId;
     this.offset = offset;
     this.length = length;
@@ -43,7 +49,7 @@ public class BufferSegment {
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof BufferSegment) {
-      return blockId == ((BufferSegment) obj).getBlockId()
+      return blockId.equals(((BufferSegment) obj).getBlockId())
           && offset == ((BufferSegment) obj).getOffset()
           && length == ((BufferSegment) obj).getLength()
           && uncompressLength == ((BufferSegment) obj).getUncompressLength()
@@ -86,7 +92,7 @@ public class BufferSegment {
     return length;
   }
 
-  public long getBlockId() {
+  public BlockId getBlockId() {
     return blockId;
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -22,12 +22,13 @@ import java.util.List;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ByteBufUtils;
 
 public class ShuffleBlockInfo {
 
   private int partitionId;
-  private long blockId;
+  private BlockId blockId;
   private int length;
   private int shuffleId;
   private long crc;
@@ -43,7 +44,7 @@ public class ShuffleBlockInfo {
   public ShuffleBlockInfo(
       int shuffleId,
       int partitionId,
-      long blockId,
+      BlockId blockId,
       int length,
       long crc,
       byte[] data,
@@ -67,7 +68,7 @@ public class ShuffleBlockInfo {
   public ShuffleBlockInfo(
       int shuffleId,
       int partitionId,
-      long blockId,
+      BlockId blockId,
       int length,
       long crc,
       ByteBuf data,
@@ -87,7 +88,7 @@ public class ShuffleBlockInfo {
     this.taskAttemptId = taskAttemptId;
   }
 
-  public long getBlockId() {
+  public BlockId getBlockId() {
     return blockId;
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
@@ -22,17 +22,24 @@ import java.util.Objects;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+import org.apache.uniffle.common.util.BlockId;
+
 public class ShufflePartitionedBlock {
 
   private int length;
   private long crc;
-  private long blockId;
+  private BlockId blockId;
   private int uncompressLength;
   private ByteBuf data;
   private long taskAttemptId;
 
   public ShufflePartitionedBlock(
-      int length, int uncompressLength, long crc, long blockId, long taskAttemptId, byte[] data) {
+      int length,
+      int uncompressLength,
+      long crc,
+      BlockId blockId,
+      long taskAttemptId,
+      byte[] data) {
     this.length = length;
     this.crc = crc;
     this.blockId = blockId;
@@ -42,7 +49,12 @@ public class ShufflePartitionedBlock {
   }
 
   public ShufflePartitionedBlock(
-      int length, int uncompressLength, long crc, long blockId, long taskAttemptId, ByteBuf data) {
+      int length,
+      int uncompressLength,
+      long crc,
+      BlockId blockId,
+      long taskAttemptId,
+      ByteBuf data) {
     this.length = length;
     this.crc = crc;
     this.blockId = blockId;
@@ -68,7 +80,7 @@ public class ShufflePartitionedBlock {
     ShufflePartitionedBlock that = (ShufflePartitionedBlock) o;
     return length == that.length
         && crc == that.crc
-        && blockId == that.blockId
+        && blockId.equals(that.blockId)
         && data.equals(that.data);
   }
 
@@ -93,11 +105,11 @@ public class ShufflePartitionedBlock {
     this.crc = crc;
   }
 
-  public long getBlockId() {
+  public BlockId getBlockId() {
     return blockId;
   }
 
-  public void setBlockId(long blockId) {
+  public void setBlockId(BlockId blockId) {
     this.blockId = blockId;
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
@@ -29,6 +29,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.common.util.NettyUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 public class Decoders {
   public static ShuffleServerInfo decodeShuffleServerInfo(ByteBuf byteBuf) {
@@ -59,7 +60,7 @@ public class Decoders {
     return new ShuffleBlockInfo(
         shuffleId,
         partId,
-        blockId,
+        new OpaqueBlockId(blockId),
         length,
         crc,
         data,
@@ -95,7 +96,8 @@ public class Decoders {
       long crc = byteBuf.readLong();
       long taskAttemptId = byteBuf.readLong();
       BufferSegment bufferSegment =
-          new BufferSegment(blockId, offset, length, uncompressLength, crc, taskAttemptId);
+          new BufferSegment(
+              new OpaqueBlockId(blockId), offset, length, uncompressLength, crc, taskAttemptId);
       bufferSegments.add(bufferSegment);
     }
     return bufferSegments;

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Encoders.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Encoders.java
@@ -37,7 +37,7 @@ public class Encoders {
 
   public static void encodeShuffleBlockInfo(ShuffleBlockInfo shuffleBlockInfo, ByteBuf byteBuf) {
     byteBuf.writeInt(shuffleBlockInfo.getPartitionId());
-    byteBuf.writeLong(shuffleBlockInfo.getBlockId());
+    byteBuf.writeLong(shuffleBlockInfo.getBlockId().getBlockId());
     byteBuf.writeInt(shuffleBlockInfo.getLength());
     byteBuf.writeInt(shuffleBlockInfo.getShuffleId());
     byteBuf.writeLong(shuffleBlockInfo.getCrc());
@@ -83,7 +83,7 @@ public class Encoders {
   public static void encodeBufferSegments(List<BufferSegment> bufferSegments, ByteBuf byteBuf) {
     byteBuf.writeInt(bufferSegments.size());
     for (BufferSegment bufferSegment : bufferSegments) {
-      byteBuf.writeLong(bufferSegment.getBlockId());
+      byteBuf.writeLong(bufferSegment.getBlockId().getBlockId());
       byteBuf.writeInt(bufferSegment.getOffset());
       byteBuf.writeInt(bufferSegment.getLength());
       byteBuf.writeInt(bufferSegment.getUncompressLength());

--- a/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java
@@ -29,6 +29,7 @@ import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 public class FixedSizeSegmentSplitter implements SegmentSplitter {
   private static final Logger LOGGER = LoggerFactory.getLogger(FixedSizeSegmentSplitter.class);
@@ -92,7 +93,13 @@ public class FixedSizeSegmentSplitter implements SegmentSplitter {
         }
 
         bufferSegments.add(
-            new BufferSegment(blockId, bufferOffset, length, uncompressLength, crc, taskAttemptId));
+            new BufferSegment(
+                new OpaqueBlockId(blockId),
+                bufferOffset,
+                length,
+                uncompressLength,
+                crc,
+                taskAttemptId));
         bufferOffset += length;
 
         if (bufferOffset >= readBufferSize) {

--- a/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
+++ b/common/src/main/java/org/apache/uniffle/common/segment/LocalOrderSegmentSplitter.java
@@ -31,6 +31,7 @@ import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataSegment;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 /**
  * {@class LocalOrderSegmentSplitter} will be initialized only when the {@class
@@ -135,7 +136,12 @@ public class LocalOrderSegmentSplitter implements SegmentSplitter {
           }
           bufferSegments.add(
               new BufferSegment(
-                  blockId, bufferOffset, length, uncompressLength, crc, taskAttemptId));
+                  new OpaqueBlockId(blockId),
+                  bufferOffset,
+                  length,
+                  uncompressLength,
+                  crc,
+                  taskAttemptId));
           bufferOffset += length;
           lastExpectedBlockIndex = index;
         }

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockId.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockId.java
@@ -17,8 +17,6 @@
 
 package org.apache.uniffle.common.util;
 
-import java.util.Objects;
-
 /**
  * This represents a block id and all its constituents. This is particularly useful for logging and
  * debugging block ids.
@@ -27,49 +25,24 @@ import java.util.Objects;
  * that order from highest to lowest bits. The number of bits is defined by a {@link BlockIdLayout}.
  * Values of partitionId, taskAttemptId and AtomicInteger are always positive.
  */
-public class BlockId {
-  public final long blockId;
-  public final BlockIdLayout layout;
-  public final int sequenceNo;
-  public final int partitionId;
-  public final int taskAttemptId;
+public interface BlockId extends Comparable<BlockId> {
+  long getBlockId();
 
-  protected BlockId(
-      long blockId, BlockIdLayout layout, int sequenceNo, int partitionId, int taskAttemptId) {
-    this.blockId = blockId;
-    this.layout = layout;
-    this.sequenceNo = sequenceNo;
-    this.partitionId = partitionId;
-    this.taskAttemptId = taskAttemptId;
-  }
+  int getSequenceNo();
 
-  @Override
-  public String toString() {
-    return "blockId["
-        + Long.toHexString(blockId)
-        + " (seq: "
-        + sequenceNo
-        + ", part: "
-        + partitionId
-        + ", task: "
-        + taskAttemptId
-        + ")]";
-  }
+  int getPartitionId();
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+  int getTaskAttemptId();
+
+  default BlockId withLayoutIfOpaque(BlockIdLayout layout) {
+    if (this instanceof OpaqueBlockId) {
+      return ((OpaqueBlockId) this).withLayout(layout);
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    BlockId blockId1 = (BlockId) o;
-    return blockId == blockId1.blockId && Objects.equals(layout, blockId1.layout);
+    return this;
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(blockId, layout);
+  default int compareTo(BlockId other) {
+    return Long.compare(this.getBlockId(), other.getBlockId());
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockIdLayout.java
@@ -143,7 +143,7 @@ public class BlockIdLayout {
     return Objects.hash(sequenceNoBits, partitionIdBits, taskAttemptIdBits);
   }
 
-  public long getBlockId(int sequenceNo, int partitionId, long taskAttemptId) {
+  protected long getBlockId(int sequenceNo, int partitionId, long taskAttemptId) {
     if (sequenceNo < 0 || sequenceNo > maxSequenceNo) {
       throw new IllegalArgumentException(
           "Don't support sequenceNo[" + sequenceNo + "], the max value should be " + maxSequenceNo);
@@ -180,13 +180,13 @@ public class BlockIdLayout {
     return (int) ((blockId & taskAttemptIdMask) >> taskAttemptIdOffset);
   }
 
-  public BlockId asBlockId(long blockId) {
-    return new BlockId(
+  public BlockIdWithLayout asBlockId(long blockId) {
+    return new BlockIdWithLayout(
         blockId, this, getSequenceNo(blockId), getPartitionId(blockId), getTaskAttemptId(blockId));
   }
 
-  public BlockId asBlockId(int sequenceNo, int partitionId, long taskAttemptId) {
-    return new BlockId(
+  public BlockIdWithLayout asBlockId(int sequenceNo, int partitionId, long taskAttemptId) {
+    return new BlockIdWithLayout(
         getBlockId(sequenceNo, partitionId, taskAttemptId),
         this,
         sequenceNo,

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockIdSet.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockIdSet.java
@@ -19,46 +19,31 @@ package org.apache.uniffle.common.util;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.LongConsumer;
-import java.util.stream.LongStream;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 /** Implementations are thread-safe. */
 public interface BlockIdSet {
-  BlockIdSet add(long blockId);
+  BlockIdSet add(BlockId blockId);
 
   default BlockIdSet addAll(BlockIdSet blockIds) {
     return addAll(blockIds.stream());
   }
 
-  default BlockIdSet addAll(Stream<Long> blockIds) {
+  default BlockIdSet addAll(Stream<BlockId> blockIds) {
     synchronized (this) {
       blockIds.forEach(this::add);
     }
     return this;
   }
 
-  default BlockIdSet addAll(LongStream blockIds) {
-    synchronized (this) {
-      blockIds.forEach(this::add);
-    }
-    return this;
-  }
-
-  BlockIdSet remove(long blockId);
+  BlockIdSet remove(BlockId blockId);
 
   default BlockIdSet removeAll(BlockIdSet blockIds) {
     return removeAll(blockIds.stream());
   }
 
-  default BlockIdSet removeAll(Stream<Long> blockIds) {
-    synchronized (this) {
-      blockIds.forEach(this::remove);
-    }
-    return this;
-  }
-
-  default BlockIdSet removeAll(LongStream blockIds) {
+  default BlockIdSet removeAll(Stream<BlockId> blockIds) {
     synchronized (this) {
       blockIds.forEach(this::remove);
     }
@@ -67,7 +52,7 @@ public interface BlockIdSet {
 
   BlockIdSet retainAll(BlockIdSet blockIds);
 
-  boolean contains(long blockId);
+  boolean contains(BlockId blockId);
 
   boolean containsAll(BlockIdSet blockIds);
 
@@ -77,9 +62,9 @@ public interface BlockIdSet {
 
   boolean isEmpty();
 
-  void forEach(LongConsumer func);
+  void forEach(Consumer<BlockId> func);
 
-  LongStream stream();
+  Stream<BlockId> stream();
 
   BlockIdSet copy();
 
@@ -91,9 +76,16 @@ public interface BlockIdSet {
   }
 
   // create new instance from given block ids using default implementation
-  static BlockIdSet of(long... blockIds) {
+  static BlockIdSet of(BlockId... blockIds) {
     BlockIdSet set = empty();
     set.addAll(Arrays.stream(blockIds));
+    return set;
+  }
+
+  // create new instance from given block ids stream using default implementation
+  static BlockIdSet from(Stream<Long> blockIds) {
+    BlockIdSet set = empty();
+    set.addAll(blockIds.map(OpaqueBlockId::new));
     return set;
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockIdWithLayout.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockIdWithLayout.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+import java.util.Objects;
+
+/**
+ * This represents a block id and all its constituents. This is particularly useful for logging and
+ * debugging block ids.
+ *
+ * <p>BlockId is positive long (63 bits) composed of sequenceNo, partitionId and taskAttemptId in
+ * that order from highest to lowest bits. The number of bits is defined by a {@link BlockIdLayout}.
+ * Values of partitionId, taskAttemptId and AtomicInteger are always positive.
+ */
+public class BlockIdWithLayout implements BlockId {
+  public final long blockId;
+  public final BlockIdLayout layout;
+  public final int sequenceNo;
+  public final int partitionId;
+  public final int taskAttemptId;
+
+  protected BlockIdWithLayout(
+      long blockId, BlockIdLayout layout, int sequenceNo, int partitionId, int taskAttemptId) {
+    this.blockId = blockId;
+    this.layout = layout;
+    this.sequenceNo = sequenceNo;
+    this.partitionId = partitionId;
+    this.taskAttemptId = taskAttemptId;
+  }
+
+  @Override
+  public long getBlockId() {
+    return blockId;
+  }
+
+  @Override
+  public int getSequenceNo() {
+    return sequenceNo;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public int getTaskAttemptId() {
+    return taskAttemptId;
+  }
+
+  @Override
+  public String toString() {
+    return Long.toHexString(blockId)
+        + " (seq: "
+        + sequenceNo
+        + ", part: "
+        + partitionId
+        + ", task: "
+        + taskAttemptId
+        + ")";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof BlockIdWithLayout) {
+      BlockIdWithLayout other = (BlockIdWithLayout) o;
+      return blockId == other.blockId && Objects.equals(layout, other.layout);
+    }
+    if (o instanceof OpaqueBlockId) {
+      BlockId other = (BlockId) o;
+      return blockId == other.getBlockId();
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(blockId);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/util/OpaqueBlockId.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/OpaqueBlockId.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+import java.util.Objects;
+
+public class OpaqueBlockId implements BlockId {
+  public final long blockId;
+
+  public OpaqueBlockId(long blockId) {
+    this.blockId = blockId;
+  }
+
+  @Override
+  public long getBlockId() {
+    return blockId;
+  }
+
+  public BlockIdWithLayout withLayout(BlockIdLayout layout) {
+    return layout.asBlockId(blockId);
+  }
+
+  @Override
+  public int getSequenceNo() {
+    throw new UnsupportedOperationException(
+        "This is an opaque block id, "
+            + "the sequence number cannot be accessed as the layout is not known.");
+  }
+
+  @Override
+  public int getPartitionId() {
+    throw new UnsupportedOperationException(
+        "This is an opaque block id, "
+            + "the partition id cannot be accessed as the layout is not known.");
+  }
+
+  @Override
+  public int getTaskAttemptId() {
+    throw new UnsupportedOperationException(
+        "This is an opaque block id, "
+            + "the task attempt id cannot be accessed as the layout is not known.");
+  }
+
+  @Override
+  public String toString() {
+    return Long.toHexString(blockId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof BlockId) {
+      BlockId other = (BlockId) o;
+      return blockId == other.getBlockId();
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(blockId);
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/util/RoaringBitmapBlockIdSet.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RoaringBitmapBlockIdSet.java
@@ -18,8 +18,8 @@
 package org.apache.uniffle.common.util;
 
 import java.io.IOException;
-import java.util.function.LongConsumer;
-import java.util.stream.LongStream;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -35,8 +35,8 @@ public class RoaringBitmapBlockIdSet implements BlockIdSet {
   }
 
   @Override
-  public synchronized BlockIdSet add(long blockId) {
-    bitmap.addLong(blockId);
+  public synchronized BlockIdSet add(BlockId blockId) {
+    bitmap.addLong(blockId.getBlockId());
     return this;
   }
 
@@ -51,8 +51,8 @@ public class RoaringBitmapBlockIdSet implements BlockIdSet {
   }
 
   @Override
-  public synchronized BlockIdSet remove(long blockId) {
-    bitmap.removeLong(blockId);
+  public synchronized BlockIdSet remove(BlockId blockId) {
+    bitmap.removeLong(blockId.getBlockId());
     return this;
   }
 
@@ -77,8 +77,8 @@ public class RoaringBitmapBlockIdSet implements BlockIdSet {
   }
 
   @Override
-  public boolean contains(long blockId) {
-    return bitmap.contains(blockId);
+  public boolean contains(BlockId blockId) {
+    return bitmap.contains(blockId.getBlockId());
   }
 
   @Override
@@ -89,7 +89,8 @@ public class RoaringBitmapBlockIdSet implements BlockIdSet {
     }
     Roaring64NavigableMap expecteds = ((RoaringBitmapBlockIdSet) blockIds).bitmap;
 
-    // first a quick check: no need for expensive bitwise AND when this is equal to the other BlockIdSet
+    // first a quick check: no need for expensive bitwise AND when this is equal to the other
+    // BlockIdSet
     if (this.bitmap.equals(expecteds)) {
       return true;
     }
@@ -131,13 +132,13 @@ public class RoaringBitmapBlockIdSet implements BlockIdSet {
   }
 
   @Override
-  public synchronized void forEach(LongConsumer func) {
-    bitmap.forEach(func::accept);
+  public synchronized void forEach(Consumer<BlockId> func) {
+    bitmap.stream().mapToObj(OpaqueBlockId::new).forEach(func);
   }
 
   @Override
-  public LongStream stream() {
-    return bitmap.stream();
+  public Stream<BlockId> stream() {
+    return bitmap.stream().mapToObj(OpaqueBlockId::new);
   }
 
   @Override

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -342,10 +342,10 @@ public class RssUtils {
     for (int partitionId = startPartition; partitionId < endPartition; partitionId++) {
       result.computeIfAbsent(partitionId, key -> BlockIdSet.empty());
     }
-    Iterator<Long> it = shuffleBitmap.stream().iterator();
+    Iterator<BlockId> it = shuffleBitmap.stream().iterator();
     while (it.hasNext()) {
-      Long blockId = it.next();
-      int partitionId = layout.getPartitionId(blockId);
+      BlockId blockId = it.next();
+      int partitionId = layout.getPartitionId(blockId.getBlockId());
       if (partitionId >= startPartition && partitionId < endPartition) {
         result.get(partitionId).add(blockId);
       }
@@ -386,7 +386,8 @@ public class RssUtils {
   public static Roaring64NavigableMap generateTaskIdBitMap(
       BlockIdSet blockIdBitmap, IdHelper idHelper) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
-    blockIdBitmap.forEach(blockId -> taskIdBitmap.addLong(idHelper.getTaskAttemptId(blockId)));
+    blockIdBitmap.forEach(
+        blockId -> taskIdBitmap.addLong(idHelper.getTaskAttemptId(blockId.getBlockId())));
     return taskIdBitmap;
   }
 

--- a/common/src/test/java/org/apache/uniffle/common/BufferSegmentTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/BufferSegmentTest.java
@@ -21,16 +21,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BufferSegmentTest {
+  private static BlockId blockId = new OpaqueBlockId(0);
 
   @Test
   public void testEquals() {
-    BufferSegment segment1 = new BufferSegment(0, 1, 2, 3, 4, 5);
-    BufferSegment segment2 = new BufferSegment(0, 1, 2, 3, 4, 5);
+    BufferSegment segment1 = new BufferSegment(blockId, 1, 2, 3, 4, 5);
+    BufferSegment segment2 = new BufferSegment(blockId, 1, 2, 3, 4, 5);
     assertEquals(segment1, segment2);
     assertEquals(segment1.hashCode(), segment2.hashCode());
     assertNotEquals(segment1, null);
@@ -47,16 +51,22 @@ public class BufferSegmentTest {
     "0, 1, 2, 3, 4, 6",
   })
   public void testNotEquals(
-      long blockId, long offset, int length, int uncompressLength, long crc, long taskAttemptId) {
-    BufferSegment segment1 = new BufferSegment(0, 1, 2, 3, 4, 5);
+      long blockIdlong,
+      long offset,
+      int length,
+      int uncompressLength,
+      long crc,
+      long taskAttemptId) {
+    BlockId bid = new OpaqueBlockId(blockIdlong);
+    BufferSegment segment1 = new BufferSegment(blockId, 1, 2, 3, 4, 5);
     BufferSegment segment2 =
-        new BufferSegment(blockId, offset, length, uncompressLength, crc, taskAttemptId);
+        new BufferSegment(bid, offset, length, uncompressLength, crc, taskAttemptId);
     assertNotEquals(segment1, segment2);
   }
 
   @Test
   public void testToString() {
-    BufferSegment segment = new BufferSegment(0, 1, 2, 3, 4, 5);
+    BufferSegment segment = new BufferSegment(blockId, 1, 2, 3, 4, 5);
     assertEquals(
         "BufferSegment{blockId[0], taskAttemptId[5], offset[1], length[2], crc[4], uncompressLength[3]}",
         segment.toString());
@@ -64,9 +74,9 @@ public class BufferSegmentTest {
 
   @Test
   public void testGetOffset() {
-    BufferSegment segment1 = new BufferSegment(0, Integer.MAX_VALUE, 2, 3, 4, 5);
+    BufferSegment segment1 = new BufferSegment(blockId, Integer.MAX_VALUE, 2, 3, 4, 5);
     assertEquals(Integer.MAX_VALUE, segment1.getOffset());
-    BufferSegment segment2 = new BufferSegment(0, (long) Integer.MAX_VALUE + 1, 2, 3, 4, 5);
+    BufferSegment segment2 = new BufferSegment(blockId, (long) Integer.MAX_VALUE + 1, 2, 3, 4, 5);
     assertThrows(RuntimeException.class, segment2::getOffset);
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleBlockInfoTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleBlockInfoTest.java
@@ -22,16 +22,20 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShuffleBlockInfoTest {
+  private final BlockId blockId3 = new OpaqueBlockId(3);
 
   @Test
   public void testToString() {
     List<ShuffleServerInfo> shuffleServerInfos =
         Collections.singletonList(new ShuffleServerInfo("0", "localhost", 1234));
     ShuffleBlockInfo info =
-        new ShuffleBlockInfo(1, 2, 3, 4, 5, new byte[6], shuffleServerInfos, 7, 8, 9);
+        new ShuffleBlockInfo(1, 2, blockId3, 4, 5, new byte[6], shuffleServerInfos, 7, 8, 9);
     assertEquals(
         "ShuffleBlockInfo:shuffleId["
             + info.getShuffleId()
@@ -48,7 +52,7 @@ public class ShuffleBlockInfoTest {
             + "],shuffleServer[0,]",
         info.toString());
 
-    ShuffleBlockInfo info2 = new ShuffleBlockInfo(1, 2, 3, 4, 5, new byte[6], null, 7, 8, 9);
+    ShuffleBlockInfo info2 = new ShuffleBlockInfo(1, 2, blockId3, 4, 5, new byte[6], null, 7, 8, 9);
     assertEquals(
         "ShuffleBlockInfo:shuffleId["
             + info2.getShuffleId()

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleDataResultTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleDataResultTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.util.OpaqueBlockId;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,7 +31,8 @@ public class ShuffleDataResultTest {
 
   @Test
   public void testEmpty() {
-    List<BufferSegment> segments = Collections.singletonList(new BufferSegment(1, 2, 3, 4, 5, 6));
+    List<BufferSegment> segments =
+        Collections.singletonList(new BufferSegment(new OpaqueBlockId(1), 2, 3, 4, 5, 6));
     byte[] bytes = null;
     assertTrue(new ShuffleDataResult().isEmpty());
     assertTrue(new ShuffleDataResult(new byte[1]).isEmpty());

--- a/common/src/test/java/org/apache/uniffle/common/ShufflePartitionedBlockTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShufflePartitionedBlockTest.java
@@ -23,32 +23,36 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ByteBufUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ShufflePartitionedBlockTest {
+  private final BlockId blockId3 = new OpaqueBlockId(3);
+  private final BlockId blockId4 = new OpaqueBlockId(4);
 
   @Test
   public void shufflePartitionedBlockTest() {
     byte[] buf = new byte[3];
     new Random().nextBytes(buf);
 
-    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 1, 2, 3, 1, buf);
+    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 1, 2, blockId3, 1, buf);
     assertEquals(1, b1.getLength());
     assertEquals(2, b1.getCrc());
-    assertEquals(3, b1.getBlockId());
+    assertEquals(3, b1.getBlockId().getBlockId());
 
-    ShufflePartitionedBlock b3 = new ShufflePartitionedBlock(1, 1, 2, 3, 3, buf);
+    ShufflePartitionedBlock b3 = new ShufflePartitionedBlock(1, 1, 2, blockId3, 3, buf);
     assertArrayEquals(buf, ByteBufUtils.readBytes(b3.getData()));
   }
 
   @Test
   public void testEquals() {
-    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, 4, 5, new byte[6]);
-    ShufflePartitionedBlock b2 = new ShufflePartitionedBlock(1, 6, 3, 4, 7, new byte[6]);
+    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, blockId4, 5, new byte[6]);
+    ShufflePartitionedBlock b2 = new ShufflePartitionedBlock(1, 6, 3, blockId4, 7, new byte[6]);
     assertEquals(b1, b1);
     assertEquals(b1.hashCode(), b1.hashCode());
     assertEquals(b1, b2);
@@ -60,15 +64,16 @@ public class ShufflePartitionedBlockTest {
   @ParameterizedTest
   @CsvSource({"5, 2, 3, 4", "1, 5, 3, 4", "1, 2, 5, 4", "1, 2, 3, 5"})
   public void testNotEquals(int length, long crc, long blockId, int dataSize) {
-    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 0, 2, 3, 0, new byte[4]);
+    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 0, 2, blockId3, 0, new byte[4]);
     ShufflePartitionedBlock b2 =
-        new ShufflePartitionedBlock(length, 0, crc, blockId, 0, new byte[dataSize]);
+        new ShufflePartitionedBlock(
+            length, 0, crc, new OpaqueBlockId(blockId), 0, new byte[dataSize]);
     assertNotEquals(b1, b2);
   }
 
   @Test
   public void testToString() {
-    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, 4, 5, new byte[6]);
+    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, blockId4, 5, new byte[6]);
     assertEquals(
         "ShufflePartitionedBlock{blockId["
             + b1.getBlockId()
@@ -86,7 +91,7 @@ public class ShufflePartitionedBlockTest {
 
   @Test
   public void testSize() {
-    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, 4, 5, new byte[6]);
+    ShufflePartitionedBlock b1 = new ShufflePartitionedBlock(1, 2, 3, blockId4, 5, new byte[6]);
     assertEquals(b1.getSize(), b1.getLength() + 3 * Long.BYTES + 2 * Integer.BYTES);
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ShufflePartitionedDataTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShufflePartitionedDataTest.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.util.OpaqueBlockId;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShufflePartitionedDataTest {
@@ -39,7 +41,7 @@ public class ShufflePartitionedDataTest {
         new ShufflePartitionedData(
             1,
             new ShufflePartitionedBlock[] {
-              new ShufflePartitionedBlock(2, 3, 4, 5, 6, new byte[0])
+              new ShufflePartitionedBlock(2, 3, 4, new OpaqueBlockId(5), 6, new byte[0])
             });
     assertEquals(
         "ShufflePartitionedData{partitionId="

--- a/common/src/test/java/org/apache/uniffle/common/netty/EncoderAndDecoderTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/EncoderAndDecoderTest.java
@@ -49,7 +49,9 @@ import org.apache.uniffle.common.netty.protocol.NettyProtocolTestUtils;
 import org.apache.uniffle.common.netty.protocol.RpcResponse;
 import org.apache.uniffle.common.netty.protocol.SendShuffleDataRequest;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.NettyUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,6 +65,8 @@ public class EncoderAndDecoderTest {
   private static final long REQUEST_ID = 1;
   private static final StatusCode STATUS_CODE = StatusCode.SUCCESS;
   private static final int PORT = 12345;
+  private static final BlockId blockId1 = new OpaqueBlockId(1);
+  private static final BlockId blockId2 = new OpaqueBlockId(2);
 
   static class MockResponseHandler extends ChannelInboundHandlerAdapter {
     @Override
@@ -137,7 +141,7 @@ public class EncoderAndDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -148,7 +152,7 @@ public class EncoderAndDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -161,7 +165,7 @@ public class EncoderAndDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 2,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -172,7 +176,7 @@ public class EncoderAndDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                2,
+                blockId2,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),

--- a/common/src/test/java/org/apache/uniffle/common/netty/TransportFrameDecoderTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/TransportFrameDecoderTest.java
@@ -42,12 +42,16 @@ import org.apache.uniffle.common.netty.protocol.Message;
 import org.apache.uniffle.common.netty.protocol.RpcResponse;
 import org.apache.uniffle.common.netty.protocol.SendShuffleDataRequest;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransportFrameDecoderTest {
+  private final BlockId blockId1 = new OpaqueBlockId(1);
+  private final BlockId blockId2 = new OpaqueBlockId(2);
 
   /** test if the RPC response should be released after decoding */
   @Test
@@ -170,7 +174,8 @@ public class TransportFrameDecoderTest {
     byte[] data4 = new byte[] {1, 2, 3, 4, 5};
     List<BufferSegment> bufferSegments =
         Lists.newArrayList(
-            new BufferSegment(1, 0, 5, 10, 123, 1), new BufferSegment(1, 0, 5, 10, 345, 1));
+            new BufferSegment(blockId1, 0, 5, 10, 123, 1),
+            new BufferSegment(blockId1, 0, 5, 10, 345, 1));
     GetMemoryShuffleDataResponse rpcResponse4 =
         new GetMemoryShuffleDataResponse(
             1, StatusCode.SUCCESS, "", bufferSegments, Unpooled.wrappedBuffer(data4).retain());
@@ -187,7 +192,7 @@ public class TransportFrameDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -198,7 +203,7 @@ public class TransportFrameDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -211,7 +216,7 @@ public class TransportFrameDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 2,
-                1,
+                blockId1,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -222,7 +227,7 @@ public class TransportFrameDecoderTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                2,
+                blockId2,
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
@@ -33,6 +33,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +50,7 @@ public class NettyProtocolTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                new OpaqueBlockId(1),
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -60,7 +61,7 @@ public class NettyProtocolTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                1,
+                new OpaqueBlockId(1),
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -73,7 +74,7 @@ public class NettyProtocolTest {
             new ShuffleBlockInfo(
                 1,
                 2,
-                1,
+                new OpaqueBlockId(1),
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -84,7 +85,7 @@ public class NettyProtocolTest {
             new ShuffleBlockInfo(
                 1,
                 1,
-                2,
+                new OpaqueBlockId(2),
                 data.length,
                 123,
                 Unpooled.wrappedBuffer(data).retain(),
@@ -273,7 +274,8 @@ public class NettyProtocolTest {
     byte[] data = new byte[] {1, 2, 3, 4, 5};
     List<BufferSegment> bufferSegments =
         Lists.newArrayList(
-            new BufferSegment(1, 0, 5, 10, 123, 1), new BufferSegment(1, 0, 5, 10, 345, 1));
+            new BufferSegment(new OpaqueBlockId(1), 0, 5, 10, 123, 1),
+            new BufferSegment(new OpaqueBlockId(1), 0, 5, 10, 345, 1));
     GetMemoryShuffleDataResponse getMemoryShuffleDataResponse =
         new GetMemoryShuffleDataResponse(
             1, StatusCode.SUCCESS, "", bufferSegments, Unpooled.wrappedBuffer(data).retain());

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
@@ -28,7 +28,7 @@ public class NettyProtocolTestUtils {
   private static boolean compareShuffleBlockInfo(
       ShuffleBlockInfo blockInfo1, ShuffleBlockInfo blockInfo2) {
     return blockInfo1.getPartitionId() == blockInfo2.getPartitionId()
-        && blockInfo1.getBlockId() == blockInfo2.getBlockId()
+        && blockInfo1.getBlockId().equals(blockInfo2.getBlockId())
         && blockInfo1.getLength() == blockInfo2.getLength()
         && blockInfo1.getShuffleId() == blockInfo2.getShuffleId()
         && blockInfo1.getCrc() == blockInfo2.getCrc()

--- a/common/src/test/java/org/apache/uniffle/common/util/BlockIdTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/BlockIdTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BlockIdTest {
   BlockIdLayout layout1 = BlockIdLayout.DEFAULT;
@@ -33,12 +34,52 @@ public class BlockIdTest {
   BlockId blockId3 = layout2.asBlockId(1, 2, 3);
   BlockId blockId4 = layout2.asBlockId(15, 30, 63);
 
+  BlockId opaqueBlockId1 = new OpaqueBlockId(blockId1.getBlockId());
+  BlockId opaqueBlockId2 = new OpaqueBlockId(blockId2.getBlockId());
+  BlockId opaqueBlockId3 = new OpaqueBlockId(blockId3.getBlockId());
+  BlockId opaqueBlockId4 = new OpaqueBlockId(blockId4.getBlockId());
+
+  @Test
+  public void testGetters() {
+    assertEquals(35184376283139L, blockId1.getBlockId());
+    assertEquals(527765644247103L, blockId2.getBlockId());
+    assertEquals(4295098371L, blockId3.getBlockId());
+    assertEquals(64426475583L, blockId4.getBlockId());
+    assertEquals(35184376283139L, opaqueBlockId1.getBlockId());
+    assertEquals(527765644247103L, opaqueBlockId2.getBlockId());
+    assertEquals(4295098371L, opaqueBlockId3.getBlockId());
+    assertEquals(64426475583L, opaqueBlockId4.getBlockId());
+
+    assertEquals(1, blockId1.getSequenceNo());
+    assertEquals(15, blockId2.getSequenceNo());
+    assertEquals(1, blockId3.getSequenceNo());
+    assertEquals(15, blockId4.getSequenceNo());
+    assertThrows(UnsupportedOperationException.class, () -> opaqueBlockId1.getSequenceNo());
+
+    assertEquals(2, blockId1.getPartitionId());
+    assertEquals(30, blockId2.getPartitionId());
+    assertEquals(2, blockId3.getPartitionId());
+    assertEquals(30, blockId4.getPartitionId());
+    assertThrows(UnsupportedOperationException.class, () -> opaqueBlockId1.getPartitionId());
+
+    assertEquals(3, blockId1.getTaskAttemptId());
+    assertEquals(63, blockId2.getTaskAttemptId());
+    assertEquals(3, blockId3.getTaskAttemptId());
+    assertEquals(63, blockId4.getTaskAttemptId());
+    assertThrows(UnsupportedOperationException.class, () -> opaqueBlockId1.getTaskAttemptId());
+  }
+
   @Test
   public void testToString() {
-    assertEquals("blockId[200000400003 (seq: 1, part: 2, task: 3)]", blockId1.toString());
-    assertEquals("blockId[1e00003c0003f (seq: 15, part: 30, task: 63)]", blockId2.toString());
-    assertEquals("blockId[100020003 (seq: 1, part: 2, task: 3)]", blockId3.toString());
-    assertEquals("blockId[f001e003f (seq: 15, part: 30, task: 63)]", blockId4.toString());
+    assertEquals("200000400003 (seq: 1, part: 2, task: 3)", blockId1.toString());
+    assertEquals("1e00003c0003f (seq: 15, part: 30, task: 63)", blockId2.toString());
+    assertEquals("100020003 (seq: 1, part: 2, task: 3)", blockId3.toString());
+    assertEquals("f001e003f (seq: 15, part: 30, task: 63)", blockId4.toString());
+
+    assertEquals("200000400003", opaqueBlockId1.toString());
+    assertEquals("1e00003c0003f", opaqueBlockId2.toString());
+    assertEquals("100020003", opaqueBlockId3.toString());
+    assertEquals("f001e003f", opaqueBlockId4.toString());
   }
 
   @Test
@@ -50,6 +91,21 @@ public class BlockIdTest {
     assertNotEquals(blockId1, blockId3);
     assertNotEquals(blockId1, blockId4);
     assertNotEquals(blockId2, blockId4);
+
+    assertEquals(blockId1, opaqueBlockId1);
+    assertEquals(blockId2, opaqueBlockId2);
+    assertEquals(blockId3, opaqueBlockId3);
+    assertEquals(blockId4, opaqueBlockId4);
+    assertNotSame(blockId1, opaqueBlockId1);
+    assertNotSame(blockId2, opaqueBlockId2);
+    assertNotSame(blockId3, opaqueBlockId3);
+    assertNotSame(blockId4, opaqueBlockId4);
+    assertNotEquals(blockId1, opaqueBlockId2);
+    assertNotEquals(blockId1, opaqueBlockId3);
+    assertNotEquals(blockId1, opaqueBlockId4);
+
+    assertEquals(opaqueBlockId1, opaqueBlockId1);
+    assertEquals(opaqueBlockId1, new OpaqueBlockId(opaqueBlockId1.getBlockId()));
 
     BlockId blockId4 = layout1.asBlockId(1, 2, 3);
     assertEquals(blockId1, blockId4);

--- a/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
@@ -239,16 +239,16 @@ public class RssUtilsTest {
   public void testShuffleBitmapToPartitionBitmap(BlockIdLayout layout) {
     BlockIdSet partition1Bitmap =
         BlockIdSet.of(
-            layout.getBlockId(0, 0, 0),
-            layout.getBlockId(1, 0, 0),
-            layout.getBlockId(0, 0, 1),
-            layout.getBlockId(1, 0, 1));
+            layout.asBlockId(0, 0, 0),
+            layout.asBlockId(1, 0, 0),
+            layout.asBlockId(0, 0, 1),
+            layout.asBlockId(1, 0, 1));
     BlockIdSet partition2Bitmap =
         BlockIdSet.of(
-            layout.getBlockId(0, 1, 0),
-            layout.getBlockId(1, 1, 0),
-            layout.getBlockId(0, 1, 1),
-            layout.getBlockId(1, 1, 1));
+            layout.asBlockId(0, 1, 0),
+            layout.asBlockId(1, 1, 0),
+            layout.asBlockId(0, 1, 1),
+            layout.asBlockId(1, 1, 1));
     BlockIdSet shuffleBitmap = BlockIdSet.empty();
     shuffleBitmap.addAll(partition1Bitmap);
     shuffleBitmap.addAll(partition2Bitmap);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/DiskErrorToleranceTest.java
@@ -53,6 +53,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
@@ -165,8 +166,8 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
     ShuffleServerGrpcClient shuffleServerClient =
         isNettyMode ? nettyShuffleServerClient : grpcShuffleServerClient;
     String appId = "ap_disk_error_data";
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
-    Set<Long> expectedBlock1 = Sets.newHashSet();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
+    Set<BlockId> expectedBlock1 = Sets.newHashSet();
     BlockIdSet blockIdBitmap1 = BlockIdSet.empty();
     List<ShuffleBlockInfo> blocks1 =
         createShuffleBlockList(0, 0, 1, 3, 25, blockIdBitmap1, expectedData);
@@ -214,7 +215,7 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
     partitionToBlocks.clear();
     shuffleToBlocks.clear();
     BlockIdSet blockIdBitmap2 = BlockIdSet.empty();
-    Set<Long> expectedBlock2 = Sets.newHashSet();
+    Set<BlockId> expectedBlock2 = Sets.newHashSet();
     List<ShuffleBlockInfo> blocks2 =
         createShuffleBlockList(0, 0, 2, 5, 30, blockIdBitmap2, expectedData);
     blocks2.forEach(b -> expectedBlock2.add(b.getBlockId()));

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
@@ -43,6 +43,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.coordinator.CoordinatorServer;
@@ -152,7 +153,7 @@ public class RpcClientRetryTest extends ShuffleReadWriteBase {
   public void testRpcRetryLogic(StorageType storageType) {
     String testAppId = "testRpcRetryLogic";
     registerShuffleServer(testAppId, 3, 2, 2, true);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
 
     List<ShuffleBlockInfo> blocks =
@@ -169,10 +170,10 @@ public class RpcClientRetryTest extends ShuffleReadWriteBase {
     SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
     BlockIdSet failedBlockIdBitmap = BlockIdSet.empty();
     BlockIdSet successfulBlockIdBitmap = BlockIdSet.empty();
-    for (Long blockId : result.getSuccessBlockIds()) {
+    for (BlockId blockId : result.getSuccessBlockIds()) {
       successfulBlockIdBitmap.add(blockId);
     }
-    for (Long blockId : result.getFailedBlockIds()) {
+    for (BlockId blockId : result.getFailedBlockIds()) {
       failedBlockIdBitmap.add(blockId);
     }
     assertEquals(0, failedBlockIdBitmap.getLongCardinality());

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleReadWriteBase.java
@@ -39,6 +39,7 @@ import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.segment.FixedSizeSegmentSplitter;
 import org.apache.uniffle.common.segment.SegmentSplitter;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -56,7 +57,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
       int blockNum,
       int length,
       BlockIdSet blockIdBitmap,
-      Map<Long, byte[]> dataMap,
+      Map<BlockId, byte[]> dataMap,
       List<ShuffleServerInfo> shuffleServerInfoList) {
     List<ShuffleBlockInfo> shuffleBlockInfoList = Lists.newArrayList();
     for (int i = 0; i < blockNum; i++) {
@@ -64,7 +65,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
       new Random().nextBytes(buf);
       int seqno = ATOMIC_INT.getAndIncrement();
 
-      long blockId = LAYOUT.getBlockId(seqno, 0, taskAttemptId);
+      BlockId blockId = LAYOUT.asBlockId(seqno, partitionId, taskAttemptId);
       blockIdBitmap.add(blockId);
       dataMap.put(blockId, buf);
       shuffleBlockInfoList.add(
@@ -90,7 +91,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
       int blockNum,
       int length,
       BlockIdSet blockIdBitmap,
-      Map<Long, byte[]> dataMap) {
+      Map<BlockId, byte[]> dataMap) {
     List<ShuffleServerInfo> shuffleServerInfoList =
         Lists.newArrayList(new ShuffleServerInfo("id", "host", 0));
     return createShuffleBlockList(
@@ -105,7 +106,7 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
   }
 
   public static Map<Integer, List<ShuffleBlockInfo>> createTestData(
-      BlockIdSet[] bitmaps, Map<Long, byte[]> expectedData) {
+      BlockIdSet[] bitmaps, Map<BlockId, byte[]> expectedData) {
     for (int i = 0; i < 4; i++) {
       bitmaps[i] = BlockIdSet.empty();
     }
@@ -129,7 +130,8 @@ public abstract class ShuffleReadWriteBase extends IntegrationTestBase {
     return TestUtils.compareByte(expected, buffer);
   }
 
-  public static void validateResult(ShuffleReadClient readClient, Map<Long, byte[]> expectedData) {
+  public static void validateResult(
+      ShuffleReadClient readClient, Map<BlockId, byte[]> expectedData) {
     TestUtils.validateResult(readClient, expectedData);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerConcurrentWriteOfHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerConcurrentWriteOfHadoopTest.java
@@ -54,6 +54,7 @@ import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -122,14 +123,14 @@ public class ShuffleServerConcurrentWriteOfHadoopTest extends ShuffleServerWithH
     shuffleServerClient.registerShuffle(rrsr);
 
     List<BlockIdSet> bitmaps = new ArrayList<>();
-    Map<Long, byte[]> expectedDataList = new HashMap<>();
+    Map<BlockId, byte[]> expectedDataList = new HashMap<>();
     IntStream.range(0, 20)
         .forEach(
             x -> {
               BlockIdSet bitmap = BlockIdSet.empty();
               bitmaps.add(bitmap);
 
-              Map<Long, byte[]> expectedData = Maps.newHashMap();
+              Map<BlockId, byte[]> expectedData = Maps.newHashMap();
 
               List<ShuffleBlockInfo> blocks =
                   createShuffleBlockList(0, 0, 0, 1, 1024 * 1025, bitmap, expectedData, mockSSI);
@@ -172,7 +173,7 @@ public class ShuffleServerConcurrentWriteOfHadoopTest extends ShuffleServerWithH
     bitmaps.stream()
         .forEach(
             x -> {
-              Iterator<Long> iterator = x.stream().iterator();
+              Iterator<BlockId> iterator = x.stream().iterator();
               while (iterator.hasNext()) {
                 blocksBitmap.add(iterator.next());
               }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -48,6 +48,7 @@ import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -133,7 +134,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
           client.registerShuffle(rrsr);
         });
     BlockIdSet expectBlockIds = BlockIdSet.empty();
-    Map<Long, byte[]> dataMap = Maps.newHashMap();
+    Map<BlockId, byte[]> dataMap = Maps.newHashMap();
     Roaring64NavigableMap[] bitmaps = new Roaring64NavigableMap[1];
     bitmaps[0] = Roaring64NavigableMap.bitmapOf();
     List<ShuffleBlockInfo> blocks =
@@ -162,7 +163,7 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     AbstractClientReadHandler clientReadHandler =
         (AbstractClientReadHandler)
             ShuffleHandlerFactory.getInstance().createShuffleReadHandler(request);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     expectedData.clear();
     blocks.forEach(
         (block) -> {

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithHadoopTest.java
@@ -48,6 +48,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.coordinator.CoordinatorConf;
 import org.apache.uniffle.server.ShuffleServer;
@@ -139,7 +140,7 @@ public class ShuffleServerWithHadoopTest extends ShuffleReadWriteBase {
     shuffleServerClient.registerShuffle(rrsr);
 
     BlockIdSet[] bitmaps = new BlockIdSet[4];
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     Map<Integer, List<ShuffleBlockInfo>> dataBlocks = createTestData(bitmaps, expectedData);
     Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
     partitionToBlocks.put(0, dataBlocks.get(0));
@@ -249,11 +250,13 @@ public class ShuffleServerWithHadoopTest extends ShuffleReadWriteBase {
   }
 
   protected void validateResult(
-      ShuffleReadClientImpl readClient, Map<Long, byte[]> expectedData, BlockIdSet blockIdBitmap) {
+      ShuffleReadClientImpl readClient,
+      Map<BlockId, byte[]> expectedData,
+      BlockIdSet blockIdBitmap) {
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();
     BlockIdSet matched = BlockIdSet.empty();
     while (csb != null && csb.getByteBuffer() != null) {
-      for (Entry<Long, byte[]> entry : expectedData.entrySet()) {
+      for (Entry<BlockId, byte[]> entry : expectedData.entrySet()) {
         if (compareByte(entry.getValue(), csb.getByteBuffer())) {
           matched.add(entry.getKey());
           break;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -56,6 +56,7 @@ import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
@@ -192,7 +193,7 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
   }
 
   private Map<Integer, List<ShuffleBlockInfo>> createTestData(
-      BlockIdSet[] bitmaps, Map<Long, byte[]> expectedData) {
+      BlockIdSet[] bitmaps, Map<BlockId, byte[]> expectedData) {
     for (int i = 0; i < 4; i++) {
       bitmaps[i] = BlockIdSet.empty();
     }
@@ -267,7 +268,7 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
     shuffleServerClient.registerShuffle(rrsr);
 
     BlockIdSet[] bitmaps = new BlockIdSet[4];
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     Map<Integer, List<ShuffleBlockInfo>> dataBlocks = createTestData(bitmaps, expectedData);
     Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
     partitionToBlocks.put(0, dataBlocks.get(0));
@@ -377,11 +378,13 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
   }
 
   protected void validateResult(
-      ShuffleReadClientImpl readClient, Map<Long, byte[]> expectedData, BlockIdSet blockIdBitmap) {
+      ShuffleReadClientImpl readClient,
+      Map<BlockId, byte[]> expectedData,
+      BlockIdSet blockIdBitmap) {
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();
     BlockIdSet matched = BlockIdSet.empty();
     while (csb != null && csb.getByteBuffer() != null) {
-      for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {
+      for (Map.Entry<BlockId, byte[]> entry : expectedData.entrySet()) {
         if (TestUtils.compareByte(entry.getValue(), csb.getByteBuffer())) {
           matched.add(entry.getKey());
           break;

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithLocalOfLocalOrderTest.java
@@ -55,6 +55,7 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.segment.LocalOrderSegmentSplitter;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -128,7 +129,7 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
   }
 
   public static Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> createTestDataWithMultiMapIdx(
-      BlockIdSet[] bitmaps, Map<Long, byte[]> expectedData) {
+      BlockIdSet[] bitmaps, Map<BlockId, byte[]> expectedData) {
     for (int i = 0; i < 4; i++) {
       bitmaps[i] = BlockIdSet.empty();
     }
@@ -192,7 +193,7 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
     }
 
     /** Write the data to shuffle-servers */
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet[] bitMaps = new BlockIdSet[4];
 
     // Create the shuffle block with the mapIdx
@@ -226,11 +227,11 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
 
     /** Read the single partition data by specified [startMapIdx, endMapIdx) */
     // case1: get the mapIdx range [0, 1) of partition0
-    final Set<Long> expectedBlockIds1 =
+    final Set<BlockId> expectedBlockIds1 =
         partitionToBlocksWithMapIdx.get(0).get(0).stream()
             .map(x -> x.getBlockId())
             .collect(Collectors.toSet());
-    final Map<Long, byte[]> expectedData1 =
+    final Map<BlockId, byte[]> expectedData1 =
         expectedData.entrySet().stream()
             .filter(x -> expectedBlockIds1.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
@@ -250,12 +251,12 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
     validate(sdr, expectedBlockIds1, expectedData1, new HashSet<>(Arrays.asList(0L)));
 
     // case2: get the mapIdx range [0, 2) of partition0
-    final Set<Long> expectedBlockIds2 =
+    final Set<BlockId> expectedBlockIds2 =
         partitionToBlocksWithMapIdx.get(0).get(1).stream()
             .map(x -> x.getBlockId())
             .collect(Collectors.toSet());
     expectedBlockIds2.addAll(expectedBlockIds1);
-    final Map<Long, byte[]> expectedData2 =
+    final Map<BlockId, byte[]> expectedData2 =
         expectedData.entrySet().stream()
             .filter(x -> expectedBlockIds2.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
@@ -274,7 +275,7 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
     validate(sdr, expectedBlockIds2, expectedData2, new HashSet<>(Arrays.asList(0L, 1L)));
 
     // case2: get the mapIdx range [1, 3) of partition0
-    final Set<Long> expectedBlockIds3 =
+    final Set<BlockId> expectedBlockIds3 =
         partitionToBlocksWithMapIdx.get(0).get(1).stream()
             .map(x -> x.getBlockId())
             .collect(Collectors.toSet());
@@ -283,7 +284,7 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
             .map(x -> x.getBlockId())
             .collect(Collectors.toSet()));
     expectedBlockIds2.addAll(expectedBlockIds1);
-    final Map<Long, byte[]> expectedData3 =
+    final Map<BlockId, byte[]> expectedData3 =
         expectedData.entrySet().stream()
             .filter(x -> expectedBlockIds3.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
@@ -303,16 +304,16 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
 
     // case3: get the mapIdx range [0, Integer.MAX_VALUE) of partition0, it should always return all
     // data
-    final Set<Long> expectedBlockIds4 =
+    final Set<BlockId> expectedBlockIds4 =
         partitionToBlocks.get(0).stream().map(x -> x.getBlockId()).collect(Collectors.toSet());
-    final Map<Long, byte[]> expectedData4 =
+    final Map<BlockId, byte[]> expectedData4 =
         expectedData.entrySet().stream()
             .filter(x -> expectedBlockIds4.contains(x.getKey()))
             .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
     taskIds = Roaring64NavigableMap.bitmapOf();
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
-    for (long blockId : expectedBlockIds4) {
-      taskIds.add(new DefaultIdHelper(layout).getTaskAttemptId(blockId));
+    for (BlockId blockId : expectedBlockIds4) {
+      taskIds.add(new DefaultIdHelper(layout).getTaskAttemptId(blockId.getBlockId()));
     }
     sdr =
         readShuffleData(
@@ -330,8 +331,8 @@ public class ShuffleServerWithLocalOfLocalOrderTest extends ShuffleReadWriteBase
 
   private void validate(
       ShuffleDataResult sdr,
-      Set<Long> expectedBlockIds,
-      Map<Long, byte[]> expectedData,
+      Set<BlockId> expectedBlockIds,
+      Map<BlockId, byte[]> expectedData,
       Set<Long> expectedTaskAttemptIds) {
     byte[] buffer = sdr.getData();
     List<BufferSegment> bufferSegments = sdr.getBufferSegments();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleWithRssClientTest.java
@@ -45,6 +45,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.ServerType;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.Constants;
@@ -137,7 +138,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         new RemoteStorageInfo(""),
         ShuffleDataDistributionType.NORMAL,
         -1);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
 
     // simulator a failed server
@@ -157,10 +158,10 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         shuffleWriteClientImpl.sendShuffleData(testAppId, blocks, () -> false);
     BlockIdSet failedBlockIdBitmap = BlockIdSet.empty();
     BlockIdSet succBlockIdBitmap = BlockIdSet.empty();
-    for (Long blockId : result.getFailedBlockIds()) {
+    for (BlockId blockId : result.getFailedBlockIds()) {
       failedBlockIdBitmap.add(blockId);
     }
-    for (Long blockId : result.getSuccessBlockIds()) {
+    for (BlockId blockId : result.getSuccessBlockIds()) {
       succBlockIdBitmap.add(blockId);
     }
     // There will no failed blocks when replica=2
@@ -173,9 +174,10 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     assertFalse(commitResult);
 
     // Report will success when replica=2
-    Map<Integer, Set<Long>> ptb = Maps.newHashMap();
+    Map<Integer, Set<BlockId>> ptb = Maps.newHashMap();
     ptb.put(0, Sets.newHashSet(blockIdBitmap.stream().iterator()));
-    Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds = Maps.newHashMap();
+    Map<ShuffleServerInfo, Map<Integer, Set<BlockId>>> serverToPartitionToBlockIds =
+        Maps.newHashMap();
     serverToPartitionToBlockIds.put(shuffleServerInfo1, ptb);
     serverToPartitionToBlockIds.put(fakeShuffleServerInfo, ptb);
     shuffleWriteClientImpl.reportShuffleResult(serverToPartitionToBlockIds, testAppId, 0, 0, 2);
@@ -208,12 +210,13 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         -1);
 
-    Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds = Maps.newHashMap();
-    Map<Integer, Set<Long>> partitionToBlocks = Maps.newHashMap();
-    Set<Long> blockIds = Sets.newHashSet();
+    Map<ShuffleServerInfo, Map<Integer, Set<BlockId>>> serverToPartitionToBlockIds =
+        Maps.newHashMap();
+    Map<Integer, Set<BlockId>> partitionToBlocks = Maps.newHashMap();
+    Set<BlockId> blockIds = Sets.newHashSet();
     int partitionIdx = 1;
     for (int i = 0; i < 5; i++) {
-      blockIds.add(layout.getBlockId(i, partitionIdx, 0));
+      blockIds.add(layout.asBlockId(i, partitionIdx, 0));
     }
     partitionToBlocks.put(partitionIdx, blockIds);
     serverToPartitionToBlockIds.put(shuffleServerInfo1, partitionToBlocks);
@@ -228,7 +231,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         shuffleWriteClientImpl.getShuffleResult(
             "GRPC", Sets.newHashSet(shuffleServerInfo1), testAppId, 1, partitionIdx);
     assertEquals(5, bitmap.getLongCardinality());
-    for (Long b : partitionToBlocks.get(1)) {
+    for (BlockId b : partitionToBlocks.get(1)) {
       assertTrue(bitmap.contains(b));
     }
   }
@@ -259,19 +262,20 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = Maps.newHashMap();
     partitionToServers.putIfAbsent(1, Lists.newArrayList(shuffleServerInfo1));
     partitionToServers.putIfAbsent(2, Lists.newArrayList(shuffleServerInfo2));
-    Map<Integer, Set<Long>> partitionToBlocks1 = Maps.newHashMap();
-    Set<Long> blockIds = Sets.newHashSet();
+    Map<Integer, Set<BlockId>> partitionToBlocks1 = Maps.newHashMap();
+    Set<BlockId> blockIds = Sets.newHashSet();
     for (int i = 0; i < 5; i++) {
-      blockIds.add(layout.getBlockId(i, 1, 0));
+      blockIds.add(layout.asBlockId(i, 1, 0));
     }
     partitionToBlocks1.put(1, blockIds);
-    Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds = Maps.newHashMap();
+    Map<ShuffleServerInfo, Map<Integer, Set<BlockId>>> serverToPartitionToBlockIds =
+        Maps.newHashMap();
     serverToPartitionToBlockIds.put(shuffleServerInfo1, partitionToBlocks1);
 
-    Map<Integer, Set<Long>> partitionToBlocks2 = Maps.newHashMap();
+    Map<Integer, Set<BlockId>> partitionToBlocks2 = Maps.newHashMap();
     blockIds = Sets.newHashSet();
     for (int i = 0; i < 7; i++) {
-      blockIds.add(layout.getBlockId(i, 2, 0));
+      blockIds.add(layout.asBlockId(i, 2, 0));
     }
     partitionToBlocks2.put(2, blockIds);
     serverToPartitionToBlockIds.put(shuffleServerInfo2, partitionToBlocks2);
@@ -287,7 +291,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         shuffleWriteClientImpl.getShuffleResult(
             "GRPC", Sets.newHashSet(shuffleServerInfo1), testAppId, 1, 1);
     assertEquals(5, bitmap.getLongCardinality());
-    for (Long b : partitionToBlocks1.get(1)) {
+    for (BlockId b : partitionToBlocks1.get(1)) {
       assertTrue(bitmap.contains(b));
     }
 
@@ -310,7 +314,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         shuffleWriteClientImpl.getShuffleResult(
             "GRPC", Sets.newHashSet(shuffleServerInfo2), testAppId, 1, 2);
     assertEquals(7, bitmap.getLongCardinality());
-    for (Long b : partitionToBlocks2.get(2)) {
+    for (BlockId b : partitionToBlocks2.get(2)) {
       assertTrue(bitmap.contains(b));
     }
   }
@@ -334,7 +338,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         new RemoteStorageInfo(""),
         ShuffleDataDistributionType.NORMAL,
         -1);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
 

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RssShuffleManagerTest.java
@@ -228,11 +228,7 @@ public class RssShuffleManagerTest extends SparkIntegrationTestBase {
         BlockIdSet blockIdLongs =
             shuffleWriteClient.getShuffleResult(
                 ClientType.GRPC.name(), servers, shuffleManager.getAppId(), 0, partitionId);
-        List<BlockId> blockIds =
-            blockIdLongs.stream()
-                .sorted()
-                .mapToObj(expectedLayout::asBlockId)
-                .collect(Collectors.toList());
+        List<BlockId> blockIds = blockIdLongs.stream().sorted().collect(Collectors.toList());
         assertEquals(2, blockIds.size());
         long taskAttemptId0 = shuffleManager.getTaskAttemptIdForBlockId(0, 0);
         long taskAttemptId1 = shuffleManager.getTaskAttemptIdForBlockId(1, 0);

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/SparkClientWithLocalTest.java
@@ -156,11 +156,11 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest1";
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     createTestData(testAppId, expectedData, blockIdBitmap, taskIdBitmap, isNettyMode);
-    blockIdBitmap.add(layout.getBlockId(0, 1, 0));
+    blockIdBitmap.add(layout.asBlockId(0, 1, 0));
     ShuffleReadClientImpl readClient;
     readClient =
         baseReadBuilder(isNettyMode)
@@ -186,7 +186,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest2";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
@@ -213,7 +213,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest3";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     List<ShuffleBlockInfo> blocks =
         createShuffleBlockList(0, 0, 0, 2, 30, blockIdBitmap, expectedData, mockSSI);
@@ -250,8 +250,8 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest4";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 1)), isNettyMode);
 
-    Map<Long, byte[]> expectedData1 = Maps.newHashMap();
-    Map<Long, byte[]> expectedData2 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData1 = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData2 = Maps.newHashMap();
     BlockIdSet blockIdBitmap1 = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
@@ -312,7 +312,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
     List<ShuffleBlockInfo> blocks =
@@ -320,11 +320,12 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     sendTestData(testAppId, blocks, isNettyMode);
 
     BlockIdSet wrongBlockIdBitmap = BlockIdSet.empty();
-    Iterator<Long> iter = blockIdBitmap.stream().iterator();
+    Iterator<BlockId> iter = blockIdBitmap.stream().iterator();
     while (iter.hasNext()) {
-      BlockId blockId = layout.asBlockId(iter.next());
+      BlockId blockId = iter.next().withLayoutIfOpaque(layout);
       wrongBlockIdBitmap.add(
-          layout.getBlockId(blockId.sequenceNo, blockId.partitionId + 1, blockId.taskAttemptId));
+          layout.asBlockId(
+              blockId.getSequenceNo(), blockId.getPartitionId() + 1, blockId.getTaskAttemptId()));
     }
 
     ShuffleReadClientImpl readClient =
@@ -348,7 +349,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest7";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 1);
 
@@ -381,7 +382,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest8";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 3);
     List<ShuffleBlockInfo> blocks =
@@ -416,7 +417,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
   public void readTest9(boolean isNettyMode) throws Exception {
     String testAppId = "localReadTest9";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet blockIdBitmap = BlockIdSet.empty();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
 
@@ -462,7 +463,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     String testAppId = "localReadTest10";
     registerApp(testAppId, Lists.newArrayList(new PartitionRange(0, 0)), isNettyMode);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet expectedBlockIds = BlockIdSet.empty();
     BlockIdSet unexpectedBlockIds = BlockIdSet.empty();
     final Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0, 1);
@@ -523,7 +524,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
   private void createTestData(
       String testAppId,
-      Map<Long, byte[]> expectedData,
+      Map<BlockId, byte[]> expectedData,
       BlockIdSet blockIdBitmap,
       Roaring64NavigableMap taskIdBitmap,
       boolean isNettyMode) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleResultRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReportShuffleResultRequest.java
@@ -19,9 +19,11 @@ package org.apache.uniffle.client.request;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.proto.RssProtos;
 
 public class RssReportShuffleResultRequest {
@@ -30,13 +32,13 @@ public class RssReportShuffleResultRequest {
   private int shuffleId;
   private long taskAttemptId;
   private int bitmapNum;
-  private Map<Integer, List<Long>> partitionToBlockIds;
+  private Map<Integer, List<BlockId>> partitionToBlockIds;
 
   public RssReportShuffleResultRequest(
       String appId,
       int shuffleId,
       long taskAttemptId,
-      Map<Integer, List<Long>> partitionToBlockIds,
+      Map<Integer, List<BlockId>> partitionToBlockIds,
       int bitmapNum) {
     this.appId = appId;
     this.shuffleId = shuffleId;
@@ -61,20 +63,20 @@ public class RssReportShuffleResultRequest {
     return bitmapNum;
   }
 
-  public Map<Integer, List<Long>> getPartitionToBlockIds() {
+  public Map<Integer, List<BlockId>> getPartitionToBlockIds() {
     return partitionToBlockIds;
   }
 
   public RssProtos.ReportShuffleResultRequest toProto() {
     RssReportShuffleResultRequest request = this;
     List<RssProtos.PartitionToBlockIds> partitionToBlockIds = Lists.newArrayList();
-    for (Map.Entry<Integer, List<Long>> entry : request.getPartitionToBlockIds().entrySet()) {
-      List<Long> blockIds = entry.getValue();
+    for (Map.Entry<Integer, List<BlockId>> entry : request.getPartitionToBlockIds().entrySet()) {
+      List<BlockId> blockIds = entry.getValue();
       if (blockIds != null && !blockIds.isEmpty()) {
         partitionToBlockIds.add(
             RssProtos.PartitionToBlockIds.newBuilder()
                 .setPartitionId(entry.getKey())
-                .addAllBlockIds(entry.getValue())
+                .addAllBlockIds(blockIds.stream().map(BlockId::getBlockId).collect(Collectors.toList()))
                 .build());
       }
     }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -211,7 +211,7 @@ public class ShuffleFlushManager {
     Map<Integer, BlockIdSet> shuffleToBlockIds = committedBlockIds.get(appId);
     shuffleToBlockIds.computeIfAbsent(shuffleId, key -> BlockIdSet.empty());
     BlockIdSet blockIds = shuffleToBlockIds.get(shuffleId);
-    blockIds.addAll(blocks.stream().mapToLong(ShufflePartitionedBlock::getBlockId));
+    blockIds.addAll(blocks.stream().map(ShufflePartitionedBlock::getBlockId));
   }
 
   public BlockIdSet getCommittedBlockIds(String appId, Integer shuffleId) {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.NettyUtils;
@@ -230,7 +231,7 @@ public class ShuffleBufferManager {
   }
 
   public ShuffleDataResult getShuffleData(
-      String appId, int shuffleId, int partitionId, long blockId, int readBufferSize) {
+      String appId, int shuffleId, int partitionId, BlockId blockId, int readBufferSize) {
     return getShuffleData(appId, shuffleId, partitionId, blockId, readBufferSize, null);
   }
 
@@ -238,7 +239,7 @@ public class ShuffleBufferManager {
       String appId,
       int shuffleId,
       int partitionId,
-      long blockId,
+      BlockId blockId,
       int readBufferSize,
       Roaring64NavigableMap expectedTaskIds) {
     Map.Entry<Range<Integer>, ShuffleBuffer> entry =

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -53,6 +53,7 @@ import org.apache.uniffle.common.netty.protocol.RequestMessage;
 import org.apache.uniffle.common.netty.protocol.RpcResponse;
 import org.apache.uniffle.common.netty.protocol.SendShuffleDataRequest;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.server.ShuffleDataReadEvent;
 import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
@@ -274,7 +275,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                     appId,
                     shuffleId,
                     partitionId,
-                    blockId,
+                    new OpaqueBlockId(blockId),
                     readBufferSize,
                     req.getExpectedTaskIdsBitmap());
         ManagedBuffer data = NettyManagedBuffer.EMPTY_BUFFER;

--- a/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/KerberizedShuffleTaskManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.util.ChecksumUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.server.buffer.ShuffleBuffer;
 import org.apache.uniffle.server.buffer.ShuffleBufferManager;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;
@@ -177,7 +178,12 @@ public class KerberizedShuffleTaskManagerTest extends KerberizedHadoopBase {
       new Random().nextBytes(buf);
       blocks[i] =
           new ShufflePartitionedBlock(
-              length, length, ChecksumUtils.getCrc32(buf), ATOMIC_INT.incrementAndGet(), 0, buf);
+              length,
+              length,
+              ChecksumUtils.getCrc32(buf),
+              new OpaqueBlockId(ATOMIC_INT.incrementAndGet()),
+              0,
+              buf);
     }
     return blocks;
   }

--- a/server/src/test/java/org/apache/uniffle/server/TopNShuffleDataSizeOfAppCalcTaskTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/TopNShuffleDataSizeOfAppCalcTaskTest.java
@@ -53,6 +53,7 @@ import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.metrics.TestUtils;
 import org.apache.uniffle.common.rpc.ServerType;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -188,7 +189,7 @@ public class TopNShuffleDataSizeOfAppCalcTaskTest {
             new ShuffleBlockInfo(
                 shuffleId,
                 partitionId,
-                0,
+                new OpaqueBlockId(0),
                 length,
                 0,
                 new byte[length],

--- a/server/src/test/java/org/apache/uniffle/server/buffer/BufferTestBase.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/BufferTestBase.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.util.ChecksumUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.server.ShuffleServerMetrics;
 
 public abstract class BufferTestBase {
@@ -58,7 +59,7 @@ public abstract class BufferTestBase {
             len,
             len,
             ChecksumUtils.getCrc32(buf),
-            atomBlockId.incrementAndGet(),
+            new OpaqueBlockId(atomBlockId.incrementAndGet()),
             taskAttemptId,
             buf);
     ShufflePartitionedData data =

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferManagerTest.java
@@ -42,8 +42,8 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedData;
 import org.apache.uniffle.common.config.ConfigUtils;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ByteBufUtils;
-import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.server.DefaultFlushEventHandler;
 import org.apache.uniffle.server.ShuffleFlushManager;
 import org.apache.uniffle.server.ShuffleServer;
@@ -137,13 +137,13 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     /** case1: all blocks in cached and read multiple times */
     ShuffleDataResult result =
         shuffleBufferManager.getShuffleData(
-            appId, 1, 0, Constants.INVALID_BLOCK_ID, 60, Roaring64NavigableMap.bitmapOf(1));
+            appId, 1, 0, null, 60, Roaring64NavigableMap.bitmapOf(1));
     assertEquals(1, result.getBufferSegments().size());
     assertEquals(0, result.getBufferSegments().get(0).getOffset());
     assertEquals(68, result.getBufferSegments().get(0).getLength());
 
     // 2nd read
-    long lastBlockId = result.getBufferSegments().get(0).getBlockId();
+    BlockId lastBlockId = result.getBufferSegments().get(0).getBlockId();
     result =
         shuffleBufferManager.getShuffleData(
             appId, 1, 0, lastBlockId, 60, Roaring64NavigableMap.bitmapOf(1));
@@ -178,10 +178,9 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     assertEquals(200, bufferPool.get(appId).get(2).get(0).getSize());
     assertEquals(100, bufferPool.get(appId).get(3).get(0).getSize());
     // validate get shuffle data
-    ShuffleDataResult sdr =
-        shuffleBufferManager.getShuffleData(appId, 2, 0, Constants.INVALID_BLOCK_ID, 60);
+    ShuffleDataResult sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, null, 60);
     assertArrayEquals(ByteBufUtils.readBytes(spd2.getBlockList()[0].getData()), sdr.getData());
-    long lastBlockId = spd2.getBlockList()[0].getBlockId();
+    BlockId lastBlockId = spd2.getBlockList()[0].getBlockId();
     sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, lastBlockId, 100);
     assertArrayEquals(ByteBufUtils.readBytes(spd3.getBlockList()[0].getData()), sdr.getData());
     // flush happen
@@ -197,7 +196,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     // keep buffer whose size < low watermark
     assertEquals(1, bufferPool.get(appId).get(4).get(0).getBlocks().size());
     // data in flush buffer now, it also can be got before flush finish
-    sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, Constants.INVALID_BLOCK_ID, 60);
+    sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, null, 60);
     assertArrayEquals(ByteBufUtils.readBytes(spd2.getBlockList()[0].getData()), sdr.getData());
     lastBlockId = spd2.getBlockList()[0].getBlockId();
     sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, lastBlockId, 100);
@@ -211,7 +210,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
     bufferPool.get(appId).get(2).get(0).getInFlushBlockMap().clear();
     bufferPool.get(appId).get(3).get(0).getInFlushBlockMap().clear();
     // empty data return
-    sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, Constants.INVALID_BLOCK_ID, 60);
+    sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, null, 60);
     assertEquals(0, sdr.getDataLength());
     lastBlockId = spd2.getBlockList()[0].getBlockId();
     sdr = shuffleBufferManager.getShuffleData(appId, 2, 0, lastBlockId, 100);

--- a/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/HybridStorageManagerTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.common.HadoopStorage;
@@ -35,6 +37,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HybridStorageManagerTest {
+  private final BlockId blockId = new OpaqueBlockId(1);
 
   /**
    * this tests the fallback strategy when encountering the local storage is invalid. 1. When
@@ -67,7 +70,7 @@ public class HybridStorageManagerTest {
     String appId = "selectStorageManagerWithSelectorAndFallbackStrategy_appId";
     manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     assertTrue((manager.selectStorage(event) instanceof HadoopStorage));
@@ -97,7 +100,7 @@ public class HybridStorageManagerTest {
     String appId = "selectStorageManagerTest_appId";
     manager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     assertTrue((manager.selectStorage(event) instanceof LocalStorage));
@@ -130,7 +133,7 @@ public class HybridStorageManagerTest {
      * is enabled.
      */
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(10001, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(10001, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 100000, blocks, null, null);
     Storage storage = manager.selectStorage(event);
@@ -161,13 +164,14 @@ public class HybridStorageManagerTest {
 
     /** case1: big event should be written into cold storage directly */
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(10001, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(10001, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent hugeEvent =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 10001, blocks, null, null);
     assertTrue(manager.selectStorage(hugeEvent) instanceof HadoopStorage);
 
     /** case2: fallback when disk can not write */
-    blocks = Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+    blocks =
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     Storage storage = manager.selectStorage(event);

--- a/server/src/test/java/org/apache/uniffle/server/storage/StorageManagerFallbackStrategyTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/storage/StorageManagerFallbackStrategyTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class StorageManagerFallbackStrategyTest {
   private ShuffleServerConf conf;
+  private final BlockId blockId = new OpaqueBlockId(1);
 
   @BeforeEach
   public void prepare() {
@@ -56,7 +59,7 @@ public class StorageManagerFallbackStrategyTest {
     String appId = "testDefaultFallbackStrategy_appId";
     coldStorageManager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     event.increaseRetryTimes();
@@ -98,7 +101,7 @@ public class StorageManagerFallbackStrategyTest {
     String appId = "testHdfsFallbackStrategy_appId";
     coldStorageManager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     event.increaseRetryTimes();
@@ -123,7 +126,7 @@ public class StorageManagerFallbackStrategyTest {
     String appId = "testLocalFallbackStrategy_appId";
     coldStorageManager.registerRemoteStorage(appId, new RemoteStorageInfo(remoteStorage));
     List<ShufflePartitionedBlock> blocks =
-        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, 1, 1L, (byte[]) null));
+        Lists.newArrayList(new ShufflePartitionedBlock(100, 1000, 1, blockId, 1L, (byte[]) null));
     ShuffleDataFlushEvent event =
         new ShuffleDataFlushEvent(1, appId, 1, 1, 1, 1000, blocks, null, null);
     event.increaseRetryTimes();

--- a/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
@@ -19,6 +19,8 @@ package org.apache.uniffle.storage.common;
 
 import java.util.Objects;
 
+import org.apache.uniffle.common.util.BlockId;
+
 public class FileBasedShuffleSegment extends ShuffleSegment
     implements Comparable<FileBasedShuffleSegment> {
 
@@ -27,11 +29,16 @@ public class FileBasedShuffleSegment extends ShuffleSegment
   private int length;
   private int uncompressLength;
   private long crc;
-  private long blockId;
+  private BlockId blockId;
   private long taskAttemptId;
 
   public FileBasedShuffleSegment(
-      long blockId, long offset, int length, int uncompressLength, long crc, long taskAttemptId) {
+      BlockId blockId,
+      long offset,
+      int length,
+      int uncompressLength,
+      long crc,
+      long taskAttemptId) {
     this.offset = offset;
     this.length = length;
     this.uncompressLength = uncompressLength;
@@ -60,11 +67,11 @@ public class FileBasedShuffleSegment extends ShuffleSegment
     return crc;
   }
 
-  public long getBlockId() {
+  public BlockId getBlockId() {
     return blockId;
   }
 
-  public void setBlockId(long blockId) {
+  public void setBlockId(BlockId blockId) {
     this.blockId = blockId;
   }
 
@@ -88,7 +95,7 @@ public class FileBasedShuffleSegment extends ShuffleSegment
     return offset == that.offset
         && length == that.length
         && crc == that.crc
-        && blockId == that.blockId
+        && blockId.equals(that.blockId)
         && uncompressLength == that.uncompressLength
         && taskAttemptId == that.taskAttemptId;
   }
@@ -119,9 +126,9 @@ public class FileBasedShuffleSegment extends ShuffleSegment
         + uncompressLength
         + "], crc["
         + crc
-        + "], blockid["
+        + "], "
         + blockId
-        + "], taskAttemptId["
+        + ", taskAttemptId["
         + taskAttemptId
         + "]}";
   }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataFileSegment.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataFileSegment.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.util.BlockId;
 
 public class DataFileSegment extends FileSegment {
 
@@ -37,8 +38,8 @@ public class DataFileSegment extends FileSegment {
     return bufferSegments;
   }
 
-  public Set<Long> getBlockIds() {
-    Set<Long> blockIds = Sets.newHashSet();
+  public Set<BlockId> getBlockIds() {
+    Set<BlockId> blockIds = Sets.newHashSet();
     for (BufferSegment bs : bufferSegments) {
       blockIds.add(bs.getBlockId());
     }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
@@ -90,8 +90,7 @@ public abstract class DataSkippableReadHandler extends AbstractClientReadHandler
     while (segmentIndex < shuffleDataSegments.size()) {
       ShuffleDataSegment segment = shuffleDataSegments.get(segmentIndex);
       BlockIdSet blocksOfSegment = BlockIdSet.empty();
-      blocksOfSegment.addAll(
-          segment.getBufferSegments().stream().mapToLong(BufferSegment::getBlockId));
+      blocksOfSegment.addAll(segment.getBufferSegments().stream().map(BufferSegment::getBlockId));
       // skip unexpected blockIds
       blocksOfSegment.retainAll(expectBlockIds);
       if (!blocksOfSegment.isEmpty()) {

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriter.java
@@ -99,7 +99,7 @@ public class HadoopFileWriter implements FileWriter, Closeable {
     fsDataOutputStream.writeInt(segment.getLength());
     fsDataOutputStream.writeInt(segment.getUncompressLength());
     fsDataOutputStream.writeLong(segment.getCrc());
-    fsDataOutputStream.writeLong(segment.getBlockId());
+    fsDataOutputStream.writeLong(segment.getBlockId().getBlockId());
     fsDataOutputStream.writeLong(segment.getTaskAttemptId());
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleWriteHandler.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.filesystem.HadoopFilesystemProvider;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
@@ -123,7 +124,7 @@ public class HadoopShuffleWriteHandler implements ShuffleWriteHandler {
       try (HadoopFileWriter dataWriter = createWriter(dataFileName);
           HadoopFileWriter indexWriter = createWriter(indexFileName)) {
         for (ShufflePartitionedBlock block : shuffleBlocks) {
-          long blockId = block.getBlockId();
+          BlockId blockId = block.getBlockId();
           long crc = block.getCrc();
           long startOffset = dataWriter.nextOffset();
           dataWriter.writeData(ByteBufUtils.readBytes(block.getData()));

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
@@ -100,7 +101,7 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
 
       long startTime = System.currentTimeMillis();
       for (ShufflePartitionedBlock block : shuffleBlocks) {
-        long blockId = block.getBlockId();
+        BlockId blockId = block.getBlockId();
         long crc = block.getCrc();
         long startOffset = dataWriter.nextOffset();
         dataWriter.writeData(ByteBufUtils.readBytes(block.getData()));

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
@@ -52,7 +52,7 @@ public class LocalFileWriter implements FileWriter, Closeable {
     dataOutputStream.writeInt(segment.getLength());
     dataOutputStream.writeInt(segment.getUncompressLength());
     dataOutputStream.writeLong(segment.getCrc());
-    dataOutputStream.writeLong(segment.getBlockId());
+    dataOutputStream.writeLong(segment.getBlockId().getBlockId());
     dataOutputStream.writeLong(segment.getTaskAttemptId());
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MemoryClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MemoryClientReadHandler.java
@@ -30,12 +30,13 @@ import org.apache.uniffle.client.response.RssGetInMemoryShuffleDataResponse;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.Constants;
 
 public class MemoryClientReadHandler extends AbstractClientReadHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(MemoryClientReadHandler.class);
-  private long lastBlockId = Constants.INVALID_BLOCK_ID;
+  private BlockId lastBlockId = null;
   private ShuffleServerClient shuffleServerClient;
   private Roaring64NavigableMap expectTaskIds;
   private int retryMax;
@@ -74,6 +75,10 @@ public class MemoryClientReadHandler extends AbstractClientReadHandler {
   @Override
   public ShuffleDataResult readShuffleData() {
     ShuffleDataResult result = null;
+    long lastBlockId = Constants.INVALID_BLOCK_ID;
+    if (this.lastBlockId != null) {
+      lastBlockId = this.lastBlockId.getBlockId();
+    }
 
     RssGetInMemoryShuffleDataRequest request =
         new RssGetInMemoryShuffleDataRequest(
@@ -101,7 +106,7 @@ public class MemoryClientReadHandler extends AbstractClientReadHandler {
     // update lastBlockId for next rpc call
     if (!result.isEmpty()) {
       List<BufferSegment> bufferSegments = result.getBufferSegments();
-      lastBlockId = bufferSegments.get(bufferSegments.size() - 1).getBlockId();
+      this.lastBlockId = bufferSegments.get(bufferSegments.size() - 1).getBlockId();
     }
 
     return result;

--- a/storage/src/test/java/org/apache/uniffle/storage/HadoopShuffleHandlerTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HadoopShuffleHandlerTestBase.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ByteBufUtils;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -50,14 +51,14 @@ public class HadoopShuffleHandlerTestBase {
       int num,
       int length,
       long taskAttemptId,
-      Map<Long, byte[]> expectedData)
+      Map<BlockId, byte[]> expectedData)
       throws Exception {
     List<ShufflePartitionedBlock> blocks = Lists.newArrayList();
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
       BlockIdLayout layout = BlockIdLayout.DEFAULT;
-      long blockId = layout.getBlockId(ATOMIC_INT.getAndIncrement(), 0, taskAttemptId);
+      BlockId blockId = layout.asBlockId(ATOMIC_INT.getAndIncrement(), 0, taskAttemptId);
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -72,7 +73,7 @@ public class HadoopShuffleHandlerTestBase {
       int num,
       int length,
       long taskAttemptId,
-      Map<Long, byte[]> expectedData,
+      Map<BlockId, byte[]> expectedData,
       Map<Integer, List<ShufflePartitionedBlock>> expectedBlocks,
       Map<Integer, List<FileBasedShuffleSegment>> expectedIndexSegments,
       boolean doWrite)
@@ -83,7 +84,7 @@ public class HadoopShuffleHandlerTestBase {
     for (int i = 0; i < num; i++) {
       byte[] buf = new byte[length];
       new Random().nextBytes(buf);
-      long blockId = layout.getBlockId(ATOMIC_INT.getAndIncrement(), 0, taskAttemptId);
+      BlockId blockId = layout.asBlockId(ATOMIC_INT.getAndIncrement(), 0, taskAttemptId);
       blocks.add(
           new ShufflePartitionedBlock(
               length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -135,7 +136,7 @@ public class HadoopShuffleHandlerTestBase {
   }
 
   public static void checkData(
-      ShuffleDataResult shuffleDataResult, Map<Long, byte[]> expectedData) {
+      ShuffleDataResult shuffleDataResult, Map<BlockId, byte[]> expectedData) {
 
     byte[] buffer = shuffleDataResult.getData();
     List<BufferSegment> bufferSegments = shuffleDataResult.getBufferSegments();

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopClientReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopClientReadHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleIndexResult;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.storage.HadoopTestBase;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
@@ -51,7 +52,7 @@ public class HadoopClientReadHandlerTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, "test", hadoopConf, writeUser);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     BlockIdSet expectBlockIds = BlockIdSet.empty();
 
     int readBufferSize = 13;
@@ -108,7 +109,7 @@ public class HadoopClientReadHandlerTest extends HadoopTestBase {
             processBlockIds,
             basePath,
             hadoopConf);
-    Set<Long> actualBlockIds = Sets.newHashSet();
+    Set<BlockId> actualBlockIds = Sets.newHashSet();
 
     for (int i = 0; i < total; ++i) {
       ShuffleDataResult shuffleDataResult = handler.readShuffleData();

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopFileReaderTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopFileReaderTest.java
@@ -24,7 +24,9 @@ import java.util.Random;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.ChecksumUtils;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.storage.HadoopTestBase;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HadoopFileReaderTest extends HadoopTestBase {
+  private static final BlockId blockId = new OpaqueBlockId(23);
 
   @Test
   public void createStreamTest() throws Exception {
@@ -71,7 +74,7 @@ public class HadoopFileReaderTest extends HadoopTestBase {
       writer.writeData(data);
     }
     FileBasedShuffleSegment segment =
-        new FileBasedShuffleSegment(23, offset, length, length, 0xdeadbeef, 1);
+        new FileBasedShuffleSegment(blockId, offset, length, length, 0xdeadbeef, 1);
     try (HadoopFileReader reader = new HadoopFileReader(path, conf)) {
       byte[] actual = reader.read(segment.getOffset(), segment.getLength());
       long crc22 = ChecksumUtils.getCrc32(actual);
@@ -81,7 +84,7 @@ public class HadoopFileReaderTest extends HadoopTestBase {
       }
       assertEquals(crc11, crc22);
       // EOF exception is expected
-      segment = new FileBasedShuffleSegment(23, offset * 2, length, length, 1, 1);
+      segment = new FileBasedShuffleSegment(blockId, offset * 2, length, length, 1, 1);
       assertEquals(0, reader.read(segment.getOffset(), segment.getLength()).length);
     }
   }

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriterTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.storage.HadoopTestBase;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
@@ -147,7 +148,8 @@ public class HadoopFileWriterTest extends HadoopTestBase {
 
   @Test
   public void writeSegmentTest() throws IOException {
-    FileBasedShuffleSegment segment = new FileBasedShuffleSegment(23, 128, 32, 32, 0xdeadbeef, 0);
+    FileBasedShuffleSegment segment =
+        new FileBasedShuffleSegment(new OpaqueBlockId(23), 128, 32, 32, 0xdeadbeef, 0);
 
     Path path = new Path(HDFS_URI, "writeSegmentTest");
     try (HadoopFileWriter writer = new HadoopFileWriter(fs, path, conf)) {

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopHandlerTest.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.api.Test;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.storage.HadoopTestBase;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
@@ -54,7 +56,7 @@ public class HadoopHandlerTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 1, 1, 1, basePath, "test", conf);
     List<ShufflePartitionedBlock> blocks = new LinkedList<>();
-    List<Long> expectedBlockId = new LinkedList<>();
+    List<BlockId> expectedBlockId = new LinkedList<>();
     List<byte[]> expectedData = new LinkedList<>();
     List<FileBasedShuffleSegment> expectedIndex = new LinkedList<>();
 
@@ -63,9 +65,10 @@ public class HadoopHandlerTest extends HadoopTestBase {
       byte[] buf = new byte[i * 8];
       new Random().nextBytes(buf);
       expectedData.add(buf);
-      blocks.add(new ShufflePartitionedBlock(i * 8, i * 8, i, i, 0, buf));
-      expectedBlockId.add(Long.valueOf(i));
-      expectedIndex.add(new FileBasedShuffleSegment(i, pos, i * 8, i * 8, i, 0));
+      blocks.add(new ShufflePartitionedBlock(i * 8, i * 8, i, new OpaqueBlockId(i), 0, buf));
+      BlockId blockId = new OpaqueBlockId(i);
+      expectedBlockId.add(blockId);
+      expectedIndex.add(new FileBasedShuffleSegment(blockId, pos, i * 8, i * 8, i, 0));
       pos += i * 8;
     }
     writeHandler.write(blocks);
@@ -78,9 +81,10 @@ public class HadoopHandlerTest extends HadoopTestBase {
       byte[] buf = new byte[i * 8];
       new Random().nextBytes(buf);
       expectedData.add(buf);
-      expectedBlockId.add(Long.valueOf(i));
-      blocksAppend.add(new ShufflePartitionedBlock(i * 8, i * 8, i, i, i, buf));
-      expectedIndex.add(new FileBasedShuffleSegment(i, pos, i * 8, i * 8, i, i));
+      BlockId blockId = new OpaqueBlockId(i);
+      expectedBlockId.add(blockId);
+      blocksAppend.add(new ShufflePartitionedBlock(i * 8, i * 8, i, new OpaqueBlockId(i), i, buf));
+      expectedIndex.add(new FileBasedShuffleSegment(blockId, pos, i * 8, i * 8, i, i));
       pos += i * 8;
     }
     writeHandler = new HadoopShuffleWriteHandler("appId", 1, 1, 1, basePath, "test", conf);
@@ -95,11 +99,11 @@ public class HadoopHandlerTest extends HadoopTestBase {
       int partitionId,
       String basePath,
       List<byte[]> expectedData,
-      List<Long> expectedBlockId)
+      List<BlockId> expectedBlockId)
       throws IllegalStateException {
     BlockIdSet expectBlockIds = BlockIdSet.empty();
     BlockIdSet processBlockIds = BlockIdSet.empty();
-    for (long blockId : expectedBlockId) {
+    for (BlockId blockId : expectedBlockId) {
       expectBlockIds.add(blockId);
     }
     // read directly and compare
@@ -124,7 +128,7 @@ public class HadoopHandlerTest extends HadoopTestBase {
     }
   }
 
-  private List<ByteBuffer> readData(HadoopClientReadHandler handler, Set<Long> blockIds)
+  private List<ByteBuffer> readData(HadoopClientReadHandler handler, Set<BlockId> blockIds)
       throws IllegalStateException {
     ShuffleDataResult sdr = handler.readShuffleData();
     List<BufferSegment> bufferSegments = sdr.getBufferSegments();

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -54,7 +55,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
     HadoopShuffleWriteHandler writeHandler =
         new HadoopShuffleWriteHandler("appId", 0, 1, 1, basePath, "test", conf, user);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
 
     int readBufferSize = 13;
     int totalBlockNum = 0;
@@ -76,7 +77,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
         new HadoopShuffleReadHandler(
             "appId", 0, 1, fileNamePrefix, readBufferSize, expectBlockIds, processBlockIds, conf);
 
-    Set<Long> actualBlockIds = Sets.newHashSet();
+    Set<BlockId> actualBlockIds = Sets.newHashSet();
     for (int i = 0; i < total; ++i) {
       ShuffleDataResult shuffleDataResult = handler.readShuffleData();
       totalBlockNum += shuffleDataResult.getBufferSegments().size();
@@ -104,7 +105,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
         new TestHadoopShuffleWriteHandler(
             "appId", 0, 1, 1, basePath, "test", conf, StringUtils.EMPTY);
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     int totalBlockNum = 0;
     int expectTotalBlockNum = 6;
     int blockSize = 7;
@@ -119,7 +120,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
     byte[] buf = new byte[blockSize];
     new Random().nextBytes(buf);
     BlockIdLayout layout = BlockIdLayout.DEFAULT;
-    long blockId = layout.getBlockId(expectTotalBlockNum, 0, taskAttemptId);
+    BlockId blockId = layout.asBlockId(expectTotalBlockNum, 0, taskAttemptId);
     blocks.add(
         new ShufflePartitionedBlock(
             blockSize, blockSize, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
@@ -140,7 +141,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
         new HadoopShuffleReadHandler(
             "appId", 0, 1, fileNamePrefix, readBufferSize, expectBlockIds, processBlockIds, conf);
 
-    Set<Long> actualBlockIds = Sets.newHashSet();
+    Set<BlockId> actualBlockIds = Sets.newHashSet();
     for (int i = 0; i < total; ++i) {
       ShuffleDataResult shuffleDataResult = handler.readShuffleData();
       totalBlockNum += shuffleDataResult.getBufferSegments().size();
@@ -204,7 +205,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
               ShuffleStorageUtils.generateIndexFileName(fileNamePrefix + "_" + failTimes);
           indexWriter = createWriter(indexFileName);
           for (ShufflePartitionedBlock block : shuffleBlocks) {
-            long blockId = block.getBlockId();
+            BlockId blockId = block.getBlockId();
             long crc = block.getCrc();
             long startOffset = indexWriter.nextOffset();
 

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShuffleIndexResult;
 import org.apache.uniffle.common.config.RssBaseConf;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,9 +60,9 @@ public class LocalFileHandlerTest {
         writeHandler1.getBasePath().endsWith(possiblePath1)
             || writeHandler1.getBasePath().endsWith(possiblePath2));
 
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
-    final Set<Long> expectedBlockIds1 = Sets.newHashSet();
-    final Set<Long> expectedBlockIds2 = Sets.newHashSet();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
+    final Set<BlockId> expectedBlockIds1 = Sets.newHashSet();
+    final Set<BlockId> expectedBlockIds2 = Sets.newHashSet();
 
     LocalFileHandlerTestBase.writeTestData(
         LocalFileHandlerTestBase.generateBlocks(1, 32),

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/LocalFileServerReadHandlerTest.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.common.ShuffleDataResult;
 import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.rpc.StatusCode;
+import org.apache.uniffle.common.util.BlockId;
 import org.apache.uniffle.common.util.BlockIdSet;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
@@ -45,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class LocalFileServerReadHandlerTest {
   @Test
   public void testDataInconsistent() throws Exception {
-    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Map<BlockId, byte[]> expectedData = Maps.newHashMap();
     int expectTotalBlockNum = 4;
     int blockSize = 7;
 
@@ -95,7 +96,7 @@ public class LocalFileServerReadHandlerTest {
 
     int readBufferSize = 13;
     int bytesPerSegment = ((readBufferSize / blockSize) + 1) * blockSize;
-    List<Long> actualWriteBlockIds =
+    List<BlockId> actualWriteBlockIds =
         blocks.stream()
             .map(ShufflePartitionedBlock::getBlockId)
             .limit(actualWriteDataBlock)

--- a/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleStorageUtilsTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/util/ShuffleStorageUtilsTest.java
@@ -25,6 +25,8 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 import org.apache.uniffle.common.BufferSegment;
+import org.apache.uniffle.common.util.BlockId;
+import org.apache.uniffle.common.util.OpaqueBlockId;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 import org.apache.uniffle.storage.handler.impl.DataFileSegment;
 
@@ -33,11 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleStorageUtilsTest {
+  private BlockId blockId(long blockId) {
+    return new OpaqueBlockId(blockId);
+  }
 
   @Test
   public void mergeSegmentsTest() {
     List<FileBasedShuffleSegment> segments =
-        Lists.newArrayList(new FileBasedShuffleSegment(1, 0, 40, 0, 0, 0));
+        Lists.newArrayList(new FileBasedShuffleSegment(blockId(1), 0, 40, 0, 0, 0));
     List<DataFileSegment> fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(1, fileSegments.size());
     for (DataFileSegment seg : fileSegments) {
@@ -46,14 +51,14 @@ public class ShuffleStorageUtilsTest {
       assertEquals("path", seg.getPath());
       List<BufferSegment> bufferSegments = seg.getBufferSegments();
       assertEquals(1, bufferSegments.size());
-      assertEquals(new BufferSegment(1, 0, 40, 0, 0, 0), bufferSegments.get(0));
+      assertEquals(new BufferSegment(blockId(1), 0, 40, 0, 0, 0), bufferSegments.get(0));
     }
 
     segments =
         Lists.newArrayList(
-            new FileBasedShuffleSegment(1, 0, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(2, 40, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(3, 80, 20, 0, 0, 0));
+            new FileBasedShuffleSegment(blockId(1), 0, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(2), 40, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(3), 80, 20, 0, 0, 0));
     fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(1, fileSegments.size());
     for (DataFileSegment seg : fileSegments) {
@@ -64,14 +69,14 @@ public class ShuffleStorageUtilsTest {
       assertEquals(3, bufferSegments.size());
       Set<Long> testedBlockIds = Sets.newHashSet();
       for (BufferSegment segment : bufferSegments) {
-        if (segment.getBlockId() == 1) {
-          assertTrue(segment.equals(new BufferSegment(1, 0, 40, 0, 0, 0)));
+        if (segment.getBlockId().equals(blockId(1))) {
+          assertTrue(segment.equals(new BufferSegment(blockId(1), 0, 40, 0, 0, 0)));
           testedBlockIds.add(1L);
-        } else if (segment.getBlockId() == 2) {
-          assertTrue(segment.equals(new BufferSegment(2, 40, 40, 0, 0, 0)));
+        } else if (segment.getBlockId().equals(blockId(2))) {
+          assertTrue(segment.equals(new BufferSegment(blockId(2), 40, 40, 0, 0, 0)));
           testedBlockIds.add(2L);
-        } else if (segment.getBlockId() == 3) {
-          assertTrue(segment.equals(new BufferSegment(3, 80, 20, 0, 0, 0)));
+        } else if (segment.getBlockId().equals(blockId(3))) {
+          assertTrue(segment.equals(new BufferSegment(blockId(3), 80, 20, 0, 0, 0)));
           testedBlockIds.add(3L);
         }
       }
@@ -80,10 +85,10 @@ public class ShuffleStorageUtilsTest {
 
     segments =
         Lists.newArrayList(
-            new FileBasedShuffleSegment(1, 0, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(2, 40, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(3, 80, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(4, 100, 20, 0, 0, 0));
+            new FileBasedShuffleSegment(blockId(1), 0, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(2), 40, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(3), 80, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(4), 100, 20, 0, 0, 0));
     fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(2, fileSegments.size());
     boolean tested = false;
@@ -94,18 +99,18 @@ public class ShuffleStorageUtilsTest {
         assertEquals("path", seg.getPath());
         List<BufferSegment> bufferSegments = seg.getBufferSegments();
         assertEquals(1, bufferSegments.size());
-        assertTrue(bufferSegments.get(0).equals(new BufferSegment(4, 0, 20, 0, 0, 0)));
+        assertTrue(bufferSegments.get(0).equals(new BufferSegment(blockId(4), 0, 20, 0, 0, 0)));
       }
     }
     assertTrue(tested);
 
     segments =
         Lists.newArrayList(
-            new FileBasedShuffleSegment(1, 0, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(2, 40, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(3, 80, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(4, 100, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(5, 120, 100, 0, 0, 0));
+            new FileBasedShuffleSegment(blockId(1), 0, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(2), 40, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(3), 80, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(4), 100, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(5), 120, 100, 0, 0, 0));
     fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(2, fileSegments.size());
     tested = false;
@@ -118,11 +123,11 @@ public class ShuffleStorageUtilsTest {
         assertEquals(2, bufferSegments.size());
         Set<Long> testedBlockIds = Sets.newHashSet();
         for (BufferSegment segment : bufferSegments) {
-          if (segment.getBlockId() == 4) {
-            assertTrue(segment.equals(new BufferSegment(4, 0, 20, 0, 0, 0)));
+          if (segment.getBlockId().equals(blockId(4))) {
+            assertTrue(segment.equals(new BufferSegment(blockId(4), 0, 20, 0, 0, 0)));
             testedBlockIds.add(4L);
-          } else if (segment.getBlockId() == 5) {
-            assertTrue(segment.equals(new BufferSegment(5, 20, 100, 0, 0, 0)));
+          } else if (segment.getBlockId().equals(blockId(5))) {
+            assertTrue(segment.equals(new BufferSegment(blockId(5), 20, 100, 0, 0, 0)));
             testedBlockIds.add(5L);
           }
         }
@@ -133,30 +138,30 @@ public class ShuffleStorageUtilsTest {
 
     segments =
         Lists.newArrayList(
-            new FileBasedShuffleSegment(1, 10, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(2, 80, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(3, 500, 120, 0, 0, 0),
-            new FileBasedShuffleSegment(4, 700, 20, 0, 0, 0));
+            new FileBasedShuffleSegment(blockId(1), 10, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(2), 80, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(3), 500, 120, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(4), 700, 20, 0, 0, 0));
     fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(3, fileSegments.size());
     Set<Long> expectedOffset = Sets.newHashSet(10L, 500L, 700L);
     for (DataFileSegment seg : fileSegments) {
       if (seg.getOffset() == 10) {
-        validResult(seg, 90, 1, 40, 2, 70);
+        validResult(seg, 90, blockId(1), 40, blockId(2), 70);
         expectedOffset.remove(10L);
       }
       if (seg.getOffset() == 500) {
         assertEquals(120, seg.getLength());
         List<BufferSegment> bufferSegments = seg.getBufferSegments();
         assertEquals(1, bufferSegments.size());
-        assertTrue(bufferSegments.get(0).equals(new BufferSegment(3, 0, 120, 0, 0, 0)));
+        assertTrue(bufferSegments.get(0).equals(new BufferSegment(blockId(3), 0, 120, 0, 0, 0)));
         expectedOffset.remove(500L);
       }
       if (seg.getOffset() == 700) {
         assertEquals(20, seg.getLength());
         List<BufferSegment> bufferSegments = seg.getBufferSegments();
         assertEquals(1, bufferSegments.size());
-        assertTrue(bufferSegments.get(0).equals(new BufferSegment(4, 0, 20, 0, 0, 0)));
+        assertTrue(bufferSegments.get(0).equals(new BufferSegment(blockId(4), 0, 20, 0, 0, 0)));
         expectedOffset.remove(700L);
       }
     }
@@ -164,36 +169,36 @@ public class ShuffleStorageUtilsTest {
 
     segments =
         Lists.newArrayList(
-            new FileBasedShuffleSegment(5, 500, 120, 0, 0, 0),
-            new FileBasedShuffleSegment(3, 630, 10, 0, 0, 0),
-            new FileBasedShuffleSegment(2, 80, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(1, 10, 40, 0, 0, 0),
-            new FileBasedShuffleSegment(6, 769, 20, 0, 0, 0),
-            new FileBasedShuffleSegment(4, 700, 20, 0, 0, 0));
+            new FileBasedShuffleSegment(blockId(5), 500, 120, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(3), 630, 10, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(2), 80, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(1), 10, 40, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(6), 769, 20, 0, 0, 0),
+            new FileBasedShuffleSegment(blockId(4), 700, 20, 0, 0, 0));
     fileSegments = ShuffleStorageUtils.mergeSegments("path", segments, 100);
     assertEquals(4, fileSegments.size());
     expectedOffset = Sets.newHashSet(10L, 500L, 630L, 700L);
     for (DataFileSegment seg : fileSegments) {
       if (seg.getOffset() == 10) {
-        validResult(seg, 90, 1, 40, 2, 70);
+        validResult(seg, 90, blockId(1), 40, blockId(2), 70);
         expectedOffset.remove(10L);
       }
       if (seg.getOffset() == 500) {
         assertEquals(120, seg.getLength());
         List<BufferSegment> bufferSegments = seg.getBufferSegments();
         assertEquals(1, bufferSegments.size());
-        assertTrue(bufferSegments.get(0).equals(new BufferSegment(5, 0, 120, 0, 0, 0)));
+        assertTrue(bufferSegments.get(0).equals(new BufferSegment(blockId(5), 0, 120, 0, 0, 0)));
         expectedOffset.remove(500L);
       }
       if (seg.getOffset() == 630) {
         assertEquals(10, seg.getLength());
         List<BufferSegment> bufferSegments = seg.getBufferSegments();
         assertEquals(1, bufferSegments.size());
-        assertTrue(bufferSegments.get(0).equals(new BufferSegment(3, 0, 10, 0, 0, 0)));
+        assertTrue(bufferSegments.get(0).equals(new BufferSegment(blockId(3), 0, 10, 0, 0, 0)));
         expectedOffset.remove(630L);
       }
       if (seg.getOffset() == 700) {
-        validResult(seg, 89, 4, 20, 6, 69);
+        validResult(seg, 89, blockId(4), 20, blockId(6), 69);
         expectedOffset.remove(700L);
       }
     }
@@ -203,21 +208,21 @@ public class ShuffleStorageUtilsTest {
   private void validResult(
       DataFileSegment seg,
       int length,
-      int someBlockId,
+      BlockId someBlockId,
       int someLength,
-      int anotherBlockId,
+      BlockId anotherBlockId,
       int anotherOffset) {
     assertEquals(length, seg.getLength());
     List<BufferSegment> bufferSegments = seg.getBufferSegments();
     assertEquals(2, bufferSegments.size());
-    Set<Long> testedBlockIds = Sets.newHashSet();
+    Set<BlockId> testedBlockIds = Sets.newHashSet();
     for (BufferSegment segment : bufferSegments) {
-      if (segment.getBlockId() == someBlockId) {
+      if (segment.getBlockId().equals(someBlockId)) {
         assertTrue(segment.equals(new BufferSegment(someBlockId, 0, someLength, 0, 0, 0)));
-        testedBlockIds.add((long) someBlockId);
-      } else if (segment.getBlockId() == anotherBlockId) {
+        testedBlockIds.add(someBlockId);
+      } else if (segment.getBlockId().equals(anotherBlockId)) {
         assertTrue(segment.equals(new BufferSegment(anotherBlockId, anotherOffset, 20, 0, 0, 0)));
-        testedBlockIds.add((long) anotherBlockId);
+        testedBlockIds.add(anotherBlockId);
       }
     }
     assertEquals(2, testedBlockIds.size());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hides the `long` block id behind an interface.

### Why are the changes needed?

This hides implementation details behind a meaningful interface. The `long` representation of a block id is not use in many places but currently visible everywhere. This allows to replace the block id representation in the future without touching much code.

This is based on #1723 (block id set) and makes turns the set of longs into a true set of `BlockId`s.

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit and integration tests.