### PR TITLE
[#1401] feat:(dashboard): Support deleting lost shuffle servers

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ClusterManager.java
@@ -69,6 +69,8 @@ public interface ClusterManager extends Closeable {
   /** @return list all server nodes in the cluster */
   List<ServerNode> list();
 
+  boolean deleteLostServerById(String serverId);
+
   int getShuffleNodesMax();
 
   /** @return whether to be ready for serving */

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -309,6 +310,21 @@ public class SimpleClusterManager implements ClusterManager {
   @Override
   public List<ServerNode> list() {
     return Lists.newArrayList(servers.values());
+  }
+
+  @Override
+  public boolean deleteLostServerById(String serverId) {
+    if (serverId != null && !serverId.equalsIgnoreCase("")) {
+      Iterator<ServerNode> lostNodeIter = lostNodes.iterator();
+      while (lostNodeIter.hasNext()) {
+        ServerNode node = lostNodeIter.next();
+        if (serverId.equalsIgnoreCase(node.getId())) {
+          lostNodes.remove(node);
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   @VisibleForTesting

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -23,7 +23,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -314,15 +313,8 @@ public class SimpleClusterManager implements ClusterManager {
 
   @Override
   public boolean deleteLostServerById(String serverId) {
-    if (serverId != null && !serverId.equalsIgnoreCase("")) {
-      Iterator<ServerNode> lostNodeIter = lostNodes.iterator();
-      while (lostNodeIter.hasNext()) {
-        ServerNode node = lostNodeIter.next();
-        if (serverId.equalsIgnoreCase(node.getId())) {
-          lostNodes.remove(node);
-          return true;
-        }
-      }
+    if (StringUtils.isNotBlank(serverId)) {
+      return lostNodes.remove(new ServerNode(serverId));
     }
     return false;
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.hbase.thirdparty.javax.ws.rs.DELETE;
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.POST;
 import org.apache.hbase.thirdparty.javax.ws.rs.Path;
@@ -197,6 +198,16 @@ public class ServerResource extends BaseResource {
                           n -> n.getStatus().name(), Collectors.reducing(0, n -> 1, Integer::sum)));
           return stringIntegerHash;
         });
+  }
+
+  @DELETE
+  @Path("/deleteServer")
+  public Response<String> deleteLostedServer(@QueryParam("serverId") String serverId) {
+    ClusterManager clusterManager = getClusterManager();
+    if (clusterManager.deleteLostServerById(serverId)) {
+      return Response.success("success");
+    }
+    return Response.success("failed");
   }
 
   private ClusterManager getClusterManager() {

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -207,7 +207,7 @@ public class ServerResource extends BaseResource {
     if (clusterManager.deleteLostServerById(serverId)) {
       return Response.success("success");
     }
-    return Response.success("failed");
+    return Response.fail("fail");
   }
 
   private ClusterManager getClusterManager() {

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -53,8 +53,8 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v16.20.2</nodeVersion>
-                            <npmVersion>8.19.4</npmVersion>
+                            <nodeVersion>v20.15.0</nodeVersion>
+                            <npmVersion>10.7.0</npmVersion>
                             <nodeDownloadRoot>${nodeRepositoryUrl}</nodeDownloadRoot>
                             <npmDownloadRoot>${npmRepositoryUrl}</npmDownloadRoot>
                         </configuration>

--- a/dashboard/src/main/webapp/src/api/api.js
+++ b/dashboard/src/main/webapp/src/api/api.js
@@ -80,3 +80,8 @@ export function getTotalForUser(params, headers) {
 export function getAllCoordinatorAddrees(params, headers) {
   return http.get('/coordinator/coordinatorServers', params, headers, 1)
 }
+
+// Delete the list of servers that are confirmed lost
+export function deleteConfirmedLostServer(params, headers) {
+  return http.delete('/server/deleteServer', params, headers, 0)
+}

--- a/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
@@ -56,6 +56,7 @@
         label="RegistrationTime"
         min-width="120"
         :formatter="dateFormatter"
+        sortable
       />
       <el-table-column
         prop="timestamp"
@@ -151,17 +152,30 @@ export default {
     }
 
     const loadPageData = () => {
+      isShowRemove.value = false
+      listPageData.tableData = [
+        {
+          id: '',
+          ip: '',
+          grpcPort: 0,
+          nettyPort: 0,
+          usedMemory: 0,
+          preAllocatedMemory: 0,
+          availableMemory: 0,
+          eventNumInFlush: 0,
+          tags: '',
+          status: '',
+          registrationTime: '',
+          timestamp: ''
+        }
+      ]
       if (router.currentRoute.value.name === 'activeNodeList') {
-        isShowRemove.value = false
         getShuffleActiveNodesPage()
       } else if (router.currentRoute.value.name === 'decommissioningNodeList') {
-        isShowRemove.value = false
         getShuffleDecommissioningListPage()
       } else if (router.currentRoute.value.name === 'decommissionedNodeList') {
-        isShowRemove.value = false
         getShuffleDecommissionedListPage()
       } else if (router.currentRoute.value.name === 'unhealthyNodeList') {
-        isShowRemove.value = false
         getShuffleUnhealthyListPage()
       } else if (router.currentRoute.value.name === 'lostNodeList') {
         isShowRemove.value = true

--- a/dashboard/src/main/webapp/src/utils/http.js
+++ b/dashboard/src/main/webapp/src/utils/http.js
@@ -48,6 +48,21 @@ const http = {
     } else {
       return request.getFrontEndAxiosInstance().post(url, data, headers)
     }
+  },
+  delete(url, params, headers, fontBackFlag) {
+    if (fontBackFlag === 0) {
+      // The system obtains the address of the Coordinator to be accessed from global variables.
+      const currentServerStore = useCurrentServerStore()
+      if (typeof headers !== 'undefined') {
+        headers.targetAddress = currentServerStore.currentServer
+      } else {
+        headers = {}
+        headers.targetAddress = currentServerStore.currentServer
+      }
+      return request.getBackEndAxiosInstance().delete(url, { params, headers })
+    } else {
+      return request.getFrontEndAxiosInstance().delete(url, { params, headers })
+    }
   }
 }
 export default http

--- a/dashboard/src/main/webapp/src/utils/http.js
+++ b/dashboard/src/main/webapp/src/utils/http.js
@@ -23,7 +23,7 @@ const http = {
     if (fontBackFlag === 0) {
       // The system obtains the address of the Coordinator to be accessed from global variables.
       const currentServerStore = useCurrentServerStore()
-      if (typeof headers !== 'undefined') {
+      if (headers) {
         headers.targetAddress = currentServerStore.currentServer
       } else {
         headers = {}
@@ -38,7 +38,7 @@ const http = {
     if (fontBackFlag === 0) {
       // The system obtains the address of the Coordinator to be accessed from global variables.
       const currentServerStore = useCurrentServerStore()
-      if (typeof headers !== 'undefined') {
+      if (headers) {
         headers.targetAddress = currentServerStore.currentServer
       } else {
         headers = {}
@@ -53,7 +53,7 @@ const http = {
     if (fontBackFlag === 0) {
       // The system obtains the address of the Coordinator to be accessed from global variables.
       const currentServerStore = useCurrentServerStore()
-      if (typeof headers !== 'undefined') {
+      if (headers) {
         headers.targetAddress = currentServerStore.currentServer
       } else {
         headers = {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support deleting lost shuffle servers:
If some shuffle servers are lost, they need to go offline and the Coordinator has been in the lost state. 
Add the delete function to delete these servers in the memory.

![image](https://github.com/apache/incubator-uniffle/assets/33595968/a23d63cc-ac01-4e60-9c3c-6f3571477450)


### Why are the changes needed?

Fix: #1401 

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Add UT.