### PR TITLE
[#1628] fix: Retain netty byteBuf when decoding

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleDataResponse.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleDataResponse.java
@@ -36,7 +36,7 @@ public class GetLocalShuffleDataResponse extends RpcResponse {
     StatusCode statusCode = StatusCode.fromCode(byteBuf.readInt());
     String retMessage = ByteBufUtils.readLengthAndString(byteBuf);
     if (decodeBody) {
-      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf);
+      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf.retain());
       return new GetLocalShuffleDataResponse(requestId, statusCode, retMessage, nettyManagedBuffer);
     } else {
       return new GetLocalShuffleDataResponse(

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleIndexResponse.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetLocalShuffleIndexResponse.java
@@ -75,7 +75,7 @@ public class GetLocalShuffleIndexResponse extends RpcResponse {
     String retMessage = ByteBufUtils.readLengthAndString(byteBuf);
     long fileLength = byteBuf.readLong();
     if (decodeBody) {
-      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf);
+      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf.retain());
       return new GetLocalShuffleIndexResponse(
           requestId, statusCode, retMessage, nettyManagedBuffer, fileLength);
     } else {

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetMemoryShuffleDataResponse.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/GetMemoryShuffleDataResponse.java
@@ -81,7 +81,7 @@ public class GetMemoryShuffleDataResponse extends RpcResponse {
     String retMessage = ByteBufUtils.readLengthAndString(byteBuf);
     List<BufferSegment> bufferSegments = Decoders.decodeBufferSegments(byteBuf);
     if (decodeBody) {
-      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf);
+      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf.retain());
       return new GetMemoryShuffleDataResponse(
           requestId, statusCode, retMessage, bufferSegments, nettyManagedBuffer);
     } else {

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/RpcResponse.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/RpcResponse.java
@@ -83,7 +83,7 @@ public class RpcResponse extends ResponseMessage {
     StatusCode statusCode = StatusCode.fromCode(byteBuf.readInt());
     String retMessage = ByteBufUtils.readLengthAndString(byteBuf);
     if (decodeBody) {
-      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf);
+      NettyManagedBuffer nettyManagedBuffer = new NettyManagedBuffer(byteBuf.retain());
       return new RpcResponse(requestId, statusCode, retMessage, nettyManagedBuffer);
     } else {
       return new RpcResponse(requestId, statusCode, retMessage, NettyManagedBuffer.EMPTY_BUFFER);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Retain netty byteBuf when decoding

### Why are the changes needed?

Fix: #1628

I noticed that in spark, when constructing `NettyManagedBuffer` through netty` byteBuf`, `byteBuf.retain` is called. I think we should do the same.

![image](https://github.com/apache/incubator-uniffle/assets/17894939/30581e0d-f245-4aa2-abeb-4f58bb739da8)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

TODO