### PR TITLE
[#1917] fix(server,netty): Fix memory leak issues when handling SendShuffleDataRequest

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -152,7 +152,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       } else {
         LOG.error(
             "Failed to handle send shuffle data request, no blocks this request. appId: {}, shuffleId: {}, requireBufferId: {}",
-            appId, shuffleId, requireBufferId);
+            appId,
+            shuffleId,
+            requireBufferId);
       }
       client.getChannel().writeAndFlush(rpcResponse);
       return;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extract a method to release resources including Netty buffers and memory metrics when handling SendShuffleDataRequest.

### Why are the changes needed?

Fix: #1917

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested on our test cluster
