### PR TITLE
[MINOR] Improvement(dashboard): Support display human-readable time format for app page

### DIFF
--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -96,7 +96,7 @@ export default {
         getAppTotalPage()
       }
     })
-    return { pageData, memFormatter, dateFormatter }
+    return { pageData, dateFormatter }
   }
 }
 </script>

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -43,7 +43,7 @@
       <el-table :data="pageData.appInfoData" height="250" style="width: 100%">
         <el-table-column prop="appId" label="AppId" min-width="180" />
         <el-table-column prop="userName" label="UserName" min-width="180" />
-        <el-table-column prop="updateTime" label="Update Time" min-width="180" />
+        <el-table-column prop="updateTime" label="Update Time" min-width="180" :formatter="dateFormatter" />
       </el-table>
     </div>
   </div>
@@ -52,6 +52,7 @@
 <script>
 import { getApplicationInfoList, getAppTotal, getTotalForUser } from '@/api/api'
 import { onMounted, reactive } from 'vue'
+import { memFormatter, dateFormatter } from '@/utils/common'
 import { useCurrentServerStore } from '@/store/useCurrentServerStore'
 
 export default {
@@ -95,7 +96,7 @@ export default {
         getAppTotalPage()
       }
     })
-    return { pageData }
+    return { pageData, memFormatter, dateFormatter }
   }
 }
 </script>

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -52,7 +52,7 @@
 <script>
 import { getApplicationInfoList, getAppTotal, getTotalForUser } from '@/api/api'
 import { onMounted, reactive } from 'vue'
-import { memFormatter, dateFormatter } from '@/utils/common'
+import { dateFormatter } from '@/utils/common'
 import { useCurrentServerStore } from '@/store/useCurrentServerStore'
 
 export default {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Display the human-readable time format in application page.

### Why are the changes needed?

A long type timestamp really hard to get information from it.

### Does this PR introduce _any_ user-facing change?

Format the update time to human-readable.

### How was this patch tested?

<img width="1889" alt="image" src="https://github.com/apache/incubator-uniffle/assets/17329931/4aa42a38-f058-4a59-8582-8840c83cf54b">

