### PR TITLE
[MINOR] refactor: Reduce minor logs

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BufferManagerOptions.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/BufferManagerOptions.java
@@ -64,9 +64,9 @@ public class BufferManagerOptions {
             RssSparkConfig.RSS_WRITER_PRE_ALLOCATED_BUFFER_SIZE.defaultValue().get());
     requireMemoryInterval = sparkConf.get(RssSparkConfig.RSS_WRITER_REQUIRE_MEMORY_INTERVAL);
     requireMemoryRetryMax = sparkConf.get(RssSparkConfig.RSS_WRITER_REQUIRE_MEMORY_RETRY_MAX);
-    LOG.info(RssSparkConfig.RSS_WRITER_BUFFER_SIZE.key() + "=" + bufferSize);
-    LOG.info(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key() + "=" + bufferSpillThreshold);
-    LOG.info(
+    LOG.debug(RssSparkConfig.RSS_WRITER_BUFFER_SIZE.key() + "=" + bufferSize);
+    LOG.debug(RssSparkConfig.RSS_WRITER_BUFFER_SPILL_SIZE.key() + "=" + bufferSpillThreshold);
+    LOG.debug(
         RssSparkConfig.RSS_WRITER_PRE_ALLOCATED_BUFFER_SIZE.key() + "=" + preAllocatedBufferSize);
     checkBufferSize();
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -505,7 +505,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
               shuffleId, rssHandle.getPartitionToServers(), rssHandle.getRemoteStorage());
     }
     String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
-    LOG.info("RssHandle appId {} shuffleId {} ", rssHandle.getAppId(), rssHandle.getShuffleId());
     return new RssShuffleWriter<>(
         rssHandle.getAppId(),
         shuffleId,

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -182,7 +182,11 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       Function<String, Boolean> taskFailureCallback,
       ShuffleHandleInfo shuffleHandleInfo,
       TaskContext context) {
-    LOG.info("RssShuffle start write taskAttemptId[{}] data with RssHandle[appId {}, shuffleId {}].", taskAttemptId, rssHandle.getAppId(), rssHandle.getShuffleId());
+    LOG.info(
+        "RssShuffle start write taskAttemptId[{}] data with RssHandle[appId {}, shuffleId {}].",
+        taskAttemptId,
+        rssHandle.getAppId(),
+        rssHandle.getShuffleId());
     this.shuffleManager = shuffleManager;
     this.appId = appId;
     this.shuffleId = shuffleId;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -182,7 +182,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       Function<String, Boolean> taskFailureCallback,
       ShuffleHandleInfo shuffleHandleInfo,
       TaskContext context) {
-    LOG.info("RssShuffle start write taskAttemptId data" + taskAttemptId);
+    LOG.info("RssShuffle start write taskAttemptId[{}] data with RssHandle[appId {}, shuffleId {}].", taskAttemptId, rssHandle.getAppId(), rssHandle.getShuffleId());
     this.shuffleManager = shuffleManager;
     this.appId = appId;
     this.shuffleId = shuffleId;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

reduce minor logs

### Why are the changes needed?

a lot of minor rss logs are printed in spark executor.

![image](https://github.com/apache/incubator-uniffle/assets/17894939/61994908-cdd8-4842-8562-366915456c08)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

minor fix
