### PR TITLE
[#1755] fix(spark): Avoid task failure of inconsistent record number

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -333,13 +333,11 @@ public class WriteBufferManager extends MemoryConsumer {
     long targetSpillSize = Long.MAX_VALUE;
     bufferSpillRatio = Math.max(0.1, Math.min(1.0, bufferSpillRatio));
     List<Integer> partitionList = new ArrayList(buffers.keySet());
-    if (bufferSpillRatio != 1.0) {
-      if (Double.compare(bufferSpillRatio, 1.0) < 0) {
-        partitionList.sort(
-            Comparator.comparingInt(
-                    o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
-                .reversed());
-      }
+    if (Double.compare(bufferSpillRatio, 1.0) < 0) {
+      partitionList.sort(
+          Comparator.comparingInt(
+                  o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
+              .reversed());
       targetSpillSize = (long) ((getUsedBytes() - getInSendListBytes()) * bufferSpillRatio);
     }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -329,14 +329,20 @@ public class WriteBufferManager extends MemoryConsumer {
     List<ShuffleBlockInfo> result = Lists.newArrayList();
     long dataSize = 0;
     long memoryUsed = 0;
+
+    long targetSpillSize = Long.MAX_VALUE;
     bufferSpillRatio = Math.max(0.1, Math.min(1.0, bufferSpillRatio));
     List<Integer> partitionList = new ArrayList(buffers.keySet());
-    if (Double.compare(bufferSpillRatio, 1.0) < 0) {
-      partitionList.sort(
-          Comparator.comparingInt(o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
-              .reversed());
+    if (bufferSpillRatio != 1.0) {
+      if (Double.compare(bufferSpillRatio, 1.0) < 0) {
+        partitionList.sort(
+            Comparator.comparingInt(
+                    o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
+                .reversed());
+      }
+      targetSpillSize = (long) ((usedBytes.get() - inSendListBytes.get()) * bufferSpillRatio);
     }
-    long targetSpillSize = (long) ((usedBytes.get() - inSendListBytes.get()) * bufferSpillRatio);
+
     for (int partitionId : partitionList) {
       WriterBuffer wb = buffers.get(partitionId);
       if (wb == null) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -340,7 +340,7 @@ public class WriteBufferManager extends MemoryConsumer {
                     o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
                 .reversed());
       }
-      targetSpillSize = (long) ((usedBytes.get() - inSendListBytes.get()) * bufferSpillRatio);
+      targetSpillSize = (long) ((getUsedBytes() - getInSendListBytes()) * bufferSpillRatio);
     }
 
     for (int partitionId : partitionList) {

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -335,8 +335,7 @@ public class WriteBufferManager extends MemoryConsumer {
     List<Integer> partitionList = new ArrayList(buffers.keySet());
     if (Double.compare(bufferSpillRatio, 1.0) < 0) {
       partitionList.sort(
-          Comparator.comparingInt(
-                  o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
+          Comparator.comparingInt(o -> buffers.get(o) == null ? 0 : buffers.get(o).getMemoryUsed())
               .reversed());
       targetSpillSize = (long) ((getUsedBytes() - getInSendListBytes()) * bufferSpillRatio);
     }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -268,6 +268,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     processShuffleBlockInfos(shuffleBlockInfos);
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     long s = System.currentTimeMillis();
+    checkAllBufferSpilled();
     checkSentRecordCount(recordCount);
     checkSentBlockCount();
     checkBlockSendResult(blockIds);
@@ -295,6 +296,13 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             + commitDuration
             + "], "
             + bufferManager.getManagerCostInfo());
+  }
+
+  private void checkAllBufferSpilled() {
+    if (bufferManager.getBuffers().size() > 0) {
+      throw new RssSendFailedException(
+          "Potential data loss due to existing remaining data buffers that are not flushed. This should not happen.");
+    }
   }
 
   private void checkSentRecordCount(long recordCount) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -313,6 +313,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     long checkStartTs = System.currentTimeMillis();
+    checkAllBufferSpilled();
     checkSentRecordCount(recordCount);
     checkSentBlockCount();
     checkBlockSendResult(blockIds);
@@ -338,6 +339,13 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
             + (System.currentTimeMillis() - commitStartTs)
             + "], "
             + bufferManager.getManagerCostInfo());
+  }
+
+  private void checkAllBufferSpilled() {
+    if (bufferManager.getBuffers().size() > 0) {
+      throw new RssSendFailedException(
+          "Potential data loss due to existing remaining data buffers that are not flushed. This should not happen.");
+    }
   }
 
   private void checkSentRecordCount(long recordCount) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. When the spill ratio is `1.0` , the process of calculating target spill size will be ignored to avoid potential race condition that the `usedBytes` and `inSendBytes` are not thread safe. This could guarantee that the all data is flushed to the shuffle server at the end of task.
2. Adding the `bufferManager's` buffer remaining check

### Why are the changes needed?

Due to the #1670 , the partial data held by the bufferManager will not be flushed to shuffle servers in some corner cases, 
this will make task fail fast rather than silently data loss that should thanks the #1558 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
