### PR TITLE
[#1608] refactor: refactor: Reuse ShuffleManageClient in ShuffleReader and ShuffleWriter

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssFetchFailedIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssFetchFailedIterator.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.shuffle.reader;
 
-import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Function;
 
 import scala.Product2;
 import scala.collection.AbstractIterator;
@@ -29,11 +29,8 @@ import org.apache.spark.shuffle.RssSparkShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.uniffle.client.api.ShuffleManagerClient;
-import org.apache.uniffle.client.factory.ShuffleManagerClientFactory;
 import org.apache.uniffle.client.request.RssReportShuffleFetchFailureRequest;
 import org.apache.uniffle.client.response.RssReportShuffleFetchFailureResponse;
-import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.exception.RssFetchFailedException;
 
@@ -52,8 +49,8 @@ public class RssFetchFailedIterator<K, C> extends AbstractIterator<Product2<K, C
     private int shuffleId;
     private int partitionId;
     private int stageAttemptId;
-    private String reportServerHost;
-    private int reportServerPort;
+    private Function<RssReportShuffleFetchFailureRequest, RssReportShuffleFetchFailureResponse>
+        sendReportFunc;
 
     private Builder() {}
 
@@ -77,19 +74,15 @@ public class RssFetchFailedIterator<K, C> extends AbstractIterator<Product2<K, C
       return this;
     }
 
-    Builder reportServerHost(String host) {
-      this.reportServerHost = host;
-      return this;
-    }
-
-    Builder port(int port) {
-      this.reportServerPort = port;
+    Builder doReportFun(
+        Function<RssReportShuffleFetchFailureRequest, RssReportShuffleFetchFailureResponse>
+            doReportFun) {
+      this.sendReportFunc = doReportFun;
       return this;
     }
 
     <K, C> RssFetchFailedIterator<K, C> build(Iterator<Product2<K, C>> iter) {
       Objects.requireNonNull(this.appId);
-      Objects.requireNonNull(this.reportServerHost);
       return new RssFetchFailedIterator<>(this, iter);
     }
   }
@@ -98,37 +91,25 @@ public class RssFetchFailedIterator<K, C> extends AbstractIterator<Product2<K, C
     return new Builder();
   }
 
-  private static ShuffleManagerClient createShuffleManagerClient(String host, int port)
-      throws IOException {
-    ClientType grpc = ClientType.GRPC;
-    // host is passed from spark.driver.bindAddress, which would be set when SparkContext is
-    // constructed.
-    return ShuffleManagerClientFactory.getInstance().createShuffleManagerClient(grpc, host, port);
-  }
-
-  private RssException generateFetchFailedIfNecessary(RssFetchFailedException e) {
-    String driver = builder.reportServerHost;
-    int port = builder.reportServerPort;
-    // todo: reuse this manager client if this is a bottleneck.
-    try (ShuffleManagerClient client = createShuffleManagerClient(driver, port)) {
-      RssReportShuffleFetchFailureRequest req =
-          new RssReportShuffleFetchFailureRequest(
-              builder.appId,
-              builder.shuffleId,
-              builder.stageAttemptId,
-              builder.partitionId,
-              e.getMessage());
-      RssReportShuffleFetchFailureResponse response = client.reportShuffleFetchFailure(req);
-      if (response.getReSubmitWholeStage()) {
-        // since we are going to roll out the whole stage, mapIndex shouldn't matter, hence -1 is
-        // provided.
-        FetchFailedException ffe =
-            RssSparkShuffleUtils.createFetchFailedException(
-                builder.shuffleId, -1, builder.partitionId, e);
-        return new RssException(ffe);
-      }
-    } catch (IOException ioe) {
-      LOG.info("Error closing shuffle manager client with error:", ioe);
+  private RssException generateFetchFailedIfNecessary(
+      RssFetchFailedException e,
+      Function<RssReportShuffleFetchFailureRequest, RssReportShuffleFetchFailureResponse>
+          doReportFun) {
+    RssReportShuffleFetchFailureRequest req =
+        new RssReportShuffleFetchFailureRequest(
+            builder.appId,
+            builder.shuffleId,
+            builder.stageAttemptId,
+            builder.partitionId,
+            e.getMessage());
+    RssReportShuffleFetchFailureResponse response = doReportFun.apply(req);
+    if (response.getReSubmitWholeStage()) {
+      // since we are going to roll out the whole stage, mapIndex shouldn't matter, hence -1 is
+      // provided.
+      FetchFailedException ffe =
+          RssSparkShuffleUtils.createFetchFailedException(
+              builder.shuffleId, -1, builder.partitionId, e);
+      return new RssException(ffe);
     }
     return e;
   }
@@ -138,7 +119,7 @@ public class RssFetchFailedIterator<K, C> extends AbstractIterator<Product2<K, C
     try {
       return this.iter.hasNext();
     } catch (RssFetchFailedException e) {
-      throw generateFetchFailedIfNecessary(e);
+      throw generateFetchFailedIfNecessary(e, builder.sendReportFunc);
     }
   }
 
@@ -147,7 +128,7 @@ public class RssFetchFailedIterator<K, C> extends AbstractIterator<Product2<K, C
     try {
       return this.iter.next();
     } catch (RssFetchFailedException e) {
-      throw generateFetchFailedIfNecessary(e);
+      throw generateFetchFailedIfNecessary(e, builder.sendReportFunc);
     }
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -534,6 +534,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         this,
         sparkConf,
         shuffleWriteClient,
+        shuffleManagerClient,
         rssHandle,
         this::markFailedTask,
         context,
@@ -721,6 +722,7 @@ public class RssShuffleManager extends RssShuffleManagerBase {
             blockIdBitmap, startPartition, endPartition, blockIdLayout),
         taskIdBitmap,
         readMetrics,
+        shuffleManagerClient,
         RssSparkConfig.toRssConf(sparkConf),
         dataDistributionType,
         shuffleHandleInfo.getAllPartitionServersForReader());

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.spark.shuffle.RssShuffleHandle;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssClientConf;
@@ -93,6 +94,7 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
     rssConf.set(RssClientConf.RSS_STORAGE_TYPE, StorageType.HDFS.name());
     rssConf.set(RssClientConf.RSS_INDEX_READ_LIMIT, 1000);
     rssConf.set(RssClientConf.RSS_CLIENT_READ_BUFFER_SIZE, "1000");
