### PR TITLE
[#1628] Avoid exception caused by calling release multiple times

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleDataResult.java
@@ -30,7 +30,7 @@ import org.apache.uniffle.common.util.ByteBufUtils;
 
 public class ShuffleDataResult {
 
-  private final ManagedBuffer buffer;
+  private volatile ManagedBuffer buffer;
   private final List<BufferSegment> bufferSegments;
 
   public ShuffleDataResult() {
@@ -109,5 +109,6 @@ public class ShuffleDataResult {
     if (this.buffer != null) {
       this.buffer.release();
     }
+    this.buffer = null;
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
@@ -26,7 +26,7 @@ import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.util.ByteBufUtils;
 
 public class ShuffleIndexResult {
-  private final ManagedBuffer buffer;
+  private volatile ManagedBuffer buffer;
   private long dataFileLen;
 
   public ShuffleIndexResult() {
@@ -74,6 +74,7 @@ public class ShuffleIndexResult {
     if (this.buffer != null) {
       this.buffer.release();
     }
+    this.buffer = null;
   }
 
   public ManagedBuffer getManagedBuffer() {

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleDataResultTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleDataResultTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,5 +39,14 @@ public class ShuffleDataResultTest {
     assertTrue(new ShuffleDataResult(new byte[1], null).isEmpty());
     assertTrue(new ShuffleDataResult(new byte[1], Collections.emptyList()).isEmpty());
     assertFalse(new ShuffleDataResult(new byte[1], segments).isEmpty());
+  }
+
+  @Test
+  public void testRelease() {
+    ShuffleDataResult shuffleDataResult = new ShuffleDataResult("test".getBytes(), null);
+    shuffleDataResult.release();
+    // Expect no exception when executing release again
+    assertDoesNotThrow(shuffleDataResult::release);
+    assertTrue(shuffleDataResult.isEmpty());
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/ShuffleIndexResultTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/ShuffleIndexResultTest.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.common;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleIndexResultTest {
@@ -27,5 +28,14 @@ public class ShuffleIndexResultTest {
   public void testEmpty() {
     assertTrue(new ShuffleIndexResult().isEmpty());
     assertTrue(new ShuffleIndexResult((byte[]) null, -1).isEmpty());
+  }
+
+  @Test
+  public void testRelease() {
+    ShuffleIndexResult shuffleIndexResult = new ShuffleIndexResult("test".getBytes(), -1);
+    shuffleIndexResult.release();
+    // Expect no exception when executing release again
+    assertDoesNotThrow(shuffleIndexResult::release);
+    assertTrue(shuffleIndexResult.isEmpty());
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Set internal buffer to null after release.

### Why are the changes needed?

address https://github.com/apache/incubator-uniffle/issues/1628#issuecomment-2182902051

Fix: #1628

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

added unit tests
