### PR TITLE
[#1699][FOLLOWUP] fix(client): Add commons-collections4 dependencies in shaded clients

### DIFF
--- a/client-mr/core/pom.xml
+++ b/client-mr/core/pom.xml
@@ -159,6 +159,7 @@
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
                                     <include>net.jpountz.lz4:lz4</include>
+                                    <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>
                             <finalName>${project.artifactId}-${project.version}</finalName>

--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -68,6 +68,7 @@
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>org.roaringbitmap:shims</include>
+                  <include>org.apache.commons:commons-collections4</include>
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}</finalName>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -68,6 +68,7 @@
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>org.roaringbitmap:RoaringBitmap</include>
                   <include>org.roaringbitmap:shims</include>
+                  <include>org.apache.commons:commons-collections4</include>
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}</finalName>

--- a/client-tez/pom.xml
+++ b/client-tez/pom.xml
@@ -174,6 +174,7 @@
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
                                     <include>net.jpountz.lz4:lz4</include>
+                                    <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>
                             <finalName>${project.artifactId}-${project.version}</finalName>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `commons-collections4` dependencies in shaded clients.

### Why are the changes needed?

After https://github.com/apache/incubator-uniffle/pull/1700, in some old versions of Spark, the `commons-collections4` dependency could be missing. Add the potential missing dependency to improve robustness.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs. Tested in our env.
