### PR TITLE
[MINOR] fix(dashboard): Correct RegistrationTime to HeartbeatTime

### DIFF
--- a/dashboard/src/main/webapp/src/pages/serverstatus/ActiveNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/ActiveNodeListPage.vue
@@ -39,7 +39,7 @@
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
         prop="timestamp"
-        label="RegistrationTime"
+        label="HeartbeatTime"
         min-width="80"
         :formatter="dateFormatter"
       />

--- a/dashboard/src/main/webapp/src/pages/serverstatus/DecommissionednodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/DecommissionednodeListPage.vue
@@ -39,7 +39,7 @@
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
         prop="timestamp"
-        label="RegistrationTime"
+        label="HeartbeatTime"
         min-width="80"
         :formatter="dateFormatter"
       />

--- a/dashboard/src/main/webapp/src/pages/serverstatus/DecommissioningNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/DecommissioningNodeListPage.vue
@@ -39,7 +39,7 @@
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
         prop="timestamp"
-        label="RegistrationTime"
+        label="HeartbeatTime"
         min-width="80"
         :formatter="dateFormatter"
       />

--- a/dashboard/src/main/webapp/src/pages/serverstatus/LostNodeList.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/LostNodeList.vue
@@ -39,7 +39,7 @@
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
         prop="timestamp"
-        label="RegistrationTime"
+        label="HeartbeatTime"
         min-width="80"
         :formatter="dateFormatter"
       />

--- a/dashboard/src/main/webapp/src/pages/serverstatus/UnhealthyNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/UnhealthyNodeListPage.vue
@@ -39,7 +39,7 @@
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
         prop="timestamp"
-        label="RegistrationTime"
+        label="HeartbeatTime"
         min-width="80"
         :formatter="dateFormatter"
       />


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

The `RegistrationTime` in the dashboard shuffle-server page can make us confuse, I think it could be better to be  `HeartbeatTime`.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Make the displayed title more meaningful.

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

WebUI of dashboard

### How was this patch tested?

<img width="2421" alt="image" src="https://github.com/apache/incubator-uniffle/assets/17329931/b46a1560-9b17-4e63-88b4-465d2b83ff08">

