### PR TITLE
[#1826] fix(build): Fix multiple '--without' options and correct Hadoop profile usage

### DIFF
--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -81,22 +81,28 @@ while (( "$#" )); do
       ;;
     --without-mr)
       WITH_MR="false"
+      shift
       ;;
     --without-tez)
       WITH_TEZ="false"
+      shift
       ;;
     --without-spark)
       WITH_SPARK2="false"
       WITH_SPARK3="false"
+      shift
       ;;
     --without-spark2)
       WITH_SPARK2="false"
+      shift
       ;;
     --without-spark3)
       WITH_SPARK3="false"
+      shift
       ;;
     --without-dashboard)
       WITH_DASHBOARD="false"
+      shift
       ;;
     --name)
       NAME="$2"
@@ -165,7 +171,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx5g -XX:ReservedCodeCacheSize=1g}"
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
-BUILD_COMMAND=("$MVN" clean package -DskipTests $@)
+BUILD_COMMAND=("$MVN" clean package -DskipTests -P$HADOOP_PROFILE_ID $@)
 
 # Actually build the jar
 echo -e "\nBuilding with..."
@@ -209,7 +215,7 @@ mkdir -p $CLIENT_JAR_DIR
 
 # Actually build the jar
 if [ "$WITH_SPARK2" == "true" ]; then
-  BUILD_COMMAND_SPARK2=("$MVN" clean package -P$SPARK2_PROFILE_ID -pl client-spark/spark2-shaded -DskipTests -am $@ $SPARK2_MVN_OPTS)
+  BUILD_COMMAND_SPARK2=("$MVN" clean package -P$SPARK2_PROFILE_ID,$HADOOP_PROFILE_ID -pl client-spark/spark2-shaded -DskipTests -am $@ $SPARK2_MVN_OPTS)
 
   echo -e "\nBuilding with..."
   echo -e "\$ ${BUILD_COMMAND_SPARK2[@]}\n"
@@ -223,7 +229,7 @@ if [ "$WITH_SPARK2" == "true" ]; then
 fi
 
 if [ "$WITH_SPARK3" == "true" ]; then
-  BUILD_COMMAND_SPARK3=("$MVN" clean package -P$SPARK3_PROFILE_ID -pl client-spark/spark3-shaded -DskipTests -am $@ $SPARK3_MVN_OPTS)
+  BUILD_COMMAND_SPARK3=("$MVN" clean package -P$SPARK3_PROFILE_ID,$HADOOP_PROFILE_ID -pl client-spark/spark3-shaded -DskipTests -am $@ $SPARK3_MVN_OPTS)
 
   echo -e "\nBuilding with..."
   echo -e "\$ ${BUILD_COMMAND_SPARK3[@]}\n"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix two compilation issues: 
1) Ineffectiveness of specifying multiple `--without` options.
2) Correct Hadoop profile not being used despite being specified, with default profile being used instead.

### Why are the changes needed?

For: https://github.com/apache/incubator-uniffle/issues/1826.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
