### PR TITLE
[MINOR] fix(server): Flush all data blocks before writing block indexes

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/api/FileWriter.java
@@ -21,9 +21,15 @@ import java.io.IOException;
 
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
-public interface FileWriter {
+public interface FileWriter extends AutoCloseable {
 
   void writeData(byte[] data) throws IOException;
 
   void writeIndex(FileBasedShuffleSegment segment) throws IOException;
+
+  void flush() throws IOException;
+
+  long nextOffset();
+
+  void close() throws IOException;
 }

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/HadoopFileWriter.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.storage.handler.impl;
 
-import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.storage.api.FileWriter;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
-public class HadoopFileWriter implements FileWriter, Closeable {
+public class HadoopFileWriter implements FileWriter {
 
   private static final Logger LOG = LoggerFactory.getLogger(HadoopFileWriter.class);
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriter.java
@@ -18,7 +18,6 @@
 package org.apache.uniffle.storage.handler.impl;
 
 import java.io.BufferedOutputStream;
-import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,7 +26,7 @@ import java.io.IOException;
 import org.apache.uniffle.storage.api.FileWriter;
 import org.apache.uniffle.storage.common.FileBasedShuffleSegment;
 
-public class LocalFileWriter implements FileWriter, Closeable {
+public class LocalFileWriter implements FileWriter {
 
   private DataOutputStream dataOutputStream;
   private FileOutputStream fileOutputStream;
@@ -54,6 +53,10 @@ public class LocalFileWriter implements FileWriter, Closeable {
     dataOutputStream.writeLong(segment.getCrc());
     dataOutputStream.writeLong(segment.getBlockId());
     dataOutputStream.writeLong(segment.getTaskAttemptId());
+  }
+
+  public void flush() throws IOException {
+    dataOutputStream.flush();
   }
 
   public long nextOffset() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Now while writing the blocks to data storage,  the index writer may flush before the data writer, which confuses the data reader.

https://github.com/apache/incubator-uniffle/blob/master/common/src/main/java/org/apache/uniffle/common/segment/FixedSizeSegmentSplitter.java#L79C16-L82

So, flush all data blocks before writing to the index, and then the reader can definitely read all blocks in the index file.

### Why are the changes needed?

Optimize the block write workflow.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Exists UT.