+    ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     RssShuffleReader<String, String> rssShuffleReaderSpy =
         spy(
             new RssShuffleReader<>(
@@ -108,6 +110,7 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 partitionToExpectBlocks,
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
+                mockShuffleManagerClient,
                 rssConf,
                 ShuffleDataDistributionType.NORMAL,
                 partitionToServers));
@@ -131,6 +134,7 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 partitionToExpectBlocks,
                 taskIdBitmap,
                 new ShuffleReadMetrics(),
+                mockShuffleManagerClient,
                 rssConf,
                 ShuffleDataDistributionType.NORMAL,
                 partitionToServers));
@@ -151,6 +155,7 @@ public class RssShuffleReaderTest extends AbstractRssReaderTest {
                 partitionToExpectBlocks,
                 Roaring64NavigableMap.bitmapOf(),
                 new ShuffleReadMetrics(),
+                mockShuffleManagerClient,
                 rssConf,
                 ShuffleDataDistributionType.NORMAL,
                 partitionToServers));

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -55,6 +55,7 @@ import org.apache.spark.shuffle.handle.SimpleShuffleHandleInfo;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
+import org.apache.uniffle.client.api.ShuffleManagerClient;
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
 import org.apache.uniffle.common.RemoteStorageInfo;
@@ -133,6 +134,7 @@ public class RssShuffleWriterTest {
     Serializer kryoSerializer = new KryoSerializer(conf);
     Partitioner mockPartitioner = mock(Partitioner.class);
     final ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    final ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     when(mockHandle.getDependency()).thenReturn(mockDependency);
@@ -179,6 +181,7 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             shuffleHandle,
             contextMock);
@@ -385,6 +388,7 @@ public class RssShuffleWriterTest {
     Serializer kryoSerializer = new KryoSerializer(conf);
     Partitioner mockPartitioner = mock(Partitioner.class);
     final ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    final ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     when(mockHandle.getDependency()).thenReturn(mockDependency);
@@ -450,6 +454,7 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             shuffleHandleInfo,
             contextMock);
@@ -552,6 +557,7 @@ public class RssShuffleWriterTest {
             conf, false, null, successBlocks, taskToFailedBlockSendTracker);
 
     ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     Partitioner mockPartitioner = mock(Partitioner.class);
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
@@ -587,6 +593,7 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             mockShuffleHandleInfo,
             contextMock);
@@ -714,6 +721,7 @@ public class RssShuffleWriterTest {
     Serializer kryoSerializer = new KryoSerializer(conf);
     Partitioner mockPartitioner = mock(Partitioner.class);
     final ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    final ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     when(mockHandle.getDependency()).thenReturn(mockDependency);
@@ -734,6 +742,7 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             mockShuffleHandleInfo,
             contextMock);
@@ -794,6 +803,7 @@ public class RssShuffleWriterTest {
     Serializer kryoSerializer = new KryoSerializer(conf);
     Partitioner mockPartitioner = mock(Partitioner.class);
     final ShuffleWriteClient mockShuffleWriteClient = mock(ShuffleWriteClient.class);
+    final ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
     ShuffleDependency<String, String, String> mockDependency = mock(ShuffleDependency.class);
     RssShuffleHandle<String, String, String> mockHandle = mock(RssShuffleHandle.class);
     when(mockHandle.getDependency()).thenReturn(mockDependency);
@@ -857,6 +867,7 @@ public class RssShuffleWriterTest {
             manager,
             conf,
             mockShuffleWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             mockShuffleHandleInfo,
             contextMock);
@@ -958,6 +969,7 @@ public class RssShuffleWriterTest {
     TaskContext contextMock = mock(TaskContext.class);
     SimpleShuffleHandleInfo mockShuffleHandleInfo = mock(SimpleShuffleHandleInfo.class);
     ShuffleWriteClient mockWriteClient = mock(ShuffleWriteClient.class);
+    ShuffleManagerClient mockShuffleManagerClient = mock(ShuffleManagerClient.class);
 
     List<ShuffleBlockInfo> shuffleBlockInfoList = createShuffleBlockList(1, 31);
     RssShuffleWriter<String, String, String> writer =
@@ -971,6 +983,7 @@ public class RssShuffleWriterTest {
             mockShuffleManager,
             conf,
             mockWriteClient,
+            mockShuffleManagerClient,
             mockHandle,
             mockShuffleHandleInfo,
             contextMock);


### PR DESCRIPTION
…fleWriter

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

1. The `createShuffleManagerClient` function is defined in both `RssShuffleWriter` and `RssFetchFailedIterator`.
2. The `ShuffleManagerClient` is created in `RssShuffleManager` when `shuffleManagerRpcServiceEnabled` is true. We can reuse the client in `RssShuffleReader` and `RssShuffleWriter`.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
ExistingUT