### PR TITLE
[#1770] improvement(server): Increase the InitiatingHeapOccupancyPercent value of G1 option to avoid frequent garbage collection

### DIFF
--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -99,7 +99,7 @@ JVM_ARGS=" -server \
           -XX:MaxGCPauseMillis=200 \
           -XX:ParallelGCThreads=20 \
           -XX:ConcGCThreads=5 \
-          -XX:InitiatingHeapOccupancyPercent=20 \
+          -XX:InitiatingHeapOccupancyPercent=60 \
           -XX:G1HeapRegionSize=32m \
           -XX:+UnlockExperimentalVMOptions \
           -XX:G1NewSizePercent=10 \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the IHOP value to avoid frequent garbage collection.

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1770.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
