### PR TITLE
[MINOR] fix(dashboard): Fix NPE when targetAddress is null for /api/server/nodes

### DIFF
--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/JettyServerFront.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/JettyServerFront.java
@@ -23,6 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.org.glassfish.jersey.server.ServerProperties;
 import org.apache.hbase.thirdparty.org.glassfish.jersey.servlet.ServletContainer;
 import org.eclipse.jetty.server.Handler;
@@ -92,6 +93,7 @@ public class JettyServerFront {
     HandlerList handlers = new HandlerList();
     ResourceHandler resourceHandler = addResourceHandler();
     String coordinatorWebAddress = conf.getString(DashboardConf.COORDINATOR_WEB_ADDRESS);
+    Preconditions.checkNotNull(coordinatorWebAddress, "Coordinator web address is null");
     Map<String, String> stringStringMap =
         DashboardUtils.convertAddressesStrToMap(coordinatorWebAddress);
 

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -35,8 +35,8 @@ public class WebProxyServlet extends ProxyServlet {
   private Map<String, String> coordinatorServerAddressesMap;
 
   public WebProxyServlet(Map<String, String> coordinatorServerAddressesMap) {
-    Preconditions.checkArgument(coordinatorServerAddressesMap.isEmpty(),
-        "No coordinator server address found.");
+    Preconditions.checkArgument(
+        coordinatorServerAddressesMap.isEmpty(), "No coordinator server address found.");
     this.coordinatorServerAddressesMap = coordinatorServerAddressesMap;
   }
 

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -49,10 +49,6 @@ public class WebProxyServlet extends ProxyServlet {
         coordinatorServerAddressesMap.get(clientRequest.getHeader("targetAddress"));
     if (targetAddress == null) {
       // Get random one from coordinatorServerAddressesMap
-      if (coordinatorServerAddressesMap.isEmpty()) {
-        LOG.error("No coordinator server address found.");
-        return null;
-      }
       targetAddress = coordinatorServerAddressesMap.values().iterator().next();
     }
     StringBuilder target = new StringBuilder();

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -46,6 +46,10 @@ public class WebProxyServlet extends ProxyServlet {
         coordinatorServerAddressesMap.get(clientRequest.getHeader("targetAddress"));
     if (targetAddress == null) {
       // Get random one from coordinatorServerAddressesMap
+      if (coordinatorServerAddressesMap.isEmpty()) {
+        LOG.error("No coordinator server address found.");
+        return null;
+      }
       targetAddress = coordinatorServerAddressesMap.values().iterator().next();
     }
     StringBuilder target = new StringBuilder();

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.base.Preconditions;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.proxy.ProxyServlet;
@@ -34,6 +35,8 @@ public class WebProxyServlet extends ProxyServlet {
   private Map<String, String> coordinatorServerAddressesMap;
 
   public WebProxyServlet(Map<String, String> coordinatorServerAddressesMap) {
+    Preconditions.checkArgument(coordinatorServerAddressesMap.isEmpty(),
+        "No coordinator server address found.");
     this.coordinatorServerAddressesMap = coordinatorServerAddressesMap;
   }
 

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -45,7 +45,8 @@ public class WebProxyServlet extends ProxyServlet {
     String targetAddress =
         coordinatorServerAddressesMap.get(clientRequest.getHeader("targetAddress"));
     if (targetAddress == null) {
-      return null;
+      // Get random one from coordinatorServerAddressesMap
+      targetAddress = coordinatorServerAddressesMap.values().iterator().next();
     }
     StringBuilder target = new StringBuilder();
     if (targetAddress.endsWith("/")) {

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/proxy/WebProxyServlet.java
@@ -44,6 +44,9 @@ public class WebProxyServlet extends ProxyServlet {
     }
     String targetAddress =
         coordinatorServerAddressesMap.get(clientRequest.getHeader("targetAddress"));
+    if (targetAddress == null) {
+      return null;
+    }
     StringBuilder target = new StringBuilder();
     if (targetAddress.endsWith("/")) {
       targetAddress = targetAddress.substring(0, targetAddress.length() - 1);

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/utils/DashboardUtils.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/utils/DashboardUtils.java
@@ -31,7 +31,7 @@ public class DashboardUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DashboardUtils.class);
 
   public static Map<String, String> convertAddressesStrToMap(String coordinatorAddressesStr) {
-    Preconditions.checkNotNull(coordinatorAddressesStr);
+    Preconditions.checkNotNull(coordinatorAddressesStr, "Coordinator web address is null");
     HashMap<String, String> coordinatorAddressMap = Maps.newHashMap();
     String[] coordinators = coordinatorAddressesStr.split(",");
     for (String coordinator : coordinators) {

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/utils/DashboardUtils.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/utils/DashboardUtils.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ public class DashboardUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DashboardUtils.class);
 
   public static Map<String, String> convertAddressesStrToMap(String coordinatorAddressesStr) {
+    Preconditions.checkNotNull(coordinatorAddressesStr);
     HashMap<String, String> coordinatorAddressMap = Maps.newHashMap();
     String[] coordinators = coordinatorAddressesStr.split(",");
     for (String coordinator : coordinators) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

I use rest api without given `targetAddress`, the NPE encountered.

```Console
➜  ~ curl 'http://localhost:19988/api/server/nodes?status=active'
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 </title>
</head>
<body>
<h2>HTTP ERROR: 500</h2>
<p>Problem accessing /api/server/nodes. Reason:
<pre>    java.lang.NullPointerException</pre></p>
<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.24.v20180605</a><hr/>
</body>
</html>
```

### Why are the changes needed?

Fix the NPE.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```Console
 curl 'http://localhost:19988/api/server/nodes?status=active'
```
