### PR TITLE
[#1773] improvement(client): Reduce chunkSize of gRPC Netty's PooledByteBufAllocator to reduce memory usage

### DIFF
--- a/client-mr/core/pom.xml
+++ b/client-mr/core/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -93,12 +93,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -96,6 +96,11 @@
       <version>${netty.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <exclusions>

--- a/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssClientConf.java
@@ -108,6 +108,30 @@ public class RssClientConf {
           .defaultValue(3)
           .withDescription("When we fail to send RPC calls, we will retry for maxAttempts times.");
 
+  public static final ConfigOption<Integer> RPC_NETTY_PAGE_SIZE =
+      ConfigOptions.key("rss.client.rpc.netty.pageSize")
+          .intType()
+          .defaultValue(4096)
+          .withDescription(
+              "The value of pageSize for PooledByteBufAllocator when using gRPC internal Netty on the client-side. "
+                  + "This configuration will only take effect when rss.client.type is set to GRPC_NETTY.");
+
+  public static final ConfigOption<Integer> RPC_NETTY_MAX_ORDER =
+      ConfigOptions.key("rss.client.rpc.netty.maxOrder")
+          .intType()
+          .defaultValue(3)
+          .withDescription(
+              "The value of maxOrder for PooledByteBufAllocator when using gRPC internal Netty on the client-side. "
+                  + "This configuration will only take effect when rss.client.type is set to GRPC_NETTY.");
+
+  public static final ConfigOption<Integer> RPC_NETTY_SMALL_CACHE_SIZE =
+      ConfigOptions.key("rss.client.rpc.netty.smallCacheSize")
+          .intType()
+          .defaultValue(1024)
+          .withDescription(
+              "The value of smallCacheSize for PooledByteBufAllocator when using gRPC internal Netty on the client-side. "
+                  + "This configuration will only take effect when rss.client.type is set to GRPC_NETTY.");
+
   public static final ConfigOption<Integer> NETTY_IO_CONNECT_TIMEOUT_MS =
       ConfigOptions.key("rss.client.netty.io.connect.timeout.ms")
           .intType()

--- a/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
@@ -27,12 +27,6 @@ public class GrpcNettyUtils {
         preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, 0);
   }
 
-  public static PooledByteBufAllocator createPooledByteBufAllocatorWithSmallCacheOnly(
-      boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
-    return createPooledByteBufAllocator(
-        preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, -1);
-  }
-
   private static PooledByteBufAllocator createPooledByteBufAllocator(
       boolean preferDirect,
       boolean allowCache,
@@ -65,5 +59,11 @@ public class GrpcNettyUtils {
         allowCache && smallCacheSize != -1 ? smallCacheSize : 0,
         allowCache && normalCacheSize != -1 ? normalCacheSize : 0,
         allowCache && PooledByteBufAllocator.defaultUseCacheForAllThreads());
+  }
+
+  public static PooledByteBufAllocator createPooledByteBufAllocatorWithSmallCacheOnly(
+      boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
+    return createPooledByteBufAllocator(
+        preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, -1);
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
+
+public class GrpcNettyUtils {
+  public static PooledByteBufAllocator createPooledByteBufAllocator(
+      boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
+    return createPooledByteBufAllocator(
+        preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, 0);
+  }
+
+  public static PooledByteBufAllocator createPooledByteBufAllocatorWithSmallCacheOnly(
+      boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
+    return createPooledByteBufAllocator(
+        preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, -1);
+  }
+
+  private static PooledByteBufAllocator createPooledByteBufAllocator(
+      boolean preferDirect,
+      boolean allowCache,
+      int numCores,
+      int pageSize,
+      int maxOrder,
+      int smallCacheSize,
+      int normalCacheSize) {
+    if (numCores == 0) {
+      numCores = Runtime.getRuntime().availableProcessors();
+    }
+    if (pageSize == 0) {
+      pageSize = PooledByteBufAllocator.defaultPageSize();
+    }
+    if (maxOrder == 0) {
+      maxOrder = PooledByteBufAllocator.defaultMaxOrder();
+    }
+    if (smallCacheSize == 0) {
+      smallCacheSize = PooledByteBufAllocator.defaultSmallCacheSize();
+    }
+    if (normalCacheSize == 0) {
+      normalCacheSize = PooledByteBufAllocator.defaultNormalCacheSize();
+    }
+    return new PooledByteBufAllocator(
+        preferDirect && PlatformDependent.directBufferPreferred(),
+        Math.min(PooledByteBufAllocator.defaultNumHeapArena(), numCores),
+        Math.min(PooledByteBufAllocator.defaultNumDirectArena(), preferDirect ? numCores : 0),
+        pageSize,
+        maxOrder,
+        allowCache && smallCacheSize != -1 ? smallCacheSize : 0,
+        allowCache && normalCacheSize != -1 ? normalCacheSize : 0,
+        allowCache && PooledByteBufAllocator.defaultUseCacheForAllThreads());
+  }
+}

--- a/internal-client/pom.xml
+++ b/internal-client/pom.xml
@@ -37,5 +37,11 @@
       <groupId>org.apache.uniffle</groupId>
       <artifactId>rss-common</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/internal-client/pom.xml
+++ b/internal-client/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
@@ -20,9 +20,13 @@ package org.apache.uniffle.client.impl.grpc;
 import java.util.concurrent.TimeUnit;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.AbstractByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.common.util.GrpcNettyUtils;
 
 public abstract class GrpcClient {
 
@@ -34,13 +38,27 @@ public abstract class GrpcClient {
   protected ManagedChannel channel;
 
   protected GrpcClient(String host, int port, int maxRetryAttempts, boolean usePlaintext) {
+    this(host, port, maxRetryAttempts, usePlaintext, 0, 0, 0);
+  }
+
+  protected GrpcClient(
+      String host,
+      int port,
+      int maxRetryAttempts,
+      boolean usePlaintext,
+      int pageSize,
+      int maxOrder,
+      int smallCacheSize) {
     this.host = host;
     this.port = port;
     this.maxRetryAttempts = maxRetryAttempts;
     this.usePlaintext = usePlaintext;
 
-    // build channel
-    ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(host, port);
+    NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forAddress(host, port)
+            .withOption(
+                ChannelOption.ALLOCATOR,
+                createByteBufAllocator(pageSize, maxOrder, smallCacheSize));
 
     if (usePlaintext) {
       channelBuilder.usePlaintext();
@@ -56,6 +74,11 @@ public abstract class GrpcClient {
 
   protected GrpcClient(ManagedChannel channel) {
     this.channel = channel;
+  }
+
+  protected AbstractByteBufAllocator createByteBufAllocator(
+      int pageSize, int maxOrder, int smallCacheSize) {
+    return GrpcNettyUtils.createPooledByteBufAllocator(true, 0, 0, 0, 0);
   }
 
   public void close() {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -137,7 +137,10 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         host,
         port,
         RssClientConf.RPC_MAX_ATTEMPTS.defaultValue(),
-        RssClientConf.RPC_TIMEOUT_MS.defaultValue());
+        RssClientConf.RPC_TIMEOUT_MS.defaultValue(),
+        RssClientConf.RPC_NETTY_PAGE_SIZE.defaultValue(),
+        RssClientConf.RPC_NETTY_MAX_ORDER.defaultValue(),
+        RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE.defaultValue());
   }
 
   public ShuffleServerGrpcClient(RssConf rssConf, String host, int port) {
@@ -149,16 +152,39 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             : rssConf.getInteger(RssClientConf.RPC_MAX_ATTEMPTS),
         rssConf == null
             ? RssClientConf.RPC_TIMEOUT_MS.defaultValue()
-            : rssConf.getLong(RssClientConf.RPC_TIMEOUT_MS));
-  }
-
-  public ShuffleServerGrpcClient(String host, int port, int maxRetryAttempts, long rpcTimeoutMs) {
-    this(host, port, maxRetryAttempts, rpcTimeoutMs, true);
+            : rssConf.getLong(RssClientConf.RPC_TIMEOUT_MS),
+        rssConf == null
+            ? RssClientConf.RPC_NETTY_PAGE_SIZE.defaultValue()
+            : rssConf.getInteger(RssClientConf.RPC_NETTY_PAGE_SIZE),
+        rssConf == null
+            ? RssClientConf.RPC_NETTY_MAX_ORDER.defaultValue()
+            : rssConf.getInteger(RssClientConf.RPC_NETTY_MAX_ORDER),
+        rssConf == null
+            ? RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE.defaultValue()
+            : rssConf.getInteger(RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE));
   }
 
   public ShuffleServerGrpcClient(
-      String host, int port, int maxRetryAttempts, long rpcTimeoutMs, boolean usePlaintext) {
-    super(host, port, maxRetryAttempts, usePlaintext);
+      String host,
+      int port,
+      int maxRetryAttempts,
+      long rpcTimeoutMs,
+      int pageSize,
+      int maxOrder,
+      int smallCacheSize) {
+    this(host, port, maxRetryAttempts, rpcTimeoutMs, true, pageSize, maxOrder, smallCacheSize);
+  }
+
+  public ShuffleServerGrpcClient(
+      String host,
+      int port,
+      int maxRetryAttempts,
+      long rpcTimeoutMs,
+      boolean usePlaintext,
+      int pageSize,
+      int maxOrder,
+      int smallCacheSize) {
+    super(host, port, maxRetryAttempts, usePlaintext, pageSize, maxOrder, smallCacheSize);
     blockingStub = ShuffleServerGrpc.newBlockingStub(channel);
     rpcTimeout = rpcTimeoutMs;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce configs to reduce the chunkSize of the gRPC internal Netty's PooledByteBufAllocator to reduce memory usage on the client-side.
When enabling Netty, the changes for gRPC internal Netty's configs will be as follows:
`io.netty.allocator.pageSize`: 8192 -> 4096 (bytes)
`io.netty.allocator.maxOrder`: 11 -> 3
`io.netty.allocator.smallCacheSize`: 128 -> 1024
Note: `chunkSize` = `pageSize` * 2^`maxOrder`, 
Thus, the `io.netty.allocator.chunkSize`: 2MB -> 32KB

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/1773.

### Does this PR introduce _any_ user-facing change?

No. This PR will not change anything when using GRPC. It will only take effect when using GRPC_NETTY.
Adds configs: `rss.client.rpc.netty.pageSize`, `rss.client.rpc.netty.maxOrder`, `rss.client.rpc.netty.smallCacheSize`

### How was this patch tested?

Existing tests.
