### PR TITLE
[#1807] improvement(server): Avoid repeating judgment of partition whether is huge

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -200,6 +200,12 @@ public class ShuffleTaskInfo {
     }
   }
 
+  public boolean isHugePartition(int shuffleId, int partitionId) {
+    return existHugePartition.get()
+        && hugePartitionTags.containsKey(shuffleId)
+        && hugePartitionTags.get(shuffleId).contains(partitionId);
+  }
+
   public Set<Integer> getShuffleIds() {
     return partitionDataSizes.keySet();
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -733,8 +733,7 @@ public class ShuffleBufferManager {
 
   boolean isHugePartition(String appId, int shuffleId, int partitionId) {
     return shuffleTaskManager != null
-        && shuffleTaskManager.getPartitionDataSize(appId, shuffleId, partitionId)
-            > hugePartitionSizeThresholdRef.getSizeAsBytes();
+        && shuffleTaskManager.getShuffleTaskInfo(appId).isHugePartition(shuffleId, partitionId);
   }
 
   public boolean isHugePartition(long usedPartitionDataSize) {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -733,6 +733,7 @@ public class ShuffleBufferManager {
 
   boolean isHugePartition(String appId, int shuffleId, int partitionId) {
     return shuffleTaskManager != null
+        && shuffleTaskManager.getShuffleTaskInfo(appId) != null
         && shuffleTaskManager.getShuffleTaskInfo(appId).isHugePartition(shuffleId, partitionId);
   }
 

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskInfoTest.java
@@ -120,6 +120,18 @@ public class ShuffleTaskInfoTest {
   }
 
   @Test
+  public void isHugePartitionTest() {
+    ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo("hugePartition_appId");
+    // case1
+    assertFalse(shuffleTaskInfo.hasHugePartition());
+    assertFalse(shuffleTaskInfo.isHugePartition(1, 1));
+    // case2
+    shuffleTaskInfo.markHugePartition(1, 1);
+    assertTrue(shuffleTaskInfo.isHugePartition(1, 1));
+    assertFalse(shuffleTaskInfo.isHugePartition(1, 2));
+  }
+
+  @Test
   public void partitionSizeSummaryTest() {
     ShuffleTaskInfo shuffleTaskInfo = new ShuffleTaskInfo("partitionSizeSummaryTest_appId");
     // case1


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
1、ShuffleTaskInfo add isHugePartition funtion used by hugePartitionTags
2、ShuffleBuffleManger# isHugePartition utilizes ShuffleTaskInfo#isHugePartition, it may be more efficient and faster.

### Why are the changes needed?

Fix: #1807 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

add UT