### PR TITLE
[#1401] improvement:(dashboard): The list of servers and the number of states are updated synchronously.

### DIFF
--- a/dashboard/src/main/webapp/src/pages/ShuffleServerPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ShuffleServerPage.vue
@@ -19,7 +19,11 @@
   <div>
     <el-row :gutter="20">
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/activeNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/activeNodeList"
+          @click.native="routerHandler"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -31,7 +35,11 @@
         </router-link>
       </el-col>
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/decommissioningNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/decommissioningNodeList"
+          @click.native="routerHandler"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -45,7 +53,11 @@
         </router-link>
       </el-col>
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/decommissionedNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/decommissionedNodeList"
+          @click.native="routerHandler"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -59,7 +71,12 @@
         </router-link>
       </el-col>
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/lostNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/lostNodeList"
+          @click.native="routerHandler"
+          :updateTotalPage="updateTotalPage"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -71,7 +88,11 @@
         </router-link>
       </el-col>
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/unhealthyNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/unhealthyNodeList"
+          @click.native="routerHandler"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -83,7 +104,11 @@
         </router-link>
       </el-col>
       <el-col :span="4">
-        <router-link class="router-link-active" to="/shuffleserverpage/excludeNodeList">
+        <router-link
+          class="router-link-active"
+          to="/shuffleserverpage/excludeNodeList"
+          @click.native="routerHandler"
+        >
           <el-card class="box-card" shadow="hover">
             <template #header>
               <div class="card-header">
@@ -105,7 +130,7 @@
 </template>
 
 <script>
-import { onMounted, reactive } from 'vue'
+import { onMounted, reactive, provide } from 'vue'
 import { getShufflegetStatusTotal } from '@/api/api'
 import { useCurrentServerStore } from '@/store/useCurrentServerStore'
 
@@ -123,8 +148,7 @@ export default {
     })
 
     const currentServerStore = useCurrentServerStore()
-
-    async function getShufflegetStatusTotalPage() {
+    async function getShuffleStatusTotalPage() {
       const res = await getShufflegetStatusTotal()
       dataList.allshuffleServerSize = res.data.data
     }
@@ -132,17 +156,28 @@ export default {
     // The system obtains data from global variables and requests the interface to obtain new data after data changes.
     currentServerStore.$subscribe((mutable, state) => {
       if (state.currentServer) {
-        getShufflegetStatusTotalPage()
+        getShuffleStatusTotalPage()
       }
     })
 
     onMounted(() => {
       // If the coordinator address to request is not found in the global variable, the request is not initiated.
       if (currentServerStore.currentServer) {
-        getShufflegetStatusTotalPage()
+        getShuffleStatusTotalPage()
       }
     })
-    return { dataList }
+
+    const routerHandler = () => {
+      getShuffleStatusTotalPage()
+    }
+    /**
+     * After the missing server list is removed, the number of callbacks is reduced.
+     */
+    provide('updateTotalPage', () => {
+      getShuffleStatusTotalPage()
+    })
+
+    return { dataList, routerHandler }
   }
 }
 </script>


### PR DESCRIPTION
### What changes were proposed in this pull request?

1、To change the status label of the shuffle server, the number of servers must be updated simultaneously. Otherwise, the number in the status list may be inconsistent with that in the status statistics.
2、When removing lost servers, you should also update the number of lost servers.

### Why are the changes needed?

Fix: #1401

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Deploy page Click Test.
