### PR TITLE
[#1847] fix[server]: Add Config and init bufferSize of ShuffleBufferManager

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -447,6 +447,14 @@ public class ShuffleServerConf extends RssBaseConf {
                   + " The cpu usage of the shuffle server will be reduced."
                   + " But SKIP_LIST doesn't support the slow-start feature of MR.");
 
+  public static final ConfigOption<Long> SERVER_SHUFFLE_BUFFER_SIZE =
+      ConfigOptions.key("rss.server.shuffleBuffer.size")
+          .longType()
+          .defaultValue(0L)
+          .withDescription(
+              "The size for shuffle buffers."
+                  + " The default value is 0 to keep consistant with the previous version.");
+
   public static final ConfigOption<Long> SERVER_SHUFFLE_FLUSH_THRESHOLD =
       ConfigOptions.key("rss.server.shuffle.flush.threshold")
           .longType()

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -139,6 +139,7 @@ public class ShuffleBufferManager {
     appBlockSizeMetricEnabled =
         conf.getBoolean(ShuffleServerConf.APP_LEVEL_SHUFFLE_BLOCK_SIZE_METRIC_ENABLED);
     shuffleBufferType = conf.get(ShuffleServerConf.SERVER_SHUFFLE_BUFFER_TYPE);
+    bufferSize = conf.get(ShuffleServerConf.SERVER_SHUFFLE_BUFFER_SIZE);
   }
 
   public void setShuffleTaskManager(ShuffleTaskManager taskManager) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Added a config for ShuffleBufferManager#bufferSize and assigned the config value within constructor of ShuffleBufferManager

### Why are the changes needed?

Fix: #1847

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

2. Addition key `rss.server.shuffleBuffer.size` defaults to 0 to keep consistent with previous. 

### How was this patch tested?

No need.
