### PR TITLE
[#1961] Fix(client/spark): Add serialVersionUID to each class that implements Serializable

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
@@ -28,7 +28,7 @@ import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
 public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
-  private static final long serialVersionUID = -5519528926859572710L;
+  private static final long serialVersionUID = 0L;
 
   private String appId;
   private int numMaps;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
@@ -28,6 +28,7 @@ import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
 
 public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
+  private static final long serialVersionUID = -5519528926859572710L;
 
   private String appId;
   private int numMaps;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
@@ -40,7 +40,7 @@ import org.apache.uniffle.proto.RssProtos;
 
 /** This class holds the dynamic partition assignment for partition reassign mechanism. */
 public class MutableShuffleHandleInfo extends ShuffleHandleInfoBase {
-  private static final long serialVersionUID = 6093767633402040247L;
+  private static final long serialVersionUID = 0L;
   private static final Logger LOGGER = LoggerFactory.getLogger(MutableShuffleHandleInfo.class);
 
   /**

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfo.java
@@ -40,6 +40,7 @@ import org.apache.uniffle.proto.RssProtos;
 
 /** This class holds the dynamic partition assignment for partition reassign mechanism. */
 public class MutableShuffleHandleInfo extends ShuffleHandleInfoBase {
+  private static final long serialVersionUID = 6093767633402040247L;
   private static final Logger LOGGER = LoggerFactory.getLogger(MutableShuffleHandleInfo.class);
 
   /**

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
@@ -34,7 +34,6 @@ import org.apache.uniffle.common.ShuffleServerInfo;
  */
 public class SimpleShuffleHandleInfo extends ShuffleHandleInfoBase implements Serializable {
   private static final long serialVersionUID = 0L;
-
   private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
 
   public SimpleShuffleHandleInfo(

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
@@ -33,7 +33,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
  * <p>It's to be broadcast to executors and referenced by shuffle tasks.
  */
 public class SimpleShuffleHandleInfo extends ShuffleHandleInfoBase implements Serializable {
-  private static final long serialVersionUID = 6472095256413258590L;
+  private static final long serialVersionUID = 0L;
 
   private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/SimpleShuffleHandleInfo.java
@@ -33,6 +33,8 @@ import org.apache.uniffle.common.ShuffleServerInfo;
  * <p>It's to be broadcast to executors and referenced by shuffle tasks.
  */
 public class SimpleShuffleHandleInfo extends ShuffleHandleInfoBase implements Serializable {
+  private static final long serialVersionUID = 6472095256413258590L;
+
   private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
 
   public SimpleShuffleHandleInfo(

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
@@ -32,7 +32,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.proto.RssProtos;
 
 public class StageAttemptShuffleHandleInfo extends ShuffleHandleInfoBase {
-  private static final long serialVersionUID = 1977203976386265032L;
+  private static final long serialVersionUID = 0L;
   private static final Logger LOGGER = LoggerFactory.getLogger(StageAttemptShuffleHandleInfo.class);
 
   private ShuffleHandleInfo current;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/StageAttemptShuffleHandleInfo.java
@@ -32,6 +32,7 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.proto.RssProtos;
 
 public class StageAttemptShuffleHandleInfo extends ShuffleHandleInfoBase {
+  private static final long serialVersionUID = 1977203976386265032L;
   private static final Logger LOGGER = LoggerFactory.getLogger(StageAttemptShuffleHandleInfo.class);
 
   private ShuffleHandleInfo current;

--- a/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.uniffle.common.util.Constants;
 
 public class RemoteStorageInfo implements Serializable {
-  private static final long serialVersionUID = 2585833683348028153L;
+  private static final long serialVersionUID = 0L;
   public static final RemoteStorageInfo EMPTY_REMOTE_STORAGE = new RemoteStorageInfo("", "");
   private final String path;
   private final Map<String, String> confItems;

--- a/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/RemoteStorageInfo.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.uniffle.common.util.Constants;
 
 public class RemoteStorageInfo implements Serializable {
+  private static final long serialVersionUID = 2585833683348028153L;
   public static final RemoteStorageInfo EMPTY_REMOTE_STORAGE = new RemoteStorageInfo("", "");
   private final String path;
   private final Map<String, String> confItems;

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -26,7 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.uniffle.proto.RssProtos;
 
 public class ShuffleServerInfo implements Serializable {
-  private static final long serialVersionUID = 294859041388000305L;
+  private static final long serialVersionUID = 0L;
   private String id;
 
   private String host;

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleServerInfo.java
@@ -26,7 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.uniffle.proto.RssProtos;
 
 public class ShuffleServerInfo implements Serializable {
-
+  private static final long serialVersionUID = 294859041388000305L;
   private String id;
 
   private String host;

--- a/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 public class FileBasedShuffleSegment extends ShuffleSegment
     implements Comparable<FileBasedShuffleSegment> {
-  private static final long serialVersionUID = -4212554071664808101L;
+  private static final long serialVersionUID = 0L;
   public static final int SEGMENT_SIZE = 4 * Long.BYTES + 2 * Integer.BYTES;
   private long offset;
   private int length;

--- a/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/FileBasedShuffleSegment.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 public class FileBasedShuffleSegment extends ShuffleSegment
     implements Comparable<FileBasedShuffleSegment> {
-
+  private static final long serialVersionUID = -4212554071664808101L;
   public static final int SEGMENT_SIZE = 4 * Long.BYTES + 2 * Integer.BYTES;
   private long offset;
   private int length;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add serialVersionUID to each class that implements Serializable, to avoid encountering the `local class incompatible` issue.

### Why are the changes needed?

Not specifying serialVersionUID in Java can cause Incompatible Serialization, changes in class definition without updating serialVersionUID can lead to InvalidClassException. The automatically generated serialVersionUID may differ across different Java platforms, which can lead to problems during serialization and deserialization between different platforms. Besides, sometimes, compiler optimizations may change the generated serialVersionUID.

In a word, explicitly defining serialVersionUID ensures serialization compatibility and data integrity. This is a good practice.

Fix: #1961

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

NO need
