### PR TITLE
[#1698][FOLLOWUP] fix(test): Increase stability of tests

### DIFF
--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -160,7 +160,7 @@ fi
 
 echo "RSS version is $VERSION"
 
-export MAVEN_OPTS="${MAVEN_OPTS:--Xmx2g -XX:ReservedCodeCacheSize=1g}"
+export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx5g -XX:ReservedCodeCacheSize=1g}"
 
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.

--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -167,7 +167,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <systemProperties>
                             <java.awt.headless>true</java.awt.headless>

--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -167,7 +167,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <systemProperties>
                             <java.awt.headless>true</java.awt.headless>
@@ -177,7 +177,7 @@
                         </systemProperties>
                         <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
                         <useFile>${test.redirectToFile}</useFile>
-                        <argLine>-ea -Xmx5g</argLine>
+                        <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>
                         <failIfNoTests>false</failIfNoTests>
                     </configuration>
                 </plugin>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -151,7 +151,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <systemProperties>
                             <java.awt.headless>true</java.awt.headless>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -151,7 +151,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <systemProperties>
                             <java.awt.headless>true</java.awt.headless>
@@ -161,7 +161,7 @@
                         </systemProperties>
                         <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
                         <useFile>${test.redirectToFile}</useFile>
-                        <argLine>-ea -Xmx5g</argLine>
+                        <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>
                         <failIfNoTests>false</failIfNoTests>
                     </configuration>
                 </plugin>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>2.22.2</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.2.5</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
@@ -194,7 +194,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>-ea -Xmx5g</argLine>
+            <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>

--- a/integration-test/tez/pom.xml
+++ b/integration-test/tez/pom.xml
@@ -157,6 +157,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
@@ -166,7 +167,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>-ea -Xmx5g</argLine>
+            <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>

--- a/integration-test/tez/pom.xml
+++ b/integration-test/tez/pom.xml
@@ -157,7 +157,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>2.22.2</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/pom.xml
+++ b/pom.xml
@@ -172,11 +172,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
@@ -599,12 +594,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
         <version>${junit.platform.version}</version>
@@ -925,7 +914,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>2.22.2</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
@@ -594,6 +599,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
         <version>${junit.platform.version}</version>
@@ -914,7 +925,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.2.5</version>
           <configuration>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
@@ -925,7 +936,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>${argLine} -ea -Xmx3g</argLine>
+            <argLine>${argLine} -ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>${trimStackTrace}</trimStackTrace>
             <skipTests>${skipUTs}</skipTests>


### PR DESCRIPTION
### What changes were proposed in this pull request?

We adjust the memory arguments refer to Spark's [pom.xml](https://github.com/apache/spark/blob/master/pom.xml):
> -ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs}

and [make-distribution.sh](https://github.com/apache/spark/blob/master/dev/make-distribution.sh):
> export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m}"

This is more reasonable.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/1698.
After https://github.com/apache/incubator-uniffle/pull/1726, I found that the issue may still exist.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unnecessary.
