### PR TITLE
[#1909] [FOLLOWUP] improve(common): Avoid load missing key from system properties

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.common.config;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -291,16 +292,13 @@ public class RssBaseConf extends RssConf {
     if (properties == null) {
       return false;
     }
+    Map<String, String> propertiesFromSystem = new HashMap<>();
     System.getProperties().stringPropertyNames().stream()
         .forEach(
             propName -> {
-              properties.put(propName, System.getProperty(propName));
+              propertiesFromSystem.put(propName, System.getProperty(propName));
             });
-    return loadCommonConf(properties) && loadConf(properties, configOptions, true);
-  }
-
-  public boolean loadCommonConf(Map<String, String> properties) {
-    List<ConfigOption<Object>> configOptions = ConfigUtils.getAllConfigOptions(RssBaseConf.class);
-    return loadConf(properties, configOptions, false);
+    return loadConf(properties, configOptions, true)
+        && loadConf(propertiesFromSystem, configOptions, false);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Avoid load missing key from system properties

### Why are the changes needed?

Fix: Followup work of #1909

Without this PR, all jvm args will be displayed in dashboard, it can be noisy and useless.

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/e0ebaf3e-efde-42bb-902a-7329a851ff01">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested locally.

added jvm args `-Dmissing.key=xxx -Drss.coordinator.app.expired=50000 -Drss.rpc.metrics.enabled=false`

then, check the result.

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/44997d45-8bcb-4ecd-9040-5ee435418565">



