### PR TITLE
[MINOR] fix(client): Fix allocate size by add 9 bytes

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleBlockInfo.java
@@ -95,10 +95,17 @@ public class ShuffleBlockInfo {
     return length;
   }
 
-  // calculate the data size for this block in memory including metadata which are
-  // partitionId, blockId, crc, taskAttemptId, length, uncompressLength
+  /**
+   * Calculate the data size for this block in memory including metadata which are partitionId,
+   * blockId, crc, taskAttemptId, uncompressLength and data length. This should be consistent with
+   * {@link ShufflePartitionedBlock#getSize()}.
+   *
+   * @return the encoded size of this object in memory
+   */
   public int getSize() {
-    return length + 3 * 8 + 2 * 4;
+    // FIXME(maobaolong): The size is calculated based on the Protobuf message ShuffleBlock.
+    //  If Netty's custom serialization is used, the calculation logic here needs to be modified.
+    return length + 3 * Long.BYTES + 2 * Integer.BYTES;
   }
 
   public long getCrc() {

--- a/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShufflePartitionedBlock.java
@@ -51,10 +51,17 @@ public class ShufflePartitionedBlock {
     this.data = data;
   }
 
-  // calculate the data size for this block in memory including metadata which are
-  // blockId, crc, taskAttemptId, length, uncompressLength
+  /**
+   * Calculate the data size for this block in memory including metadata which are partitionId,
+   * blockId, crc, taskAttemptId, uncompressLength and data length. This should be consistent with
+   * {@link ShuffleBlockInfo#getSize()}.
+   *
+   * @return the encoded size of this object in memory
+   */
   public long getSize() {
-    return length + 3 * 8 + 2 * 4;
+    // FIXME(maobaolong): The size is calculated based on the Protobuf message ShuffleBlock.
+    //  If Netty's custom serialization is used, the calculation logic here needs to be modified.
+    return length + 3 * Long.BYTES + 2 * Integer.BYTES;
   }
 
   @Override

--- a/common/src/main/java/org/apache/uniffle/common/netty/MessageEncoder.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/MessageEncoder.java
@@ -41,6 +41,9 @@ public final class MessageEncoder extends MessageToMessageEncoder<Message> {
   private static final Logger logger = LoggerFactory.getLogger(MessageEncoder.class);
 
   public static final MessageEncoder INSTANCE = new MessageEncoder();
+  public static final int MESSAGE_HEADER_SIZE =
+      // Inner message encodedLength + TYPE_ENCODED_LENGTH + bodyLength
+      Integer.BYTES + Message.TYPE_ENCODED_LENGTH + Integer.BYTES;
 
   private MessageEncoder() {}
 
@@ -79,7 +82,7 @@ public final class MessageEncoder extends MessageToMessageEncoder<Message> {
 
     Message.Type msgType = in.type();
     // message size, message type size, body size, message encoded length
-    int headerLength = Integer.BYTES + msgType.encodedLength() + Integer.BYTES + in.encodedLength();
+    int headerLength = MESSAGE_HEADER_SIZE + in.encodedLength();
     ByteBuf header = ctx.alloc().heapBuffer(headerLength);
     header.writeInt(in.encodedLength());
     msgType.encode(header);

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
@@ -23,7 +23,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.netty.buffer.ManagedBuffer;
 
 public abstract class Message implements Encodable {
-
+  public static final byte TYPE_ENCODED_LENGTH = 1;
   private ManagedBuffer body;
 
   protected Message() {
@@ -79,7 +79,7 @@ public abstract class Message implements Encodable {
 
     @Override
     public int encodedLength() {
-      return 1;
+      return TYPE_ENCODED_LENGTH;
     }
 
     @Override

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -45,6 +45,7 @@ import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.ExceedHugePartitionHardLimitException;
 import org.apache.uniffle.common.exception.FileNotFoundException;
 import org.apache.uniffle.common.exception.RssException;
+import org.apache.uniffle.common.netty.MessageEncoder;
 import org.apache.uniffle.common.netty.buffer.ManagedBuffer;
 import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.netty.client.TransportClient;
@@ -135,8 +136,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       PreAllocatedBufferInfo info =
           shuffleTaskManager.getAndRemovePreAllocatedBuffer(requireBufferId);
       int requireSize = info == null ? 0 : info.getRequireSize();
-      int requireBlocksSize =
-          requireSize - req.encodedLength() < 0 ? 0 : requireSize - req.encodedLength();
+      int encodedLength = req.encodedLength() + MessageEncoder.MESSAGE_HEADER_SIZE;
+      int requireBlocksSize = requireSize - encodedLength < 0 ? 0 : requireSize - encodedLength;
 
       boolean isPreAllocated = info != null;
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Improve the preAllocated buffer size.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Without this change, this encoded length always less 9 byte than byteBuf#readableSize after encoded.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
