### PR TITLE
[MINOR] fix(dashboard): Display the registration time in 24-hour format

### DIFF
--- a/dashboard/src/main/webapp/src/utils/common.js
+++ b/dashboard/src/main/webapp/src/utils/common.js
@@ -43,7 +43,7 @@ const memFormatter = (row, column, cellValue) => {
  * @returns {string}
  */
 const dateFormatter = (row, column, cellValue) => {
-    return moment(cellValue).format("YYYY-MM-DD hh:mm:ss");
+    return moment(cellValue).format("YYYY-MM-DD HH:mm:ss");
 }
 
 export {memFormatter, dateFormatter}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Display the registration time in 24-hour format.

### Why are the changes needed?

The current displayed registration time follows the system time of the machine. If the system is set to a 12-hour format, then the page will display the time in a 12-hour format. If the system is set to a 24-hour format, then the page will display the time in a 24-hour format. It's not clear in the UI whether it's AM or PM when the Linux machine uses the 12-hour format.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
