### PR TITLE
[#1705] improvement(server): Bump Jetty from 9.3.24.v20180605 to 9.4.54.v20240208

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <httpcore.version>4.4.4</httpcore.version>
     <java.version>1.8</java.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
-    <jetty.version>9.3.24.v20180605</jetty.version>
+    <jetty.version>9.4.54.v20240208</jetty.version>
     <hbase.thirdparty.version>4.1.4</hbase.thirdparty.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Jetty from 9.3.24.v20180605 to 9.4.54.v20240208.

### Why are the changes needed?

For: https://github.com/apache/incubator-uniffle/issues/1705.
Since Uniffle still needs to support JDK 8, and [Jetty no longer supports JDK 8 from version 10.x onwards](https://jetty.org/download.html#version-history), we are temporarily unable to upgrade Jetty to 10.x or higher versions. Therefore, we will first upgrade Jetty to the latest version of 9.x (which is [9.4.54.v20240208](https://jetty.org/download.html)), although it is no longer maintained, it is still a stable version and includes numerous bug fixes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
