### PR TITLE
fix(client): MultiException class not found when reassign or stag retry is enabled 

### DIFF
--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -68,6 +68,7 @@
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>org.roaringbitmap:shims</include>
+                  <include>org.eclipse.jetty:jetty-util</include>
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}</finalName>
@@ -122,6 +123,10 @@
                 <relocation>
                   <pattern>org.roaringbitmap</pattern>
                   <shadedPattern>${rss.shade.packageName}.org.roaringbitmap</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.eclipse.jetty</pattern>
+                  <shadedPattern>${rss.shade.packageName}.org.eclipse.jetty</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

include jetty-util and shade it

### Why are the changes needed?
When reassign or stag retry is enabled, GrpcServer needs to be started. If there is a port conflict during startup and retry is performed, MultiException will be thrown and the following exception will occur, causing the job to fail.The root cause is that uniffle did not include jetty-util related packages.

`ERROR [main] SparkSubmit$$anon$2: spark submit throw error: org/eclipse/jetty/util/MultiException
java.lang.NoClassDefFoundError: org/eclipse/jetty/util/MultiException
at org.apache.uniffle.common.util.RssUtils.isServerPortBindCollision(RssUtils.java:219)
at org.apache.uniffle.common.util.RssUtils.startServiceOnPort(RssUtils.java:197)
at org.apache.uniffle.common.rpc.GrpcServer.start(GrpcServer.java:188)
at org.apache.spark.shuffle.RssShuffleManager.<init>(RssShuffleManager.java:262)
at org.apache.spark.shuffle.DelegationRssShuffleManager.createShuffleManagerInDriver(DelegationRssShuffleManager.java:87)
at org.apache.spark.shuffle.DelegationRssShuffleManager.<init>(DelegationRssShuffleManager.java:60)
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
at java.lang.reflect.Constructor.newInstance(Constructor.java:423)`

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
