### PR TITLE
[MINOR] fix: Add a missing bracket in log when getting shuffle index using Netty

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -325,7 +325,8 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
             + "], shuffleId["
             + request.getShuffleId()
             + "], partitionId["
-            + request.getPartitionId();
+            + request.getPartitionId()
+            + "]";
     long start = System.currentTimeMillis();
     int retry = 0;
     RpcResponse rpcResponse;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a missing bracket in log when getting shuffle index using Netty.

### Why are the changes needed?

A better log format.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
