### PR TITLE
[#1608] improvement(spark3): Output the reassign logs in client side

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -615,6 +615,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       }
       MutableShuffleHandleInfo handle = MutableShuffleHandleInfo.fromProto(response.getHandle());
       taskAttemptAssignment.update(handle);
+      LOG.info("Success to reassign. The latest available assignment is {}", handle.getAvailablePartitionServersForWriter());
     } catch (Exception e) {
       throw new RssException(
           "Errors on reassign on block send failure. failure partition->servers : "
@@ -677,6 +678,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
 
     processShuffleBlockInfos(resendCandidates);
+    LOG.info("Failed blocks have been resent to data pusher queue since reassignment has been finished successfully");
   }
 
   private void clearFailedBlockState(ShuffleBlockInfo block) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -615,7 +615,9 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       }
       MutableShuffleHandleInfo handle = MutableShuffleHandleInfo.fromProto(response.getHandle());
       taskAttemptAssignment.update(handle);
-      LOG.info("Success to reassign. The latest available assignment is {}", handle.getAvailablePartitionServersForWriter());
+      LOG.info(
+          "Success to reassign. The latest available assignment is {}",
+          handle.getAvailablePartitionServersForWriter());
     } catch (Exception e) {
       throw new RssException(
           "Errors on reassign on block send failure. failure partition->servers : "
@@ -678,7 +680,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
 
     processShuffleBlockInfos(resendCandidates);
-    LOG.info("Failed blocks have been resent to data pusher queue since reassignment has been finished successfully");
+    LOG.info(
+        "Failed blocks have been resent to data pusher queue since reassignment has been finished successfully");
   }
 
   private void clearFailedBlockState(ShuffleBlockInfo block) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Output the reassign logs in client side

### Why are the changes needed?

For #1608

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't