### PR TITLE
[MINOR] Improvement(client): Rename rss.shade.packageName from org.apache.uniffle to org.apache.uniffle.shaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <prometheus.simpleclient.version>0.9.0</prometheus.simpleclient.version>
     <protobuf.version>3.25.1</protobuf.version>
     <roaring.bitmap.version>0.9.15</roaring.bitmap.version>
-    <rss.shade.packageName>org.apache.uniffle</rss.shade.packageName>
+    <rss.shade.packageName>org.apache.uniffle.shaded</rss.shade.packageName>
     <skipDeploy>false</skipDeploy>
     <slf4j.version>1.7.36</slf4j.version>
     <spotbugs.version>4.7.0</spotbugs.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the default value of `rss.shade.packageName` from `org.apache.uniffle` to `org.apache.uniffle.shaded`.

### Why are the changes needed?

Without this change, we cannot distinguish a class is relocated to  `org.apache.uniffle.xxx` or named `org.apache.uniffle.xxx` originally.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not needed.
