### PR TITLE
[#1799] improvement(spark): Rename shuffleManager rpc to reassignOnStageResubmit

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -237,7 +237,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
   }
 
   @Override
-  public void reassignShuffleServers(
+  public void reassignOnStageResubmit(
       RssProtos.ReassignServersRequest request,
       StreamObserver<RssProtos.ReassignServersResponse> responseObserver) {
     int stageId = request.getStageId();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -559,7 +559,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                   shuffleId,
                   partitioner.numPartitions());
           RssReassignServersResponse rssReassignServersResponse =
-              shuffleManagerClient.reassignShuffleServers(rssReassignServersRequest);
+              shuffleManagerClient.reassignOnStageResubmit(rssReassignServersRequest);
           LOG.info(
               "Whether the reassignment is successful: {}",
               rssReassignServersResponse.isNeedReassign());

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -845,7 +845,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
                   shuffleId,
                   partitioner.numPartitions());
           RssReassignServersResponse rssReassignServersResponse =
-              shuffleManagerClient.reassignShuffleServers(rssReassignServersRequest);
+              shuffleManagerClient.reassignOnStageResubmit(rssReassignServersRequest);
           LOG.info(
               "Whether the reassignment is successful: {}",
               rssReassignServersResponse.isNeedReassign());

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/ShuffleManagerClient.java
@@ -62,7 +62,7 @@ public interface ShuffleManagerClient extends Closeable {
   RssReportShuffleWriteFailureResponse reportShuffleWriteFailure(
       RssReportShuffleWriteFailureRequest req);
 
-  RssReassignServersResponse reassignShuffleServers(RssReassignServersRequest req);
+  RssReassignServersResponse reassignOnStageResubmit(RssReassignServersRequest req);
 
   RssReassignOnBlockSendFailureResponse reassignOnBlockSendFailure(
       RssReassignOnBlockSendFailureRequest request);

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleManagerGrpcClient.java
@@ -127,10 +127,10 @@ public class ShuffleManagerGrpcClient extends GrpcClient implements ShuffleManag
   }
 
   @Override
-  public RssReassignServersResponse reassignShuffleServers(RssReassignServersRequest req) {
+  public RssReassignServersResponse reassignOnStageResubmit(RssReassignServersRequest req) {
     RssProtos.ReassignServersRequest reassignServersRequest = req.toProto();
     RssProtos.ReassignServersResponse reassignServersResponse =
-        getBlockingStub().reassignShuffleServers(reassignServersRequest);
+        getBlockingStub().reassignOnStageResubmit(reassignServersRequest);
     return RssReassignServersResponse.fromProto(reassignServersResponse);
   }
 

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -537,8 +537,8 @@ service ShuffleManager {
   rpc getPartitionToShufflerServerWithBlockRetry(PartitionToShuffleServerRequest) returns (ReassignOnBlockSendFailureResponse);
   // Report write failures to ShuffleManager
   rpc reportShuffleWriteFailure (ReportShuffleWriteFailureRequest) returns (ReportShuffleWriteFailureResponse);
-  // Reassign the RPC interface of the ShuffleServer list
-  rpc reassignShuffleServers(ReassignServersRequest) returns (ReassignServersResponse);
+  // Reassign on stage resubmit
+  rpc reassignOnStageResubmit(ReassignServersRequest) returns (ReassignServersResponse);
   // Reassign on block send failure that occurs in writer
   rpc reassignOnBlockSendFailure(RssReassignOnBlockSendFailureRequest) returns (ReassignOnBlockSendFailureResponse);
   rpc reportShuffleResult (ReportShuffleResultRequest) returns (ReportShuffleResultResponse);


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Rename shuffleManager rpc from `reassignShuffleServers` to `reassignOnStageResubmit` to align with other rpc names

### Why are the changes needed?

Fix: #1799

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
