### PR TITLE
[#1784] improvement(server): Skip retries for absent HDFS app directory to speed up resource removal

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleDeleteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleDeleteHandler.java
@@ -63,7 +63,7 @@ public class HadoopShuffleDeleteHandler implements ShuffleDeleteHandler {
           isSuccess = true;
         } catch (Exception e) {
           if (e instanceof FileNotFoundException) {
-            LOG.info("[{}] doesn't exist, maybe it has been deleted.", path);
+            LOG.info("[{}] doesn't exist, ignore it.", path);
             return;
           }
           times++;

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleDeleteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleDeleteHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.storage.handler.impl;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -61,6 +62,10 @@ public class HadoopShuffleDeleteHandler implements ShuffleDeleteHandler {
           delete(fileSystem, path, shuffleServerId);
           isSuccess = true;
         } catch (Exception e) {
+          if (e instanceof FileNotFoundException) {
+            LOG.info("[{}] doesn't exist, maybe it has been deleted.", path);
+            return;
+          }
           times++;
           LOG.warn(
               "Can't delete shuffle data for appId[" + appId + "] with " + times + " times", e);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Skip retries for absent HDFS app directory to speed up resource removal

### Why are the changes needed?

For better performance.
Fix: #1784 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual testing