### PR TITLE
[#1860] feat(CLI/Coordinator/Dashboard): Add Reg time to AppInfo and Application

### DIFF
--- a/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
+++ b/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
@@ -59,8 +59,8 @@ public class UniffleCLI extends AbstractCustomCommandLine {
   private final Option help;
 
   private static final List<String> APPLICATIONS_HEADER =
-      Arrays.asList("ApplicationId", "User", "Register Time",
-          "Last HeartBeatTime", "RemoteStoragePath");
+      Arrays.asList(
+          "ApplicationId", "User", "Register Time", "Last HeartBeatTime", "RemoteStoragePath");
 
   public UniffleCLI(String shortPrefix, String longPrefix) {
     allOptions = new Options();

--- a/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
+++ b/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
@@ -59,7 +59,8 @@ public class UniffleCLI extends AbstractCustomCommandLine {
   private final Option help;
 
   private static final List<String> APPLICATIONS_HEADER =
-      Arrays.asList("ApplicationId", "User", "Last HeartBeatTime", "RemoteStoragePath");
+      Arrays.asList("ApplicationId", "User", "Register Time",
+          "Last HeartBeatTime", "RemoteStoragePath");
 
   public UniffleCLI(String shortPrefix, String longPrefix) {
     allOptions = new Options();
@@ -222,6 +223,7 @@ public class UniffleCLI extends AbstractCustomCommandLine {
                     formattingCLIUtils.addLine(
                         app.getApplicationId(),
                         app.getUser(),
+                        app.getRegisterTime(),
                         app.getLastHeartBeatTime(),
                         app.getRemoteStoragePath()));
           }

--- a/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
+++ b/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
@@ -223,7 +223,7 @@ public class UniffleCLI extends AbstractCustomCommandLine {
                     formattingCLIUtils.addLine(
                         app.getApplicationId(),
                         app.getUser(),
-                        app.getRegisterTime(),
+                        app.getRegistrationTime(),
                         app.getLastHeartBeatTime(),
                         app.getRemoteStoragePath()));
           }

--- a/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
+++ b/cli/src/main/java/org/apache/uniffle/cli/UniffleCLI.java
@@ -60,7 +60,7 @@ public class UniffleCLI extends AbstractCustomCommandLine {
 
   private static final List<String> APPLICATIONS_HEADER =
       Arrays.asList(
-          "ApplicationId", "User", "Register Time", "Last HeartBeatTime", "RemoteStoragePath");
+          "ApplicationId", "User", "Registration Time", "Last HeartBeatTime", "RemoteStoragePath");
 
   public UniffleCLI(String shortPrefix, String longPrefix) {
     allOptions = new Options();

--- a/common/src/main/java/org/apache/uniffle/common/Application.java
+++ b/common/src/main/java/org/apache/uniffle/common/Application.java
@@ -28,6 +28,7 @@ public class Application implements Comparable<Application> {
   private String user;
   private String lastHeartBeatTime;
   private String remoteStoragePath;
+  private String registerTime;
 
   public Application() {}
 
@@ -36,12 +37,14 @@ public class Application implements Comparable<Application> {
     this.user = builder.user;
     this.lastHeartBeatTime = builder.lastHeartBeatTime;
     this.remoteStoragePath = builder.remoteStoragePath;
+    this.registerTime = builder.registerTime;
   }
 
   public static class Builder {
     private String applicationId;
     private String user;
     private String lastHeartBeatTime;
+    private String registerTime;
     private String remoteStoragePath;
 
     public Builder() {}
@@ -58,6 +61,11 @@ public class Application implements Comparable<Application> {
 
     public Builder lastHeartBeatTime(long lastHeartBeatTime) {
       this.lastHeartBeatTime = DateFormatUtils.format(lastHeartBeatTime, DATE_PATTERN);
+      return this;
+    }
+
+    public Builder registerTime(long registerTime) {
+      this.registerTime = DateFormatUtils.format(registerTime, DATE_PATTERN);
       return this;
     }
 
@@ -85,6 +93,10 @@ public class Application implements Comparable<Application> {
     return lastHeartBeatTime;
   }
 
+  public String getRegisterTime() {
+    return registerTime;
+  }
+
   public String getRemoteStoragePath() {
     return remoteStoragePath;
   }
@@ -101,6 +113,10 @@ public class Application implements Comparable<Application> {
     this.lastHeartBeatTime = lastHeartBeatTime;
   }
 
+  public void setRegisterTime(String registerTime) {
+    this.registerTime = registerTime;
+  }
+
   public void setRemoteStoragePath(String remoteStoragePath) {
     this.remoteStoragePath = remoteStoragePath;
   }
@@ -115,6 +131,7 @@ public class Application implements Comparable<Application> {
         .append(this.getApplicationId(), otherImpl.getApplicationId())
         .append(this.getUser(), otherImpl.getUser())
         .append(this.getLastHeartBeatTime(), otherImpl.getLastHeartBeatTime())
+        .append(this.getRegisterTime(), otherImpl.getRegisterTime())
         .append(this.getRemoteStoragePath(), otherImpl.getRemoteStoragePath())
         .isEquals();
   }
@@ -125,6 +142,7 @@ public class Application implements Comparable<Application> {
         .append(this.getApplicationId())
         .append(this.getUser())
         .append(this.getLastHeartBeatTime())
+        .append(this.getRegisterTime())
         .append(this.getRemoteStoragePath())
         .toHashCode();
   }
@@ -145,6 +163,9 @@ public class Application implements Comparable<Application> {
         + '\''
         + ", lastHeartBeatTime='"
         + lastHeartBeatTime
+        + '\''
+        + ", registerTime='"
+        + registerTime
         + '\''
         + ", remoteStoragePath='"
         + remoteStoragePath

--- a/common/src/main/java/org/apache/uniffle/common/Application.java
+++ b/common/src/main/java/org/apache/uniffle/common/Application.java
@@ -28,7 +28,7 @@ public class Application implements Comparable<Application> {
   private String user;
   private String lastHeartBeatTime;
   private String remoteStoragePath;
-  private String registerTime;
+  private String registrationTime;
 
   public Application() {}
 
@@ -37,14 +37,14 @@ public class Application implements Comparable<Application> {
     this.user = builder.user;
     this.lastHeartBeatTime = builder.lastHeartBeatTime;
     this.remoteStoragePath = builder.remoteStoragePath;
-    this.registerTime = builder.registerTime;
+    this.registrationTime = builder.registrationTime;
   }
 
   public static class Builder {
     private String applicationId;
     private String user;
     private String lastHeartBeatTime;
-    private String registerTime;
+    private String registrationTime;
     private String remoteStoragePath;
 
     public Builder() {}
@@ -64,8 +64,8 @@ public class Application implements Comparable<Application> {
       return this;
     }
 
-    public Builder registerTime(long registerTime) {
-      this.registerTime = DateFormatUtils.format(registerTime, DATE_PATTERN);
+    public Builder registrationTime(long registrationTime) {
+      this.registrationTime = DateFormatUtils.format(registrationTime, DATE_PATTERN);
       return this;
     }
 
@@ -93,8 +93,8 @@ public class Application implements Comparable<Application> {
     return lastHeartBeatTime;
   }
 
-  public String getRegisterTime() {
-    return registerTime;
+  public String getRegistrationTime() {
+    return registrationTime;
   }
 
   public String getRemoteStoragePath() {
@@ -113,8 +113,8 @@ public class Application implements Comparable<Application> {
     this.lastHeartBeatTime = lastHeartBeatTime;
   }
 
-  public void setRegisterTime(String registerTime) {
-    this.registerTime = registerTime;
+  public void setRegistrationTime(String registrationTime) {
+    this.registrationTime = registrationTime;
   }
 
   public void setRemoteStoragePath(String remoteStoragePath) {
@@ -131,7 +131,7 @@ public class Application implements Comparable<Application> {
         .append(this.getApplicationId(), otherImpl.getApplicationId())
         .append(this.getUser(), otherImpl.getUser())
         .append(this.getLastHeartBeatTime(), otherImpl.getLastHeartBeatTime())
-        .append(this.getRegisterTime(), otherImpl.getRegisterTime())
+        .append(this.getRegistrationTime(), otherImpl.getRegistrationTime())
         .append(this.getRemoteStoragePath(), otherImpl.getRemoteStoragePath())
         .isEquals();
   }
@@ -142,7 +142,7 @@ public class Application implements Comparable<Application> {
         .append(this.getApplicationId())
         .append(this.getUser())
         .append(this.getLastHeartBeatTime())
-        .append(this.getRegisterTime())
+        .append(this.getRegistrationTime())
         .append(this.getRemoteStoragePath())
         .toHashCode();
   }
@@ -164,8 +164,8 @@ public class Application implements Comparable<Application> {
         + ", lastHeartBeatTime='"
         + lastHeartBeatTime
         + '\''
-        + ", registerTime='"
-        + registerTime
+        + ", registrationTime='"
+        + registrationTime
         + '\''
         + ", remoteStoragePath='"
         + remoteStoragePath

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/AppInfo.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/AppInfo.java
@@ -15,29 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.uniffle.coordinator.web.vo;
+package org.apache.uniffle.coordinator;
 
 import java.util.Objects;
 
-public class AppInfoVO implements Comparable<AppInfoVO> {
-  private String userName;
+public class AppInfo implements Comparable<AppInfo> {
   private String appId;
   private long updateTime;
   private long registerTime;
 
-  public AppInfoVO(String userName, String appId, long updateTime, long registerTime) {
-    this.userName = userName;
+  public AppInfo(String appId, long updateTime, long registerTime) {
     this.appId = appId;
     this.updateTime = updateTime;
     this.registerTime = registerTime;
-  }
-
-  public String getUserName() {
-    return userName;
-  }
-
-  public void setUserName(String userName) {
-    this.userName = userName;
   }
 
   public String getAppId() {
@@ -65,8 +55,8 @@ public class AppInfoVO implements Comparable<AppInfoVO> {
   }
 
   @Override
-  public int compareTo(AppInfoVO appInfoVO) {
-    return Long.compare(registerTime, appInfoVO.getRegisterTime());
+  public int compareTo(AppInfo appInfo) {
+    return Long.compare(registerTime, appInfo.getRegisterTime());
   }
 
   @Override
@@ -74,18 +64,21 @@ public class AppInfoVO implements Comparable<AppInfoVO> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof AppInfoVO)) {
+    if (!(o instanceof AppInfo)) {
       return false;
     }
-    AppInfoVO appInfoVO = (AppInfoVO) o;
-    return updateTime == appInfoVO.updateTime
-        && registerTime == appInfoVO.registerTime
-        && userName.equals(appInfoVO.userName)
-        && appId.equals(appInfoVO.appId);
+    AppInfo appInfo = (AppInfo) o;
+    return updateTime == appInfo.updateTime
+        && registerTime == appInfo.registerTime
+        && appId.equals(appInfo.appId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userName, appId, updateTime, registerTime);
+    return Objects.hash(appId, updateTime, registerTime);
+  }
+
+  public static AppInfo createAppInfo(String appId, long updateTime) {
+    return new AppInfo(appId, updateTime, updateTime);
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/AppInfo.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/AppInfo.java
@@ -22,12 +22,12 @@ import java.util.Objects;
 public class AppInfo implements Comparable<AppInfo> {
   private String appId;
   private long updateTime;
-  private long registerTime;
+  private long registrationTime;
 
-  public AppInfo(String appId, long updateTime, long registerTime) {
+  public AppInfo(String appId, long updateTime, long registrationTime) {
     this.appId = appId;
     this.updateTime = updateTime;
-    this.registerTime = registerTime;
+    this.registrationTime = registrationTime;
   }
 
   public String getAppId() {
@@ -46,17 +46,17 @@ public class AppInfo implements Comparable<AppInfo> {
     this.updateTime = updateTime;
   }
 
-  public long getRegisterTime() {
-    return registerTime;
+  public long getRegistrationTime() {
+    return registrationTime;
   }
 
-  public void setRegisterTime(long registerTime) {
-    this.registerTime = registerTime;
+  public void setRegistrationTime(long registrationTime) {
+    this.registrationTime = registrationTime;
   }
 
   @Override
   public int compareTo(AppInfo appInfo) {
-    return Long.compare(registerTime, appInfo.getRegisterTime());
+    return Long.compare(registrationTime, appInfo.getRegistrationTime());
   }
 
   @Override
@@ -69,13 +69,13 @@ public class AppInfo implements Comparable<AppInfo> {
     }
     AppInfo appInfo = (AppInfo) o;
     return updateTime == appInfo.updateTime
-        && registerTime == appInfo.registerTime
+        && registrationTime == appInfo.registrationTime
         && appId.equals(appInfo.appId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(appId, updateTime, registerTime);
+    return Objects.hash(appId, updateTime, registrationTime);
   }
 
   public static AppInfo createAppInfo(String appId, long updateTime) {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
@@ -72,7 +72,7 @@ public class ApplicationManager implements Closeable {
   private final Map<String, RemoteStorageInfo> availableRemoteStorageInfo;
   private final ScheduledExecutorService detectStorageScheduler;
   private final ScheduledExecutorService checkAppScheduler;
-  private Map<String, Map<String, Long>> currentUserAndApp = JavaUtils.newConcurrentMap();
+  private Map<String, Map<String, AppInfo>> currentUserAndApp = JavaUtils.newConcurrentMap();
   private Map<String, String> appIdToUser = JavaUtils.newConcurrentMap();
   private QuotaManager quotaManager;
   // it's only for test case to check if status check has problem
@@ -130,17 +130,19 @@ public class ApplicationManager implements Closeable {
     // implementation class
     // in such case by default, there is no currentUserAndApp, so a unified user implementation
     // named "user" is used.
-    Map<String, Long> appAndTime =
+    Map<String, AppInfo> appAndTime =
         currentUserAndApp.computeIfAbsent(user, x -> JavaUtils.newConcurrentMap());
     appIdToUser.put(appId, user);
     if (!appAndTime.containsKey(appId)) {
       CoordinatorMetrics.counterTotalAppNum.inc();
       LOG.info("New application is registered: {}", appId);
     }
+    long currentTimeMs = System.currentTimeMillis();
+    AppInfo appInfo = new AppInfo(appId, currentTimeMs, currentTimeMs);
     if (quotaManager != null) {
       quotaManager.registerApplicationInfo(appId, appAndTime);
     } else {
-      appAndTime.put(appId, System.currentTimeMillis());
+      appAndTime.put(appId, appInfo);
     }
   }
 
@@ -150,8 +152,15 @@ public class ApplicationManager implements Closeable {
     if (user == null) {
       registerApplicationInfo(appId, "");
     } else {
-      Map<String, Long> appAndTime = currentUserAndApp.get(user);
-      appAndTime.put(appId, System.currentTimeMillis());
+      Map<String, AppInfo> appAndTime = currentUserAndApp.get(user);
+      AppInfo appInfo = appAndTime.get(appId);
+      long currentTimeMs = System.currentTimeMillis();
+      if (appInfo != null) {
+        appInfo.setUpdateTime(currentTimeMs);
+      } else {
+        appInfo = new AppInfo(appId, currentTimeMs, currentTimeMs);
+        appAndTime.put(appId, appInfo);
+      }
     }
   }
 
@@ -317,8 +326,8 @@ public class ApplicationManager implements Closeable {
   }
 
   protected void statusCheck() {
-    List<Map<String, Long>> appAndNums = Lists.newArrayList(currentUserAndApp.values());
-    Map<String, Long> appIds = Maps.newHashMap();
+    List<Map<String, AppInfo>> appAndNums = Lists.newArrayList(currentUserAndApp.values());
+    Map<String, AppInfo> appIds = Maps.newHashMap();
     // The reason for setting an expired uuid here is that there is a scenario where accessCluster
     // succeeds,
     // but the registration of shuffle fails, resulting in no normal heartbeat, and no normal update
@@ -326,12 +335,12 @@ public class ApplicationManager implements Closeable {
     // Therefore, an expiration time is set to automatically remove expired uuids
     Set<String> expiredAppIds = Sets.newHashSet();
     try {
-      for (Map<String, Long> appAndTimes : appAndNums) {
-        for (Map.Entry<String, Long> appAndTime : appAndTimes.entrySet()) {
+      for (Map<String, AppInfo> appAndTimes : appAndNums) {
+        for (Map.Entry<String, AppInfo> appAndTime : appAndTimes.entrySet()) {
           String appId = appAndTime.getKey();
-          long lastReport = appAndTime.getValue();
+          AppInfo lastReport = appAndTime.getValue();
           appIds.put(appId, lastReport);
-          if (System.currentTimeMillis() - lastReport > expired) {
+          if (System.currentTimeMillis() - lastReport.getUpdateTime() > expired) {
             expiredAppIds.add(appId);
             appAndTimes.remove(appId);
             appIdToUser.remove(appId);
@@ -416,11 +425,11 @@ public class ApplicationManager implements Closeable {
       String pHeartBeatEndTime,
       String appIdRegex) {
     List<Application> applications = new ArrayList<>();
-    for (Map.Entry<String, Map<String, Long>> entry : currentUserAndApp.entrySet()) {
+    for (Map.Entry<String, Map<String, AppInfo>> entry : currentUserAndApp.entrySet()) {
       String user = entry.getKey();
-      Map<String, Long> apps = entry.getValue();
+      Map<String, AppInfo> apps = entry.getValue();
       apps.forEach(
-          (appId, heartBeatTime) -> {
+          (appId, appInfo) -> {
             // Filter condition 1: Check whether applicationId is included in the filter list.
             boolean match = appIds.size() == 0 || appIds.contains(appId);
 
@@ -435,7 +444,7 @@ public class ApplicationManager implements Closeable {
                 || StringUtils.isNotBlank(pHeartBeatEndTime)) {
               match =
                   matchHeartBeatStartTimeAndEndTime(
-                      pHeartBeatStartTime, pHeartBeatEndTime, heartBeatTime);
+                      pHeartBeatStartTime, pHeartBeatEndTime, appInfo.getUpdateTime());
             }
 
             // If it meets expectations, add to the list to be returned.
@@ -446,7 +455,8 @@ public class ApplicationManager implements Closeable {
                   new Application.Builder()
                       .applicationId(appId)
                       .user(user)
-                      .lastHeartBeatTime(heartBeatTime)
+                      .lastHeartBeatTime(appInfo.getUpdateTime())
+                      .registerTime(appInfo.getRegisterTime())
                       .remoteStoragePath(remoteStorageInfo)
                       .build();
               applications.add(application);
@@ -527,7 +537,7 @@ public class ApplicationManager implements Closeable {
     return REMOTE_PATH_SCHEMA;
   }
 
-  public Map<String, Map<String, Long>> getCurrentUserAndApp() {
+  public Map<String, Map<String, AppInfo>> getCurrentUserAndApp() {
     return currentUserAndApp;
   }
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
@@ -456,7 +456,7 @@ public class ApplicationManager implements Closeable {
                       .applicationId(appId)
                       .user(user)
                       .lastHeartBeatTime(appInfo.getUpdateTime())
-                      .registerTime(appInfo.getRegisterTime())
+                      .registrationTime(appInfo.getRegistrationTime())
                       .remoteStoragePath(remoteStorageInfo)
                       .build();
               applications.add(application);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ApplicationManager.java
@@ -137,8 +137,7 @@ public class ApplicationManager implements Closeable {
       CoordinatorMetrics.counterTotalAppNum.inc();
       LOG.info("New application is registered: {}", appId);
     }
-    long currentTimeMs = System.currentTimeMillis();
-    AppInfo appInfo = new AppInfo(appId, currentTimeMs, currentTimeMs);
+    AppInfo appInfo = AppInfo.createAppInfo(appId, System.currentTimeMillis());
     if (quotaManager != null) {
       quotaManager.registerApplicationInfo(appId, appAndTime);
     } else {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/QuotaManager.java
@@ -139,8 +139,7 @@ public class QuotaManager {
     }
   }
 
-  public void registerApplicationInfo(String appId, Map<String,
-      AppInfo> appAndTime) {
+  public void registerApplicationInfo(String appId, Map<String, AppInfo> appAndTime) {
     long currentTimeMillis = System.currentTimeMillis();
     String[] appIdAndUuid = appId.split("_");
     String uuidFromApp = appIdAndUuid[appIdAndUuid.length - 1];

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
@@ -90,7 +90,7 @@ public class ApplicationResource extends BaseResource {
                       userAppIdTimestampMap.getKey(),
                       appInfo.getAppId(),
                       appInfo.getUpdateTime(),
-                      appInfo.getRegisterTime()));
+                      appInfo.getRegistrationTime()));
             }
           }
           // Display is inverted by the submission time of the application.

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
@@ -32,6 +32,7 @@ import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
 
 import org.apache.uniffle.common.web.resource.BaseResource;
 import org.apache.uniffle.common.web.resource.Response;
+import org.apache.uniffle.coordinator.AppInfo;
 import org.apache.uniffle.coordinator.ApplicationManager;
 import org.apache.uniffle.coordinator.web.vo.AppInfoVO;
 import org.apache.uniffle.coordinator.web.vo.UserAppNumVO;
@@ -57,10 +58,10 @@ public class ApplicationResource extends BaseResource {
   public Response<List<UserAppNumVO>> getUserApps() {
     return execute(
         () -> {
-          Map<String, Map<String, Long>> currentUserAndApp =
+          Map<String, Map<String, AppInfo>> currentUserAndApp =
               getApplicationManager().getCurrentUserAndApp();
           List<UserAppNumVO> usercnt = new ArrayList<>();
-          for (Map.Entry<String, Map<String, Long>> stringMapEntry : currentUserAndApp.entrySet()) {
+          for (Map.Entry<String, Map<String, AppInfo>> stringMapEntry : currentUserAndApp.entrySet()) {
             String userName = stringMapEntry.getKey();
             usercnt.add(new UserAppNumVO(userName, stringMapEntry.getValue().size()));
           }
@@ -76,16 +77,15 @@ public class ApplicationResource extends BaseResource {
     return execute(
         () -> {
           List<AppInfoVO> userToAppList = new ArrayList<>();
-          Map<String, Map<String, Long>> currentUserAndApp =
+          Map<String, Map<String, AppInfo>> currentUserAndApp =
               getApplicationManager().getCurrentUserAndApp();
-          for (Map.Entry<String, Map<String, Long>> userAppIdTimestampMap :
+          for (Map.Entry<String, Map<String, AppInfo>> userAppIdTimestampMap :
               currentUserAndApp.entrySet()) {
-            String userName = userAppIdTimestampMap.getKey();
-            for (Map.Entry<String, Long> appIdTimestampMap :
+            for (Map.Entry<String, AppInfo> appIdTimestampMap :
                 userAppIdTimestampMap.getValue().entrySet()) {
-              userToAppList.add(
-                  new AppInfoVO(
-                      userName, appIdTimestampMap.getKey(), appIdTimestampMap.getValue()));
+              AppInfo appInfo = appIdTimestampMap.getValue();
+              userToAppList.add(new AppInfoVO(userAppIdTimestampMap.getKey(), appInfo.getAppId(),
+                  appInfo.getUpdateTime(), appInfo.getRegisterTime()));
             }
           }
           // Display is inverted by the submission time of the application.

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
@@ -61,7 +61,8 @@ public class ApplicationResource extends BaseResource {
           Map<String, Map<String, AppInfo>> currentUserAndApp =
               getApplicationManager().getCurrentUserAndApp();
           List<UserAppNumVO> usercnt = new ArrayList<>();
-          for (Map.Entry<String, Map<String, AppInfo>> stringMapEntry : currentUserAndApp.entrySet()) {
+          for (Map.Entry<String, Map<String, AppInfo>> stringMapEntry :
+              currentUserAndApp.entrySet()) {
             String userName = stringMapEntry.getKey();
             usercnt.add(new UserAppNumVO(userName, stringMapEntry.getValue().size()));
           }
@@ -84,8 +85,12 @@ public class ApplicationResource extends BaseResource {
             for (Map.Entry<String, AppInfo> appIdTimestampMap :
                 userAppIdTimestampMap.getValue().entrySet()) {
               AppInfo appInfo = appIdTimestampMap.getValue();
-              userToAppList.add(new AppInfoVO(userAppIdTimestampMap.getKey(), appInfo.getAppId(),
-                  appInfo.getUpdateTime(), appInfo.getRegisterTime()));
+              userToAppList.add(
+                  new AppInfoVO(
+                      userAppIdTimestampMap.getKey(),
+                      appInfo.getAppId(),
+                      appInfo.getUpdateTime(),
+                      appInfo.getRegisterTime()));
             }
           }
           // Display is inverted by the submission time of the application.

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/vo/AppInfoVO.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/vo/AppInfoVO.java
@@ -23,13 +23,13 @@ public class AppInfoVO implements Comparable<AppInfoVO> {
   private String userName;
   private String appId;
   private long updateTime;
-  private long registerTime;
+  private long registrationTime;
 
-  public AppInfoVO(String userName, String appId, long updateTime, long registerTime) {
+  public AppInfoVO(String userName, String appId, long updateTime, long registrationTime) {
     this.userName = userName;
     this.appId = appId;
     this.updateTime = updateTime;
-    this.registerTime = registerTime;
+    this.registrationTime = registrationTime;
   }
 
   public String getUserName() {
@@ -56,17 +56,17 @@ public class AppInfoVO implements Comparable<AppInfoVO> {
     this.updateTime = updateTime;
   }
 
-  public long getRegisterTime() {
-    return registerTime;
+  public long getRegistrationTime() {
+    return registrationTime;
   }
 
-  public void setRegisterTime(long registerTime) {
-    this.registerTime = registerTime;
+  public void setRegistrationTime(long registrationTime) {
+    this.registrationTime = registrationTime;
   }
 
   @Override
   public int compareTo(AppInfoVO appInfoVO) {
-    return Long.compare(registerTime, appInfoVO.getRegisterTime());
+    return Long.compare(registrationTime, appInfoVO.getRegistrationTime());
   }
 
   @Override
@@ -79,13 +79,13 @@ public class AppInfoVO implements Comparable<AppInfoVO> {
     }
     AppInfoVO appInfoVO = (AppInfoVO) o;
     return updateTime == appInfoVO.updateTime
-        && registerTime == appInfoVO.registerTime
+        && registrationTime == appInfoVO.registrationTime
         && userName.equals(appInfoVO.userName)
         && appId.equals(appInfoVO.appId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userName, appId, updateTime, registerTime);
+    return Objects.hash(userName, appId, updateTime, registrationTime);
   }
 }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
@@ -107,8 +107,9 @@ public class QuotaManagerTest {
       appId = String.valueOf(uuid.incrementAndGet());
       uuidAndTime.put(appId, AppInfo.createAppInfo(appId, System.currentTimeMillis()));
       final int i1 = uuid.incrementAndGet();
-      uuidAndTime.put(String.valueOf(i1), AppInfo.createAppInfo(String.valueOf(i1),
-          System.currentTimeMillis()));
+      uuidAndTime.put(
+          String.valueOf(i1),
+          AppInfo.createAppInfo(String.valueOf(i1), System.currentTimeMillis()));
       Map<String, AppInfo> appAndTime =
           applicationManager
               .getQuotaManager()
@@ -229,9 +230,6 @@ public class QuotaManagerTest {
         uuidAndTime.put(appId, appInfo);
       }
     }
-
-
-
 
     return uuidAndTime;
   }

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/QuotaManagerTest.java
@@ -97,14 +97,19 @@ public class QuotaManagerTest {
     conf.setInteger(CoordinatorConf.COORDINATOR_QUOTA_DEFAULT_APP_NUM, 5);
     try (ApplicationManager applicationManager = new ApplicationManager(conf)) {
       final AtomicInteger uuid = new AtomicInteger();
-      Map<String, Long> uuidAndTime = JavaUtils.newConcurrentMap();
-      uuidAndTime.put(String.valueOf(uuid.incrementAndGet()), System.currentTimeMillis());
-      uuidAndTime.put(String.valueOf(uuid.incrementAndGet()), System.currentTimeMillis());
-      uuidAndTime.put(String.valueOf(uuid.incrementAndGet()), System.currentTimeMillis());
-      uuidAndTime.put(String.valueOf(uuid.incrementAndGet()), System.currentTimeMillis());
+      Map<String, AppInfo> uuidAndTime = JavaUtils.newConcurrentMap();
+      String appId = String.valueOf(uuid.incrementAndGet());
+      uuidAndTime.put(appId, AppInfo.createAppInfo(appId, System.currentTimeMillis()));
+      appId = String.valueOf(uuid.incrementAndGet());
+      uuidAndTime.put(appId, AppInfo.createAppInfo(appId, System.currentTimeMillis()));
+      appId = String.valueOf(uuid.incrementAndGet());
+      uuidAndTime.put(appId, AppInfo.createAppInfo(appId, System.currentTimeMillis()));
+      appId = String.valueOf(uuid.incrementAndGet());
+      uuidAndTime.put(appId, AppInfo.createAppInfo(appId, System.currentTimeMillis()));
       final int i1 = uuid.incrementAndGet();
-      uuidAndTime.put(String.valueOf(i1), System.currentTimeMillis());
-      Map<String, Long> appAndTime =
+      uuidAndTime.put(String.valueOf(i1), AppInfo.createAppInfo(String.valueOf(i1),
+          System.currentTimeMillis()));
+      Map<String, AppInfo> appAndTime =
           applicationManager
               .getQuotaManager()
               .getCurrentUserAndApp()
@@ -184,7 +189,7 @@ public class QuotaManagerTest {
           .until(() -> applicationManager.getDefaultUserApps().size() > 2);
 
       QuotaManager quotaManager = applicationManager.getQuotaManager();
-      Map<String, Map<String, Long>> currentUserAndApp = quotaManager.getCurrentUserAndApp();
+      Map<String, Map<String, AppInfo>> currentUserAndApp = quotaManager.getCurrentUserAndApp();
 
       currentUserAndApp.computeIfAbsent("user1", x -> mockUUidAppAndTime(30));
       currentUserAndApp.computeIfAbsent("user2", x -> mockUUidAppAndTime(20));
@@ -211,11 +216,23 @@ public class QuotaManagerTest {
     return String.valueOf(uuid.incrementAndGet());
   }
 
-  private Map<String, Long> mockUUidAppAndTime(int mockAppNum) {
-    Map<String, Long> uuidAndTime = JavaUtils.newConcurrentMap();
+  private Map<String, AppInfo> mockUUidAppAndTime(int mockAppNum) {
+    Map<String, AppInfo> uuidAndTime = JavaUtils.newConcurrentMap();
     for (int i = 0; i < mockAppNum; i++) {
-      uuidAndTime.put(mockUUidAppId(), System.currentTimeMillis());
+      String appId = mockUUidAppId();
+      long currentTimeMs = System.currentTimeMillis();
+      AppInfo appInfo = uuidAndTime.get(appId);
+      if (appInfo != null) {
+        appInfo.setUpdateTime(currentTimeMs);
+      } else {
+        appInfo = new AppInfo(appId, currentTimeMs, currentTimeMs);
+        uuidAndTime.put(appId, appInfo);
+      }
     }
+
+
+
+
     return uuidAndTime;
   }
 }

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -43,7 +43,7 @@
       <el-table :data="pageData.appInfoData" height="250" style="width: 100%">
         <el-table-column prop="appId" label="AppId" min-width="180" />
         <el-table-column prop="userName" label="UserName" min-width="180" />
-        <el-table-column prop="registerTime" label="Register Time" min-width="180" :formatter="dateFormatter" />
+        <el-table-column prop="registrationTime" label="Register Time" min-width="180" :formatter="dateFormatter" />
         <el-table-column prop="updateTime" label="Update Time" min-width="180" :formatter="dateFormatter" />
       </el-table>
     </div>
@@ -61,7 +61,7 @@ export default {
     const pageData = reactive({
       apptotal: {},
       userAppCount: [{}],
-      appInfoData: [{ appId: '', userName: '', registerTime: '', updateTime: '' }]
+      appInfoData: [{ appId: '', userName: '', registrationTime: '', updateTime: '' }]
     })
     const currentServerStore = useCurrentServerStore()
 

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -43,7 +43,7 @@
       <el-table :data="pageData.appInfoData" height="250" style="width: 100%">
         <el-table-column prop="appId" label="AppId" min-width="180" />
         <el-table-column prop="userName" label="UserName" min-width="180" />
-        <el-table-column prop="registrationTime" label="Register Time" min-width="180" :formatter="dateFormatter" />
+        <el-table-column prop="registrationTime" label="Registration Time" min-width="180" :formatter="dateFormatter" />
         <el-table-column prop="updateTime" label="Update Time" min-width="180" :formatter="dateFormatter" />
       </el-table>
     </div>

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -43,6 +43,7 @@
       <el-table :data="pageData.appInfoData" height="250" style="width: 100%">
         <el-table-column prop="appId" label="AppId" min-width="180" />
         <el-table-column prop="userName" label="UserName" min-width="180" />
+        <el-table-column prop="registerTime" label="Register Time" min-width="180" :formatter="dateFormatter" />
         <el-table-column prop="updateTime" label="Update Time" min-width="180" :formatter="dateFormatter" />
       </el-table>
     </div>
@@ -60,7 +61,7 @@ export default {
     const pageData = reactive({
       apptotal: {},
       userAppCount: [{}],
-      appInfoData: [{ appId: '', userName: '', updateTime: '' }]
+      appInfoData: [{ appId: '', userName: '', registerTime: '', updateTime: '' }]
     })
     const currentServerStore = useCurrentServerStore()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Reg time to AppInfo and Application

### Why are the changes needed?

Fix: #1860

### Does this PR introduce _any_ user-facing change?

`bin/uniffle  client-cli -app -host localhost -port 19998` and dashboard app page will display registrationTime of each application.

### How was this patch tested?

```Console
bin/uniffle  client-cli -app -host localhost -port 19998
host:localhost,port:19998
+--------------------------------------------------------------------------------------------------------------+
|                                             Uniffle Applications                                             |
+---------------------------------------+------+---------------------+---------------------+-------------------+
|             ApplicationId             | User |    Registration Time    | Last HeartBeatTime  | RemoteStoragePath |
+---------------------------------------+------+---------------------+---------------------+-------------------+
| app-20240703231912-0003_1720019950472 | user | 2024-07-03 23:19:40 | 2024-07-03 23:21:05 |       null        |
| app-20240703232127-0004_1720020086199 | user | 2024-07-03 23:21:51 | 2024-07-03 23:22:16 |       null        |
+---------------------------------------+------+---------------------+---------------------+-------------------+
```

<img width="1508" alt="image" src="https://github.com/apache/incubator-uniffle/assets/17329931/96f9703d-6c99-4600-adb5-2ddd8ae48c4d">

