### PR TITLE
[#1826][FOLLOWUP] fix(build): Revert incorrect shift statements deletion in build_distribution.sh

### DIFF
--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -81,28 +81,22 @@ while (( "$#" )); do
       ;;
     --without-mr)
       WITH_MR="false"
-      shift
       ;;
     --without-tez)
       WITH_TEZ="false"
-      shift
       ;;
     --without-spark)
       WITH_SPARK2="false"
       WITH_SPARK3="false"
-      shift
       ;;
     --without-spark2)
       WITH_SPARK2="false"
-      shift
       ;;
     --without-spark3)
       WITH_SPARK3="false"
-      shift
       ;;
     --without-dashboard)
       WITH_DASHBOARD="false"
-      shift
       ;;
     --name)
       NAME="$2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revert the incorrect shift shell statements deletion in https://github.com/apache/incubator-uniffle/pull/1827.

### Why are the changes needed?

A follow-up PR for https://github.com/apache/incubator-uniffle/pull/1827.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
