### PR TITLE
[#1910] fix: Remove the method name from the log

### DIFF
--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -18,10 +18,10 @@
 <Configuration status="WARN" monitorInterval="30">
   <Appenders>
     <Console name="console" target="SYSTEM_ERR">
-      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] [%p] %c{1}.%M - %m%n%ex"/>
+      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] [%p] %c{1} - %m%n%ex"/>
     </Console>
     <RollingFile name="RollingAppender" fileName="${sys:log.path}" filePattern="${sys:log.path}.%i">
-      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] [%p] %c{1}.%M - %m%n%ex"/>
+      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] [%p] %c{1} - %m%n%ex"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="2GB"/>
       </Policies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

From the log4j document, we should not print out the method name into the log4j properties.

### Why are the changes needed?

Fix: #1910

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
