### PR TITLE
[MINOR] fix(test): fix flaky test ServletTest.testUnhealthyNodesServlet

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -221,8 +222,9 @@ public class ServletTest extends IntegrationTestBase {
     ShuffleServer shuffleServer4 = grpcShuffleServers.get(3);
     shuffleServer3.markUnhealthy();
     shuffleServer4.markUnhealthy();
-    List<String> expectShuffleIds = Arrays.asList(shuffleServer3.getId(), shuffleServer4.getId());
-    List<String> shuffleIds = new ArrayList<>();
+    Set<String> expectShuffleIds = Sets.newHashSet(
+        (Lists.newArrayList(shuffleServer3.getId(), shuffleServer4.getId())));
+    Set<String> shuffleIds = Sets.newHashSet();
     Awaitility.await()
         .atMost(30, TimeUnit.SECONDS)
         .until(
@@ -232,11 +234,11 @@ public class ServletTest extends IntegrationTestBase {
                       TestUtils.httpGet(UNHEALTHYNODES_URL),
                       new TypeReference<Response<List<HashMap<String, Object>>>>() {});
               List<HashMap<String, Object>> serverList = response.getData();
-              for (HashMap<String, Object> stringObjectHashMap : serverList) {
-                String shuffleId = (String) stringObjectHashMap.get("id");
+              for (HashMap<String, Object> serverInfo : serverList) {
+                String shuffleId = (String) serverInfo.get("id");
                 shuffleIds.add(shuffleId);
               }
-              return serverList.size() == 2;
+              return shuffleIds.size() == 2;
             });
     assertTrue(CollectionUtils.isEqualCollection(expectShuffleIds, shuffleIds));
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -222,8 +222,8 @@ public class ServletTest extends IntegrationTestBase {
     ShuffleServer shuffleServer4 = grpcShuffleServers.get(3);
     shuffleServer3.markUnhealthy();
     shuffleServer4.markUnhealthy();
-    Set<String> expectShuffleIds = Sets.newHashSet(
-        (Lists.newArrayList(shuffleServer3.getId(), shuffleServer4.getId())));
+    Set<String> expectShuffleIds =
+        Sets.newHashSet((Lists.newArrayList(shuffleServer3.getId(), shuffleServer4.getId())));
     Set<String> shuffleIds = Sets.newHashSet();
     Awaitility.await()
         .atMost(30, TimeUnit.SECONDS)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix flaky test ServletTest.testUnhealthyNodesServlet.

### Why are the changes needed?

In the original logic, `shuffleIds` will have three elements when only one unhealthy node is obtained for the first time.
https://github.com/apache/incubator-uniffle/actions/runs/10086923444/job/27890257649?pr=1948

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI
