### PR TITLE
[#1764] fix(client): Fix timeout time unit for unregister requests

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -950,6 +950,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
   @Override
   public void unregisterShuffle(String appId, int shuffleId) {
+    int unregisterTimeMs = unregisterRequestTimeSec * 1000;
     RssUnregisterShuffleRequest request = new RssUnregisterShuffleRequest(appId, shuffleId);
 
     Map<Integer, Set<ShuffleServerInfo>> appServerMap = shuffleServerInfoMap.get(appId);
@@ -984,7 +985,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             }
             return null;
           },
-          unregisterRequestTimeSec,
+          unregisterTimeMs,
           "unregister shuffle server");
 
     } finally {
@@ -997,6 +998,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
   @Override
   public void unregisterShuffle(String appId) {
+    int unregisterTimeMs = unregisterRequestTimeSec * 1000;
     RssUnregisterShuffleByAppIdRequest request = new RssUnregisterShuffleByAppIdRequest(appId);
 
     if (appId == null) {
@@ -1032,7 +1034,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             }
             return null;
           },
-          unregisterRequestTimeSec,
+          unregisterTimeMs,
           "unregister shuffle server");
 
     } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Method `ThreadUtils.executeTasks` expects milliseconds, but seconds are given.

### Why are the changes needed?
Requests are interrupted before the configured timeout passes.

Fix: #1764

### Does this PR introduce _any_ user-facing change?
Configured timeout is respected.

### How was this patch tested?
Manually tested.