### PR TITLE
[#1471] feat(server/dashboard): Add Reg time to ServerNode

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -24,7 +24,7 @@ import java.util.Set;
 public interface ClusterManager extends Closeable {
 
   /**
-   * Add a server to the cluster.
+   * Add or update a server to the cluster.
    *
    * @param shuffleServerInfo server info
    */

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -277,18 +277,4 @@ public class ServerNode implements Comparable<ServerNode> {
   public int getNettyPort() {
     return nettyPort;
   }
-
-  public void update(ServerNode node) {
-    this.ip = node.getIp();
-    this.grpcPort = node.getGrpcPort();
-    this.usedMemory = node.getUsedMemory();
-    this.preAllocatedMemory = node.getPreAllocatedMemory();
-    this.availableMemory = node.getAvailableMemory();
-    this.eventNumInFlush = node.getEventNumInFlush();
-    this.timestamp = System.currentTimeMillis();
-    this.tags = node.getTags();
-    this.status = node.getStatus();
-    this.storageInfo = node.getStorageInfo();
-    this.nettyPort = node.getNettyPort();
-  }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -36,6 +36,7 @@ public class ServerNode implements Comparable<ServerNode> {
   private long preAllocatedMemory;
   private long availableMemory;
   private int eventNumInFlush;
+  private long registrationTime;
   private long timestamp;
   private Set<String> tags;
   private ServerStatus status;
@@ -136,7 +137,8 @@ public class ServerNode implements Comparable<ServerNode> {
     this.preAllocatedMemory = preAllocatedMemory;
     this.availableMemory = availableMemory;
     this.eventNumInFlush = eventNumInFlush;
-    this.timestamp = System.currentTimeMillis();
+    this.registrationTime = System.currentTimeMillis();
+    this.timestamp = registrationTime;
     this.tags = tags;
     this.status = status;
     this.storageInfo = storageInfoMap;
@@ -237,6 +239,14 @@ public class ServerNode implements Comparable<ServerNode> {
     this.timestamp = timestamp;
   }
 
+  public void setRegistrationTime(long registrationTime) {
+    this.registrationTime = registrationTime;
+  }
+
+  public long getRegistrationTime() {
+    return registrationTime;
+  }
+
   @Override
   public int compareTo(ServerNode other) {
     if (availableMemory > other.getAvailableMemory()) {
@@ -266,5 +276,19 @@ public class ServerNode implements Comparable<ServerNode> {
 
   public int getNettyPort() {
     return nettyPort;
+  }
+
+  public void update(ServerNode node) {
+    this.ip = node.getIp();
+    this.grpcPort = node.getGrpcPort();
+    this.usedMemory = node.getUsedMemory();
+    this.preAllocatedMemory = node.getPreAllocatedMemory();
+    this.availableMemory = node.getAvailableMemory();
+    this.eventNumInFlush = node.getEventNumInFlush();
+    this.timestamp = System.currentTimeMillis();
+    this.tags = node.getTags();
+    this.status = node.getStatus();
+    this.storageInfo = node.getStorageInfo();
+    this.nettyPort = node.getNettyPort();
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -239,7 +239,7 @@ public class ServerNode implements Comparable<ServerNode> {
     this.timestamp = timestamp;
   }
 
-  public void setRegistrationTime(long registrationTime) {
+  void setRegistrationTime(long registrationTime) {
     this.registrationTime = registrationTime;
   }
 

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -226,8 +226,11 @@ public class SimpleClusterManager implements ClusterManager {
   public void add(ServerNode node) {
     if (!servers.containsKey(node.getId())) {
       LOG.info("Newly registering node: {}", node.getId());
+      servers.put(node.getId(), node);
+    } else {
+      servers.get(node.getId()).update(node);
     }
-    servers.put(node.getId(), node);
+
     Set<String> tags = node.getTags();
     // remove node with all tags to deal with the situation of tag change
     for (Set<ServerNode> nodes : tagToNodes.values()) {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -230,7 +230,7 @@ public class SimpleClusterManager implements ClusterManager {
       ServerNode pre = servers.get(node.getId());
       long regTime = pre.getRegistrationTime();
       // inherit registration time
-      node.setRegisterationTime(regTime);
+      node.setRegistrationTime(regTime);
     }
 
     Set<String> tags = node.getTags();

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -224,10 +224,10 @@ public class SimpleClusterManager implements ClusterManager {
 
   @Override
   public void add(ServerNode node) {
-    if (!servers.containsKey(node.getId())) {
+    ServerNode pre = servers.get(node.getId());
+    if (pre == null) {
       LOG.info("Newly registering node: {}", node.getId());
     } else {
-      ServerNode pre = servers.get(node.getId());
       long regTime = pre.getRegistrationTime();
       // inherit registration time
       node.setRegistrationTime(regTime);

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -226,9 +226,11 @@ public class SimpleClusterManager implements ClusterManager {
   public void add(ServerNode node) {
     if (!servers.containsKey(node.getId())) {
       LOG.info("Newly registering node: {}", node.getId());
-      servers.put(node.getId(), node);
     } else {
-      servers.get(node.getId()).update(node);
+      ServerNode pre = servers.get(node.getId());
+      long regTime = pre.getRegistrationTime();
+      // inherit registration time
+      node.setRegisterationTime(regTime);
     }
 
     Set<String> tags = node.getTags();

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -232,6 +232,7 @@ public class SimpleClusterManager implements ClusterManager {
       // inherit registration time
       node.setRegistrationTime(regTime);
     }
+    servers.put(node.getId(), node);
 
     Set<String> tags = node.getTags();
     // remove node with all tags to deal with the situation of tag change

--- a/dashboard/src/main/webapp/src/pages/serverstatus/ActiveNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/ActiveNodeListPage.vue
@@ -38,6 +38,12 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" />
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
+        prop="registrationTime"
+        label="RegistrationTime"
+        min-width="80"
+        :formatter="dateFormatter"
+      />
+      <el-table-column
         prop="timestamp"
         label="HeartbeatTime"
         min-width="80"
@@ -68,6 +74,7 @@ export default {
           eventNumInFlush: 0,
           tags: '',
           status: '',
+          registrationTime: '',
           timestamp: ''
         }
       ]

--- a/dashboard/src/main/webapp/src/pages/serverstatus/DecommissionednodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/DecommissionednodeListPage.vue
@@ -38,6 +38,12 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" />
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
+          prop="registrationTime"
+          label="RegistrationTime"
+          min-width="80"
+          :formatter="dateFormatter"
+      />
+      <el-table-column
         prop="timestamp"
         label="HeartbeatTime"
         min-width="80"
@@ -68,6 +74,7 @@ export default {
           eventNumInFlush: 0,
           tags: '',
           status: '',
+          registrationTime: '',
           timestamp: ''
         }
       ]

--- a/dashboard/src/main/webapp/src/pages/serverstatus/DecommissioningNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/DecommissioningNodeListPage.vue
@@ -38,6 +38,12 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" />
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
+          prop="registrationTime"
+          label="RegistrationTime"
+          min-width="80"
+          :formatter="dateFormatter"
+      />
+      <el-table-column
         prop="timestamp"
         label="HeartbeatTime"
         min-width="80"
@@ -68,6 +74,7 @@ export default {
           eventNumInFlush: 0,
           tags: '',
           status: '',
+          registrationTime: '',
           timestamp: ''
         }
       ]

--- a/dashboard/src/main/webapp/src/pages/serverstatus/LostNodeList.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/LostNodeList.vue
@@ -38,6 +38,12 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" />
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
+          prop="registrationTime"
+          label="RegistrationTime"
+          min-width="80"
+          :formatter="dateFormatter"
+      />
+      <el-table-column
         prop="timestamp"
         label="HeartbeatTime"
         min-width="80"
@@ -68,6 +74,7 @@ export default {
           eventNumInFlush: 0,
           tags: '',
           status: '',
+          registrationTime: '',
           timestamp: ''
         }
       ]

--- a/dashboard/src/main/webapp/src/pages/serverstatus/UnhealthyNodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/UnhealthyNodeListPage.vue
@@ -38,6 +38,12 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" />
       <el-table-column prop="status" label="Status" min-width="80" />
       <el-table-column
+          prop="registrationTime"
+          label="RegistrationTime"
+          min-width="80"
+          :formatter="dateFormatter"
+      />
+      <el-table-column
         prop="timestamp"
         label="HeartbeatTime"
         min-width="80"
@@ -68,6 +74,7 @@ export default {
           eventNumInFlush: 0,
           tags: '',
           status: '',
+          registrationTime: '',
           timestamp: ''
         }
       ]


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add reg time to ServerNode, and update method to update ServerNode when server heartbeat to coordinator rather than replace serverNode object.

### Why are the changes needed?

Fix: #1471

### Does this PR introduce _any_ user-facing change?

User can get registrationTime from dashboard server page.

### How was this patch tested?

<img width="2462" alt="image" src="https://github.com/apache/incubator-uniffle/assets/17329931/423733c7-7bb8-44f1-8f02-d8f6ef5026a5">
<img width="2478" alt="image" src="https://github.com/apache/incubator-uniffle/assets/17329931/aedd73c5-77f4-4264-8ae7-e43cc89c04cc">



