### PR TITLE
[#1847] refactor: Remove capacity and related codes within AbstractShuffleBuffer

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
@@ -39,11 +39,9 @@ public abstract class AbstractShuffleBuffer implements ShuffleBuffer {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractShuffleBuffer.class);
 
-  private final long capacity;
   protected long size;
 
-  public AbstractShuffleBuffer(long capacity) {
-    this.capacity = capacity;
+  public AbstractShuffleBuffer() {
     this.size = 0;
   }
 
@@ -67,11 +65,6 @@ public abstract class AbstractShuffleBuffer implements ShuffleBuffer {
   @Override
   public long getSize() {
     return size;
-  }
-
-  @Override
-  public boolean isFull() {
-    return size > capacity;
   }
 
   @Override

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -52,8 +52,6 @@ public interface ShuffleBuffer {
 
   long getSize();
 
-  boolean isFull();
-
   /** Only for test */
   List<ShufflePartitionedBlock> getBlocks();
 

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -156,9 +156,9 @@ public class ShuffleBufferManager {
       ShuffleServerMetrics.gaugeTotalPartitionNum.inc();
       ShuffleBuffer shuffleBuffer;
       if (shuffleBufferType == ShuffleBufferType.SKIP_LIST) {
-        shuffleBuffer = new ShuffleBufferWithSkipList(bufferSize);
+        shuffleBuffer = new ShuffleBufferWithSkipList();
       } else {
-        shuffleBuffer = new ShuffleBufferWithLinkedList(bufferSize);
+        shuffleBuffer = new ShuffleBufferWithLinkedList();
       }
       bufferRangeMap.put(Range.closed(startPartition, endPartition), shuffleBuffer);
     } else {

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -74,8 +74,6 @@ public class ShuffleBufferManager {
   // Huge partition vars
   private ReconfigurableConfManager.Reconfigurable<Long> hugePartitionSizeThresholdRef;
   private long hugePartitionMemoryLimitSize;
-
-  protected long bufferSize = 0;
   protected AtomicLong preAllocatedSize = new AtomicLong(0L);
   protected AtomicLong inFlushSize = new AtomicLong(0L);
   protected AtomicLong usedMemory = new AtomicLong(0L);

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -42,8 +42,7 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
   private List<ShufflePartitionedBlock> blocks;
   private Map<Long, List<ShufflePartitionedBlock>> inFlushBlockMap;
 
-  public ShuffleBufferWithLinkedList(long capacity) {
-    super(capacity);
+  public ShuffleBufferWithLinkedList() {
     this.blocks = new LinkedList<>();
     this.inFlushBlockMap = JavaUtils.newConcurrentMap();
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -44,8 +44,7 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   private final Map<Long, ConcurrentSkipListMap<Long, ShufflePartitionedBlock>> inFlushBlockMap;
   private int blockCount;
 
-  public ShuffleBufferWithSkipList(long capacity) {
-    super(capacity);
+  public ShuffleBufferWithSkipList() {
     this.blocksMap = newConcurrentSkipListMap();
     this.inFlushBlockMap = JavaUtils.newConcurrentMap();
   }

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
@@ -35,7 +35,6 @@ import org.apache.uniffle.server.ShuffleDataFlushEvent;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,7 +44,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
 
   @Test
   public void appendTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     shuffleBuffer.append(createData(10));
     // ShufflePartitionedBlock has constant 32 bytes overhead
     assertEquals(42, shuffleBuffer.getSize());
@@ -59,7 +58,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
 
   @Test
   public void appendMultiBlocksTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     ShufflePartitionedData data1 = createData(10);
     ShufflePartitionedData data2 = createData(10);
     ShufflePartitionedBlock[] dataCombine = new ShufflePartitionedBlock[2];
@@ -71,7 +70,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
 
   @Test
   public void toFlushEventTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     ShuffleDataFlushEvent event = shuffleBuffer.toFlushEvent("appId", 0, 0, 1, null);
     assertNull(event);
     shuffleBuffer.append(createData(10));
@@ -85,7 +84,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
   @Test
   public void getShuffleDataWithExpectedTaskIdsFilterTest() {
     /** case1: all blocks in cached(or in flushed map) and size < readBufferSize */
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     ShufflePartitionedData spd1 = createData(1, 1, 15);
     ShufflePartitionedData spd2 = createData(1, 0, 15);
     ShufflePartitionedData spd3 = createData(1, 2, 55);
@@ -197,7 +196,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
 
   @Test
   public void getShuffleDataWithLocalOrderTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     ShufflePartitionedData spd1 = createData(1, 1, 15);
     ShufflePartitionedData spd2 = createData(1, 0, 15);
     ShufflePartitionedData spd3 = createData(1, 2, 15);
@@ -235,7 +234,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
 
   @Test
   public void getShuffleDataTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
     // case1: cached data only, blockId = -1, readBufferSize > buffer size
     ShufflePartitionedData spd1 = createData(10);
     ShufflePartitionedData spd2 = createData(20);
@@ -247,7 +246,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertArrayEquals(expectedData, sdr.getData());
 
     // case2: cached data only, blockId = -1, readBufferSize = buffer size
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     spd1 = createData(20);
     spd2 = createData(20);
     shuffleBuffer.append(spd1);
@@ -258,7 +257,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertArrayEquals(expectedData, sdr.getData());
 
     // case3-1: cached data only, blockId = -1, readBufferSize < buffer size
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     spd1 = createData(20);
     spd2 = createData(21);
     shuffleBuffer.append(spd1);
@@ -269,7 +268,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertArrayEquals(expectedData, sdr.getData());
 
     // case3-2: cached data only, blockId = -1, readBufferSize < buffer size
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     spd1 = createData(15);
     spd2 = createData(15);
     ShufflePartitionedData spd3 = createData(15);
@@ -289,7 +288,7 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertArrayEquals(expectedData, sdr.getData());
 
     // case5: flush data only, blockId = -1, readBufferSize < buffer size
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     spd1 = createData(15);
     spd2 = createData(15);
     shuffleBuffer.append(spd1);
@@ -307,13 +306,13 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertEquals(0, sdr.getBufferSegments().size());
 
     // case6: no data in buffer & flush buffer
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 10);
     assertEquals(0, sdr.getBufferSegments().size());
     assertEquals(0, sdr.getDataLength());
 
     // case7: get data with multiple flush buffer and cached buffer
-    shuffleBuffer = new ShuffleBufferWithLinkedList(200);
+    shuffleBuffer = new ShuffleBufferWithLinkedList();
     spd1 = createData(15);
     spd2 = createData(15);
     spd3 = createData(15);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
@@ -49,15 +49,12 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     shuffleBuffer.append(createData(10));
     // ShufflePartitionedBlock has constant 32 bytes overhead
     assertEquals(42, shuffleBuffer.getSize());
-    assertFalse(shuffleBuffer.isFull());
 
     shuffleBuffer.append(createData(26));
     assertEquals(100, shuffleBuffer.getSize());
-    assertFalse(shuffleBuffer.isFull());
 
     shuffleBuffer.append(createData(1));
     assertEquals(133, shuffleBuffer.getSize());
-    assertTrue(shuffleBuffer.isFull());
   }
 
   @Test

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
@@ -31,7 +31,6 @@ import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.server.ShuffleDataFlushEvent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
@@ -40,24 +40,21 @@ public class ShuffleBufferWithSkipListTest extends BufferTestBase {
 
   @Test
   public void appendTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList();
     shuffleBuffer.append(createData(10));
     // ShufflePartitionedBlock has constant 32 bytes overhead
     assertEquals(42, shuffleBuffer.getSize());
-    assertFalse(shuffleBuffer.isFull());
 
     shuffleBuffer.append(createData(26));
     assertEquals(100, shuffleBuffer.getSize());
-    assertFalse(shuffleBuffer.isFull());
 
     shuffleBuffer.append(createData(1));
     assertEquals(133, shuffleBuffer.getSize());
-    assertTrue(shuffleBuffer.isFull());
   }
 
   @Test
   public void appendMultiBlocksTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList();
     ShufflePartitionedData data1 = createData(10);
     ShufflePartitionedData data2 = createData(10);
     ShufflePartitionedBlock[] dataCombine = new ShufflePartitionedBlock[2];
@@ -69,7 +66,7 @@ public class ShuffleBufferWithSkipListTest extends BufferTestBase {
 
   @Test
   public void toFlushEventTest() {
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList();
     ShuffleDataFlushEvent event = shuffleBuffer.toFlushEvent("appId", 0, 0, 1, null);
     assertNull(event);
     shuffleBuffer.append(createData(10));
@@ -83,7 +80,7 @@ public class ShuffleBufferWithSkipListTest extends BufferTestBase {
   @Test
   public void getShuffleDataWithExpectedTaskIdsFilterTest() {
     /** case1: all blocks in cached(or in flushed map) and size < readBufferSize */
-    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList(100);
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList();
     ShufflePartitionedData spd1 = createData(1, 1, 15);
     ShufflePartitionedData spd2 = createData(1, 0, 15);
     ShufflePartitionedData spd3 = createData(1, 2, 55);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove `capacity` and related codes within `AbstractShuffleBuffer`.

### Why are the changes needed?

Fix: #1847.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
