### PR TITLE
[MINOR] feat(common): Support set args from SystemProperties

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -284,11 +284,9 @@ public class RssBaseConf extends RssConf {
     if (properties == null) {
       return false;
     }
-    Map<String, String> systemProperties =
-        System.getProperties().stringPropertyNames().stream()
-            .collect(
-                Collectors.toMap(propName -> propName, propName -> System.getProperty(propName)));
-    properties.putAll(systemProperties);
+    System.getProperties().stringPropertyNames().stream().forEach(propName -> {
+      properties.put(propName, System.getProperty(propName));
+    });
     return loadCommonConf(properties) && loadConf(properties, configOptions, true);
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.common.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.StorageType;
@@ -279,11 +280,15 @@ public class RssBaseConf extends RssConf {
           .withDescription("start server service max retry");
 
   public boolean loadConfFromFile(String fileName, List<ConfigOption<Object>> configOptions) {
-    Map<String, String> properties = RssUtils.getPropertiesFromFile(fileName);
-
-    if (properties == null) {
+    Map<String, String> properties =
+        System.getProperties().stringPropertyNames().stream()
+            .collect(
+                Collectors.toMap(propName -> propName, propName -> System.getProperty(propName)));
+    Map<String, String> propertiesFromFile = RssUtils.getPropertiesFromFile(fileName);
+    if (propertiesFromFile == null) {
       return false;
     }
+    properties.putAll(propertiesFromFile);
     return loadCommonConf(properties) && loadConf(properties, configOptions, true);
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -280,15 +280,15 @@ public class RssBaseConf extends RssConf {
           .withDescription("start server service max retry");
 
   public boolean loadConfFromFile(String fileName, List<ConfigOption<Object>> configOptions) {
-    Map<String, String> properties =
+    Map<String, String> properties = RssUtils.getPropertiesFromFile(fileName);
+    if (properties == null) {
+      return false;
+    }
+    Map<String, String> systemProperties =
         System.getProperties().stringPropertyNames().stream()
             .collect(
                 Collectors.toMap(propName -> propName, propName -> System.getProperty(propName)));
-    Map<String, String> propertiesFromFile = RssUtils.getPropertiesFromFile(fileName);
-    if (propertiesFromFile == null) {
-      return false;
-    }
-    properties.putAll(propertiesFromFile);
+    properties.putAll(systemProperties);
     return loadCommonConf(properties) && loadConf(properties, configOptions, true);
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -19,7 +19,6 @@ package org.apache.uniffle.common.config;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.StorageType;
@@ -284,9 +283,11 @@ public class RssBaseConf extends RssConf {
     if (properties == null) {
       return false;
     }
-    System.getProperties().stringPropertyNames().stream().forEach(propName -> {
-      properties.put(propName, System.getProperty(propName));
-    });
+    System.getProperties().stringPropertyNames().stream()
+        .forEach(
+            propName -> {
+              properties.put(propName, System.getProperty(propName));
+            });
     return loadCommonConf(properties) && loadConf(properties, configOptions, true);
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

We can start server and specific arguments System.properties

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add jvm args `-Drss.dashboard.http.port=19987` to start dashboard process, we can see it take effect through the log.

```
[2024-07-15 21:56:55.942] [main] [INFO] AbstractConnector.doStart - Started ServerConnector@26be6ca7{HTTP/1.1,[http/1.1]}{0.0.0.0:19987}
```
