### PR TITLE
[#1947] feat(server): Support authentication for decommission interface

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -287,7 +287,7 @@ public class RssBaseConf extends RssConf {
           .withDescription("Serializations are used for creative Serializers and Deserializers");
 
   public static final ConfigOption<String> REST_AUTHORIZATION_CREDENTIALS =
-      ConfigOptions.key("rss.rest.authorization.credentials")
+      ConfigOptions.key("rss.http.basic.authorizationCredentials")
           .stringType()
           .noDefaultValue()
           .withDescription(

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -279,12 +279,15 @@ public class RssBaseConf extends RssConf {
           .defaultValue(16)
           .withDescription("start server service max retry");
 
-  /* Serialization */
-  public static final ConfigOption<String> RSS_IO_SERIALIZATIONS =
-      ConfigOptions.key("rss.io.serializations")
+  public static final ConfigOption<String> COORDINATOR_AUTHORIZATION_CREDENTIALS =
+      ConfigOptions.key("rss.rest.authorization.credentials")
           .stringType()
-          .defaultValue(WritableSerializer.class.getName())
-          .withDescription("Serializations are used for creative Serializers and Deserializers");
+          .noDefaultValue()
+          .withDescription(
+              "Authorization credentials for the rest interface. "
+                  + "For Basic authentication the credentials are constructed by"
+                  + " first combining the username and the password with a colon (uniffle:uniffle123)"
+                  + ", and then by encoding the resulting string in base64 (dW5pZmZsZTp1bmlmZmxlMTIz).");
 
   public boolean loadConfFromFile(String fileName, List<ConfigOption<Object>> configOptions) {
     Map<String, String> properties = RssUtils.getPropertiesFromFile(fileName);

--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -279,7 +279,14 @@ public class RssBaseConf extends RssConf {
           .defaultValue(16)
           .withDescription("start server service max retry");
 
-  public static final ConfigOption<String> COORDINATOR_AUTHORIZATION_CREDENTIALS =
+  /* Serialization */
+  public static final ConfigOption<String> RSS_IO_SERIALIZATIONS =
+      ConfigOptions.key("rss.io.serializations")
+          .stringType()
+          .defaultValue(WritableSerializer.class.getName())
+          .withDescription("Serializations are used for creative Serializers and Deserializers");
+
+  public static final ConfigOption<String> REST_AUTHORIZATION_CREDENTIALS =
       ConfigOptions.key("rss.rest.authorization.credentials")
           .stringType()
           .noDefaultValue()

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/Authorization.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/Authorization.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.web.resource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.hbase.thirdparty.javax.ws.rs.NameBinding;
+
+@NameBinding
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorization {
+}

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/Authorization.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/Authorization.java
@@ -25,7 +25,6 @@ import java.lang.annotation.Target;
 import org.apache.hbase.thirdparty.javax.ws.rs.NameBinding;
 
 @NameBinding
-@Target({ ElementType.METHOD, ElementType.TYPE })
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Authorization {
-}
+public @interface Authorization {}

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
@@ -27,7 +27,6 @@ import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Response;
 import org.apache.hbase.thirdparty.javax.ws.rs.ext.Provider;
 
-import org.apache.logging.log4j.util.Strings;
 import org.apache.uniffle.common.config.RssBaseConf;
 
 @Provider

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
@@ -20,7 +20,6 @@ package org.apache.uniffle.common.web.resource;
 import java.io.IOException;
 import javax.servlet.ServletContext;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.hbase.thirdparty.javax.ws.rs.container.ContainerRequestContext;
 import org.apache.hbase.thirdparty.javax.ws.rs.container.ContainerRequestFilter;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
@@ -28,6 +27,7 @@ import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Response;
 import org.apache.hbase.thirdparty.javax.ws.rs.ext.Provider;
 
+import org.apache.logging.log4j.util.Strings;
 import org.apache.uniffle.common.config.RssBaseConf;
 
 @Provider
@@ -43,7 +43,7 @@ public class AuthorizationRequestFilter implements ContainerRequestFilter {
       return;
     }
     String authorization = requestContext.getHeaderString("Authorization");
-    if (StringUtils.isBlank(authorization)
+    if (authorization == null
         || !authorization.startsWith("Basic ")
         || !authorization.substring(6).equals(credentials)) {
       requestContext.abortWith(

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.web.resource;
+
+import java.io.IOException;
+import javax.servlet.ServletContext;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hbase.thirdparty.javax.ws.rs.container.ContainerRequestContext;
+import org.apache.hbase.thirdparty.javax.ws.rs.container.ContainerRequestFilter;
+import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
+import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
+import org.apache.hbase.thirdparty.javax.ws.rs.core.Response;
+import org.apache.hbase.thirdparty.javax.ws.rs.ext.Provider;
+
+import org.apache.uniffle.common.config.RssBaseConf;
+
+
+@Provider
+@Authorization
+public class AuthorizationRequestFilter implements ContainerRequestFilter {
+  @Context
+  protected ServletContext servletContext;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    Object credentials = servletContext.getAttribute(
+        RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS.key());
+    if (credentials == null) {
+      return;
+    }
+    String authorization = requestContext.getHeaderString("Authorization");
+    if (StringUtils.isBlank(authorization) || !authorization.startsWith("Basic ")
+        || !authorization.substring(6).equals(credentials)) {
+      requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).entity("Authentication Failed")
+          .type(MediaType.TEXT_PLAIN).build());
+    }
+  }
+}

--- a/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/resource/AuthorizationRequestFilter.java
@@ -30,25 +30,27 @@ import org.apache.hbase.thirdparty.javax.ws.rs.ext.Provider;
 
 import org.apache.uniffle.common.config.RssBaseConf;
 
-
 @Provider
 @Authorization
 public class AuthorizationRequestFilter implements ContainerRequestFilter {
-  @Context
-  protected ServletContext servletContext;
+  @Context protected ServletContext servletContext;
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
-    Object credentials = servletContext.getAttribute(
-        RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS.key());
+    Object credentials =
+        servletContext.getAttribute(RssBaseConf.REST_AUTHORIZATION_CREDENTIALS.key());
     if (credentials == null) {
       return;
     }
     String authorization = requestContext.getHeaderString("Authorization");
-    if (StringUtils.isBlank(authorization) || !authorization.startsWith("Basic ")
+    if (StringUtils.isBlank(authorization)
+        || !authorization.startsWith("Basic ")
         || !authorization.substring(6).equals(credentials)) {
-      requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).entity("Authentication Failed")
-          .type(MediaType.TEXT_PLAIN).build());
+      requestContext.abortWith(
+          Response.status(Response.Status.UNAUTHORIZED)
+              .entity("Authentication Failed")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
     }
   }
 }

--- a/common/src/test/java/org/apache/uniffle/common/metrics/TestUtils.java
+++ b/common/src/test/java/org/apache/uniffle/common/metrics/TestUtils.java
@@ -45,17 +45,15 @@ public class TestUtils {
     return httpPost(urlString, postData, null);
   }
 
-  public static String httpPost(
-      String urlString,
-      String postData,
-      Map<String, String> headers) throws IOException {
+  public static String httpPost(String urlString, String postData, Map<String, String> headers)
+      throws IOException {
     URL url = new URL(urlString);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setDoOutput(true);
     conn.setRequestMethod("POST");
     conn.setRequestProperty("Content-type", "application/json");
     if (headers != null) {
-      for (Map.Entry<String, String> entry: headers.entrySet()) {
+      for (Map.Entry<String, String> entry : headers.entrySet()) {
         conn.setRequestProperty(entry.getKey(), entry.getValue());
       }
     }
@@ -69,8 +67,8 @@ public class TestUtils {
 
   private static String getResponseStr(HttpURLConnection conn) throws IOException {
     StringBuilder responseContent = new StringBuilder();
-    InputStream inputStream = conn.getResponseCode() == 200
-        ? conn.getInputStream() : conn.getErrorStream();
+    InputStream inputStream =
+        conn.getResponseCode() == 200 ? conn.getInputStream() : conn.getErrorStream();
     try (BufferedReader in = new BufferedReader(new InputStreamReader(inputStream))) {
       String inputLine;
       while ((inputLine = in.readLine()) != null) {
@@ -79,5 +77,4 @@ public class TestUtils {
     }
     return responseContent.toString();
   }
-
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 
 import io.prometheus.client.CollectorRegistry;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.uniffle.common.config.RssBaseConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -195,6 +196,8 @@ public class CoordinatorServer {
     CoordinatorFactory coordinatorFactory = new CoordinatorFactory(this);
     server = coordinatorFactory.getServer();
     jettyServer = new JettyServer(coordinatorConf);
+    jettyServer.registerInstance(RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS.key(),
+        coordinatorConf.getString(RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS));
     // register packages and instances for jersey
     jettyServer.addResourcePackages(
         "org.apache.uniffle.coordinator.web.resource", "org.apache.uniffle.common.web.resource");

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -21,13 +21,13 @@ import java.util.function.Consumer;
 
 import io.prometheus.client.CollectorRegistry;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.uniffle.common.config.RssBaseConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import org.apache.uniffle.common.Arguments;
 import org.apache.uniffle.common.ReconfigurableConfManager;
+import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.metrics.GRPCMetrics;
 import org.apache.uniffle.common.metrics.JvmMetrics;
@@ -196,8 +196,9 @@ public class CoordinatorServer {
     CoordinatorFactory coordinatorFactory = new CoordinatorFactory(this);
     server = coordinatorFactory.getServer();
     jettyServer = new JettyServer(coordinatorConf);
-    jettyServer.registerInstance(RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS.key(),
-        coordinatorConf.getString(RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS));
+    jettyServer.registerInstance(
+        RssBaseConf.REST_AUTHORIZATION_CREDENTIALS.key(),
+        coordinatorConf.getString(RssBaseConf.REST_AUTHORIZATION_CREDENTIALS));
     // register packages and instances for jersey
     jettyServer.addResourcePackages(
         "org.apache.uniffle.coordinator.web.resource", "org.apache.uniffle.common.web.resource");

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -27,8 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.hbase.thirdparty.javax.ws.rs.DELETE;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.POST;
 import org.apache.hbase.thirdparty.javax.ws.rs.Path;
@@ -40,9 +39,7 @@ import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
 
 import org.apache.uniffle.common.Application;
 import org.apache.uniffle.common.ServerStatus;
-import org.apache.uniffle.common.exception.RssException;
-import org.apache.uniffle.common.web.resource.BaseResource;
-import org.apache.uniffle.common.web.resource.Response;
+import org.apache.uniffle.common.web.resource.Authorization;
 import org.apache.uniffle.coordinator.ApplicationManager;
 import org.apache.uniffle.coordinator.ClusterManager;
 import org.apache.uniffle.coordinator.ServerNode;
@@ -97,6 +94,7 @@ public class ServerResource extends BaseResource {
     return Response.success(serverList);
   }
 
+  @Authorization
   @POST
   @Path("/cancelDecommission")
   public Response<Object> cancelDecommission(CancelDecommissionRequest params) {
@@ -110,6 +108,7 @@ public class ServerResource extends BaseResource {
         });
   }
 
+  @Authorization
   @POST
   @Path("/{id}/cancelDecommission")
   public Response<Object> cancelDecommission(@PathParam("id") String serverId) {
@@ -120,6 +119,7 @@ public class ServerResource extends BaseResource {
         });
   }
 
+  @Authorization
   @POST
   @Path("/decommission")
   public Response<Object> decommission(DecommissionRequest params) {
@@ -133,6 +133,7 @@ public class ServerResource extends BaseResource {
         });
   }
 
+  @Authorization
   @POST
   @Path("/{id}/decommission")
   @Produces({MediaType.APPLICATION_JSON})

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.hbase.thirdparty.javax.ws.rs.DELETE;
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.POST;
 import org.apache.hbase.thirdparty.javax.ws.rs.Path;
@@ -39,7 +40,10 @@ import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
 
 import org.apache.uniffle.common.Application;
 import org.apache.uniffle.common.ServerStatus;
+import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.web.resource.Authorization;
+import org.apache.uniffle.common.web.resource.BaseResource;
+import org.apache.uniffle.common.web.resource.Response;
 import org.apache.uniffle.coordinator.ApplicationManager;
 import org.apache.uniffle.coordinator.ClusterManager;
 import org.apache.uniffle.coordinator.ServerNode;

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ServerResource.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hbase.thirdparty.javax.ws.rs.DELETE;
 import org.apache.hbase.thirdparty.javax.ws.rs.GET;
 import org.apache.hbase.thirdparty.javax.ws.rs.POST;

--- a/docs/coordinator_guide.md
+++ b/docs/coordinator_guide.md
@@ -130,6 +130,16 @@ AccessQuotaChecker is a checker when the number of concurrent tasks submitted by
 
 ## RESTful API
 
+### Enable Authorization
+The RESTful API supports Basic authorization. we can enable it by setting `rss.http.basic.authorizationCredentials` to a not empty string.
+After enabling Basic authorization, you need to add credentials to the header when requesting some of the interfaces, such as the decommissioning interface.
+For Basic authentication the credentials are constructed by first combining the username and the password with
+a colon (uniffle:uniffle123) , and then by encoding the resulting string in base64 (dW5pZmZsZTp1bmlmZmxlMTIz).
+#### Example cURL:
+>```bash
+>curl -X POST -H 'Authorization: Basic dW5pZmZsZTp1bmlmZmxlMTIz' -H "Content-Type: application/json" http://localhost:19998/api/server/decommission  -d '{"serverIds": ["127.0.0.1-19999"]}'
+>```
+
 ### Fetch single shuffle server
 
 <details>

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -360,4 +360,20 @@ public class ServletTest extends IntegrationTestBase {
     assertEquals(0, response.getCode());
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
   }
+
+  @Test
+  public void testRequestWithWrongCredentials() throws Exception {
+    DecommissionRequest decommissionRequest = new DecommissionRequest();
+    decommissionRequest.setServerIds(Sets.newHashSet("not_exist_serverId"));
+    String wrongCredentials = "dW5pZmZsZTp1bmlmZmxlMTIz1";
+    String content =
+        TestUtils.httpPost(
+            CANCEL_DECOMMISSION_URL,
+            objectMapper.writeValueAsString(decommissionRequest),
+            ImmutableMap.of("Authorization", "Basic " + wrongCredentials));
+    for (int i = 0; i < 1000; i++) {
+      Thread.sleep(1000);
+    }
+    assertEquals("Authentication Failed", content);
+  }
 }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -89,7 +89,7 @@ public class ServletTest extends IntegrationTestBase {
     coordinatorConf.set(RssBaseConf.JETTY_HTTP_PORT, 12345);
     coordinatorConf.set(RssBaseConf.JETTY_CORE_POOL_SIZE, 128);
     coordinatorConf.set(RssBaseConf.RPC_SERVER_PORT, 12346);
-    coordinatorConf.set(RssBaseConf.COORDINATOR_AUTHORIZATION_CREDENTIALS, AUTHORIZATION_CREDENTIALS);
+    coordinatorConf.set(RssBaseConf.REST_AUTHORIZATION_CREDENTIALS, AUTHORIZATION_CREDENTIALS);
     createCoordinatorServer(coordinatorConf);
 
     ShuffleServerConf shuffleServerConf = getShuffleServerConf(ServerType.GRPC);
@@ -254,7 +254,8 @@ public class ServletTest extends IntegrationTestBase {
     decommissionRequest.setServerIds(Sets.newHashSet("not_exist_serverId"));
     String content =
         TestUtils.httpPost(
-            CANCEL_DECOMMISSION_URL, objectMapper.writeValueAsString(decommissionRequest),
+            CANCEL_DECOMMISSION_URL,
+            objectMapper.writeValueAsString(decommissionRequest),
             authorizationHeader);
     Response<?> response = objectMapper.readValue(content, Response.class);
     assertEquals(-1, response.getCode());
@@ -263,7 +264,8 @@ public class ServletTest extends IntegrationTestBase {
     cancelDecommissionRequest.setServerIds(Sets.newHashSet(shuffleServer.getId()));
     content =
         TestUtils.httpPost(
-            CANCEL_DECOMMISSION_URL, objectMapper.writeValueAsString(cancelDecommissionRequest),
+            CANCEL_DECOMMISSION_URL,
+            objectMapper.writeValueAsString(cancelDecommissionRequest),
             authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
@@ -275,7 +277,9 @@ public class ServletTest extends IntegrationTestBase {
             "testDecommissionServlet_appId", 0, Lists.newArrayList(new PartitionRange(0, 1)), ""));
     decommissionRequest.setServerIds(Sets.newHashSet(shuffleServer.getId()));
     content =
-        TestUtils.httpPost(DECOMMISSION_URL, objectMapper.writeValueAsString(decommissionRequest),
+        TestUtils.httpPost(
+            DECOMMISSION_URL,
+            objectMapper.writeValueAsString(decommissionRequest),
             authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
@@ -294,7 +298,8 @@ public class ServletTest extends IntegrationTestBase {
     // Cancel decommission.
     content =
         TestUtils.httpPost(
-            CANCEL_DECOMMISSION_URL, objectMapper.writeValueAsString(cancelDecommissionRequest),
+            CANCEL_DECOMMISSION_URL,
+            objectMapper.writeValueAsString(cancelDecommissionRequest),
             authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
@@ -306,15 +311,18 @@ public class ServletTest extends IntegrationTestBase {
     ShuffleServer shuffleServer = grpcShuffleServers.get(0);
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());
     String content =
-        TestUtils.httpPost(String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, "not_exist_serverId"),
-            null, authorizationHeader);
+        TestUtils.httpPost(
+            String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, "not_exist_serverId"),
+            null,
+            authorizationHeader);
     Response<?> response = objectMapper.readValue(content, Response.class);
     assertEquals(-1, response.getCode());
     assertNotNull(response.getErrMsg());
     content =
         TestUtils.httpPost(
             String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()),
-            null, authorizationHeader);
+            null,
+            authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
 
@@ -323,8 +331,11 @@ public class ServletTest extends IntegrationTestBase {
     shuffleServerClient.registerShuffle(
         new RssRegisterShuffleRequest(
             "testDecommissionServlet_appId", 0, Lists.newArrayList(new PartitionRange(0, 1)), ""));
-    content = TestUtils.httpPost(String.format(DECOMMISSION_SINGLENODE_URL,
-        shuffleServer.getId()), null, authorizationHeader);
+    content =
+        TestUtils.httpPost(
+            String.format(DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()),
+            null,
+            authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
     assertEquals(ServerStatus.DECOMMISSIONING, shuffleServer.getServerStatus());
@@ -343,7 +354,8 @@ public class ServletTest extends IntegrationTestBase {
     content =
         TestUtils.httpPost(
             String.format(CANCEL_DECOMMISSION_SINGLENODE_URL, shuffleServer.getId()),
-            null, authorizationHeader);
+            null,
+            authorizationHeader);
     response = objectMapper.readValue(content, Response.class);
     assertEquals(0, response.getCode());
     assertEquals(ServerStatus.ACTIVE, shuffleServer.getServerStatus());


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support authentication for decommission interface.

### Why are the changes needed?

For more safety.
Fix: #1947

### Does this PR introduce _any_ user-facing change?

Set `rss.rest.authorization.credentials` to a not empty string.

### How was this patch tested?
UT