### PR TITLE
[#1794] improvement(netty): TransportClientFactory should check whether handler is null when creating client

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/client/TransportClientFactory.java
@@ -121,8 +121,10 @@ public class TransportClientFactory implements Closeable {
       // this code was able to update things.
       TransportChannelHandler handler =
           cachedClient.getChannel().pipeline().get(TransportChannelHandler.class);
-      synchronized (handler) {
-        handler.getResponseHandler().updateTimeOfLastRequest();
+      if (handler != null) {
+        synchronized (handler) {
+          handler.getResponseHandler().updateTimeOfLastRequest();
+        }
       }
 
       if (cachedClient.isActive()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TransportClientFactory` should check whether `handler` is `null` when creating client.

### Why are the changes needed?

For: https://github.com/apache/incubator-uniffle/issues/1794.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
