### PR TITLE
[MINOR] fix(server): Use warn log when unable to acquire memory

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -728,7 +728,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle data";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       reply =
           GetLocalShuffleDataResponse.newBuilder()
               .setStatus(status.toProto())
@@ -825,7 +825,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle index";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       reply =
           GetLocalShuffleIndexResponse.newBuilder()
               .setStatus(status.toProto())
@@ -932,7 +932,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get in memory shuffle data";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       reply =
           GetMemoryShuffleDataResponse.newBuilder()
               .setData(UnsafeByteOperations.unsafeWrap(new byte[] {}))

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -728,7 +728,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle data";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       reply =
           GetLocalShuffleDataResponse.newBuilder()
               .setStatus(status.toProto())
@@ -825,7 +825,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle index";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       reply =
           GetLocalShuffleIndexResponse.newBuilder()
               .setStatus(status.toProto())
@@ -932,7 +932,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get in memory shuffle data";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       reply =
           GetMemoryShuffleDataResponse.newBuilder()
               .setData(UnsafeByteOperations.unsafeWrap(new byte[] {}))

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -516,7 +516,7 @@ public class ShuffleTaskManager {
           new PreAllocatedBufferInfo(appId, requireId, System.currentTimeMillis(), requireSize));
       return requireId;
     } else {
-      LOG.error("Failed to require buffer, require size: {}", requireSize);
+      LOG.warn("Failed to require buffer, require size: {}", requireSize);
       throw new NoBufferException("No Buffer For Regular Partition, requireSize: " + requireSize);
     }
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -454,7 +454,7 @@ public class ShuffleBufferManager {
     } while (true);
 
     if (!isSuccessful) {
-      LOG.error(
+      LOG.warn(
           "Can't require["
               + size
               + "] for read data, current["

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -313,7 +313,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get in memory shuffle data";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       response =
           new GetMemoryShuffleDataResponse(
               req.getRequestId(), status, msg, Lists.newArrayList(), Unpooled.EMPTY_BUFFER);
@@ -399,7 +399,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle index";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       response =
           new GetLocalShuffleIndexResponse(
               req.getRequestId(), status, msg, Unpooled.EMPTY_BUFFER, 0L);
@@ -495,7 +495,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle data";
-      LOG.error(msg + " for " + requestInfo);
+      LOG.warn(msg + " for " + requestInfo);
       response =
           new GetLocalShuffleDataResponse(
               req.getRequestId(), status, msg, new NettyManagedBuffer(Unpooled.EMPTY_BUFFER));

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -313,7 +313,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get in memory shuffle data";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       response =
           new GetMemoryShuffleDataResponse(
               req.getRequestId(), status, msg, Lists.newArrayList(), Unpooled.EMPTY_BUFFER);
@@ -399,7 +399,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle index";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       response =
           new GetLocalShuffleIndexResponse(
               req.getRequestId(), status, msg, Unpooled.EMPTY_BUFFER, 0L);
@@ -495,7 +495,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     } else {
       status = StatusCode.NO_BUFFER;
       msg = "Can't require memory to get shuffle data";
-      LOG.warn(msg + " for " + requestInfo);
+      LOG.warn("{} for {}", msg, requestInfo);
       response =
           new GetLocalShuffleDataResponse(
               req.getRequestId(), status, msg, new NettyManagedBuffer(Unpooled.EMPTY_BUFFER));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use warn log when unable to acquire memory.

### Why are the changes needed?

No need to use error log, because clients will retry for many times.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.