### PR TITLE
[#1885] improvement(server): release usedMemory as soon as possible after buffer is released

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -708,8 +708,6 @@ public class ShuffleBufferManager {
 
     Map<Integer, AtomicLong> shuffleIdToSizeMap = shuffleSizeMap.get(appId);
     for (int shuffleId : shuffleIds) {
-      long size = 0;
-
       RangeMap<Integer, ShuffleBuffer> bufferRangeMap = shuffleIdToBuffers.remove(shuffleId);
       if (bufferRangeMap == null) {
         continue;
@@ -719,10 +717,9 @@ public class ShuffleBufferManager {
         for (ShuffleBuffer buffer : buffers) {
           buffer.release();
           ShuffleServerMetrics.gaugeTotalPartitionNum.dec();
-          size += buffer.getSize();
+          releaseMemory(buffer.getSize(), false, false);
         }
       }
-      releaseMemory(size, false, false);
       if (shuffleIdToSizeMap != null) {
         shuffleIdToSizeMap.remove(shuffleId);
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release `usedMemory` as soon as possible after the buffer is released.

### Why are the changes needed?

For better performance.
Fix: #1885 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual testing.
