### PR TITLE
[#1787] feat(spark): Fine grained stage retry switch for fetch/write failure

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -37,6 +37,29 @@ import org.apache.uniffle.common.config.RssConf;
 
 public class RssSparkConfig {
 
+  public static final ConfigOption<Boolean> RSS_RESUBMIT_STAGE_ENABLED =
+      ConfigOptions.key("rss.stageRetry.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDeprecatedKeys(RssClientConfig.RSS_RESUBMIT_STAGE)
+          .withDescription("Whether to enable the resubmit stage for fetch/write failure");
+
+  public static final ConfigOption<Boolean> RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED =
+      ConfigOptions.key("rss.stageRetry.fetchFailureEnabled")
+          .booleanType()
+          .defaultValue(false)
+          .withFallbackKeys(RSS_RESUBMIT_STAGE_ENABLED.key(), RssClientConfig.RSS_RESUBMIT_STAGE)
+          .withDescription(
+              "If set to true, the stage retry mechanism will be enabled when a fetch failure occurs.");
+
+  public static final ConfigOption<Boolean> RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED =
+      ConfigOptions.key("rss.stageRetry.writeFailureEnabled")
+          .booleanType()
+          .defaultValue(false)
+          .withFallbackKeys(RSS_RESUBMIT_STAGE_ENABLED.key(), RssClientConfig.RSS_RESUBMIT_STAGE)
+          .withDescription(
+              "If set to true, the stage retry mechanism will be enabled when a write failure occurs.");
+
   public static final ConfigOption<Boolean> RSS_BLOCK_ID_SELF_MANAGEMENT_ENABLED =
       ConfigOptions.key("rss.blockId.selfManagementEnabled")
           .booleanType()
@@ -403,13 +426,6 @@ public class RssSparkConfig {
                   .internal()
                   .doc(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT.description()))
           .createWithDefault(-1);
-
-  public static final ConfigEntry<Boolean> RSS_RESUBMIT_STAGE =
-      createBooleanBuilder(
-              new ConfigBuilder(SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_RESUBMIT_STAGE)
-                  .internal()
-                  .doc("Whether to enable the resubmit stage."))
-          .createWithDefault(false);
 
   public static final ConfigEntry<Integer> RSS_MAX_PARTITIONS =
       createIntegerBuilder(

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -47,7 +47,6 @@ import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
 import org.apache.uniffle.client.util.ClientUtils;
-import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -57,6 +56,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 import org.apache.uniffle.common.util.Constants;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
 import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
 
 public class RssSparkShuffleUtils {
@@ -353,7 +353,7 @@ public class RssSparkShuffleUtils {
       int stageAttemptId,
       Set<Integer> failedPartitions) {
     RssConf rssConf = RssSparkConfig.toRssConf(sparkConf);
-    if (rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
+    if (rssConf.getBoolean(RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED)
         && RssSparkShuffleUtils.isStageResubmitSupported()) {
       String driver = rssConf.getString(DRIVER_HOST, "");
       int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -103,8 +103,9 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
 
   protected SparkConf sparkConf;
   protected ShuffleManagerClient shuffleManagerClient;
-  /** Whether to enable the dynamic shuffleServer function rewrite and reread functions */
-  protected boolean rssResubmitStage;
+  protected boolean rssStageRetryEnabled;
+  protected boolean rssStageRetryForWriteFailureEnabled;
+  protected boolean rssStageRetryForFetchFailureEnabled;
   /**
    * Mapping between ShuffleId and ShuffleServer list. ShuffleServer list is dynamically allocated.
    * ShuffleServer is not obtained from RssShuffleHandle, but from this mapping.
@@ -1046,7 +1047,15 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
         appId, defaultRemoteStorage, dynamicConfEnabled, storageType, shuffleWriteClient);
   }
 
-  public boolean isRssResubmitStage() {
-    return rssResubmitStage;
+  public boolean isRssStageRetryEnabled() {
+    return rssStageRetryEnabled;
+  }
+
+  public boolean isRssStageRetryForWriteFailureEnabled() {
+    return rssStageRetryForWriteFailureEnabled;
+  }
+
+  public boolean isRssStageRetryForFetchFailureEnabled() {
+    return rssStageRetryForFetchFailureEnabled;
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -54,6 +54,8 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
+
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleReader.class);
@@ -231,7 +233,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     }
 
     // stage re-compute and shuffle manager server port are both set
-    if (rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
+    if (rssConf.getBoolean(RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED)
         && rssConf.getInteger(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT, 0) > 0) {
       String driver = rssConf.getString("driver.host", "");
       int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -80,6 +80,8 @@ import org.apache.uniffle.common.exception.RssSendFailedException;
 import org.apache.uniffle.common.exception.RssWaitFailedException;
 import org.apache.uniffle.storage.util.StorageType;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED;
+
 public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleWriter.class);
@@ -238,7 +240,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       writeImpl(records);
     } catch (Exception e) {
       taskFailureCallback.apply(taskId);
-      if (shuffleManager.isRssResubmitStage()) {
+      if (RssSparkConfig.toRssConf(sparkConf).get(RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED)) {
         throwFetchFailedIfNecessary(e);
       } else {
         throw e;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -182,6 +182,10 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     LOG.info("Disable shuffle data locality in RssShuffleManager.");
     taskToSuccessBlockIds = JavaUtils.newConcurrentMap();
     taskToFailedBlockSendTracker = JavaUtils.newConcurrentMap();
+
+    this.rssStageRetryEnabled = rssConf.get(RssClientConf.RSS_CLIENT_REASSIGN_ENABLED);
+    this.partitionReassignEnabled = rssConf.get(RssClientConf.RSS_CLIENT_REASSIGN_ENABLED);
+
     // stage retry for write/fetch failure
     rssStageRetryForFetchFailureEnabled =
         rssConf.get(RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED);
@@ -201,11 +205,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
           StringUtils.join(logTips, "/"));
     }
 
-    this.rssStageRetryEnabled = rssConf.getBoolean(RssClientConf.RSS_CLIENT_REASSIGN_ENABLED);
-
     // The feature of partition reassign is exclusive with multiple replicas and stage retry.
     if (partitionReassignEnabled) {
-      if (rssStageRetryEnabled || dataReplica > 1) {
+      if (dataReplica > 1) {
         throw new RssException(
             "The feature of task partition reassign is incompatible with multiple replicas mechanism.");
       }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -56,6 +56,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
 import static org.apache.uniffle.common.util.Constants.DRIVER_HOST;
 
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
@@ -189,7 +190,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       resultIter = new InterruptibleIterator<>(context, resultIter);
     }
     // resubmit stage and shuffle manager server port are both set
-    if (rssConf.getBoolean(RssClientConfig.RSS_RESUBMIT_STAGE, false)
+    if (rssConf.getBoolean(RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED)
         && rssConf.getInteger(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT, 0) > 0) {
       String driver = rssConf.getString(DRIVER_HOST, "");
       int port = rssConf.get(RssClientConf.SHUFFLE_MANAGER_GRPC_PORT);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -92,6 +92,7 @@ import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.apache.spark.shuffle.RssSparkConfig.RSS_PARTITION_REASSIGN_BLOCK_RETRY_MAX_TIMES;
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED;
 
 public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 
@@ -277,7 +278,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       writeImpl(records);
     } catch (Exception e) {
       taskFailureCallback.apply(taskId);
-      if (shuffleManager.isRssResubmitStage()) {
+      if (RssSparkConfig.toRssConf(sparkConf).get(RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED)) {
         throwFetchFailedIfNecessary(e);
       } else {
         throw e;

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTest.java
@@ -27,14 +27,17 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import org.apache.uniffle.client.util.RssClientConfig;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
+import org.apache.uniffle.common.config.ConfigOption;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.storage.util.StorageType;
 
+import static org.apache.spark.shuffle.RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
 import static org.apache.spark.shuffle.RssSparkConfig.RSS_SHUFFLE_MANAGER_GRPC_PORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -108,6 +111,8 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
 
     RssShuffleManager shuffleManager = new RssShuffleManager(conf, true);
 
+    ConfigOption<Boolean> a = RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED;
+
     assertTrue(conf.get(RSS_SHUFFLE_MANAGER_GRPC_PORT) > 0);
   }
 
@@ -170,5 +175,60 @@ public class RssShuffleManagerTest extends RssShuffleManagerTestBase {
             + layout.maxNumPartitions
             + " partitions.",
         e.getMessage());
+  }
+
+  @Test
+  public void testWithStageRetry() {
+    // case1: disable the stage retry
+    SparkConf conf = createSparkConf();
+    RssShuffleManager shuffleManager = new RssShuffleManager(conf, true);
+    assertFalse(shuffleManager.isRssStageRetryEnabled());
+    assertFalse(shuffleManager.isRssStageRetryForFetchFailureEnabled());
+    assertFalse(shuffleManager.isRssStageRetryForWriteFailureEnabled());
+    shuffleManager.stop();
+
+    // case2: enable the stage retry
+    conf.set(
+        RssSparkConfig.SPARK_RSS_CONFIG_PREFIX + RssSparkConfig.RSS_RESUBMIT_STAGE_ENABLED.key(),
+        "true");
+    shuffleManager = new RssShuffleManager(conf, true);
+    assertTrue(shuffleManager.isRssStageRetryEnabled());
+    assertTrue(shuffleManager.isRssStageRetryForFetchFailureEnabled());
+    assertTrue(shuffleManager.isRssStageRetryForWriteFailureEnabled());
+    shuffleManager.stop();
+
+    // case3: overwrite the stage retry
+    conf.set(
+        RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
+            + RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED.key(),
+        "false");
+    shuffleManager = new RssShuffleManager(conf, true);
+    assertTrue(shuffleManager.isRssStageRetryEnabled());
+    assertFalse(shuffleManager.isRssStageRetryForFetchFailureEnabled());
+    assertTrue(shuffleManager.isRssStageRetryForWriteFailureEnabled());
+    shuffleManager.stop();
+
+    // case4: enable the partial stage retry of fetch failure
+    conf = createSparkConf();
+    conf.set(
+        RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
+            + RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED.key(),
+        "true");
+    shuffleManager = new RssShuffleManager(conf, true);
+    assertTrue(shuffleManager.isRssStageRetryEnabled());
+    assertTrue(shuffleManager.isRssStageRetryForFetchFailureEnabled());
+    assertFalse(shuffleManager.isRssStageRetryForWriteFailureEnabled());
+    shuffleManager.stop();
+  }
+
+  private SparkConf createSparkConf() {
+    SparkConf conf = new SparkConf();
+    conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
+    conf.set(RssSparkConfig.RSS_COORDINATOR_QUORUM.key(), "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
+    conf.set(RssSparkConfig.RSS_TEST_MODE_ENABLE, true);
+    conf.set("spark.task.maxFailures", "4");
+    conf.set("spark.driver.host", "localhost");
+    return conf;
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/config/ConfigOption.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/ConfigOption.java
@@ -86,7 +86,7 @@ public class ConfigOption<T> {
    * @return A new config option, with given description.
    */
   public ConfigOption<T> withDescription(final String description) {
-    return new ConfigOption<>(key, clazz, description, defaultValue, converter);
+    return new ConfigOption<>(key, clazz, description, defaultValue, converter, fallbackKeys);
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introducing the independent fine grained switch for fetch/write failure on stage retry mechanism

### Why are the changes needed?

1. The stage retry of write failure is supported recently, which is not stable. Independent switch will benifit users using the fetch failure stage retry which won't bring too much risk.
2. Leveraging the partition reassign mechanism, the importance of write failure stage retry is decreasing.

### Does this PR introduce _any_ user-facing change?

Yes. The detailed doc will be added in the next following stage retry improvement PRs.

### How was this patch tested?

Existing tests.
