### PR TITLE
[FOLLOWUP] [#1401] Fix(dashboard): Fix the display of app reg time on app page

### DIFF
--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -55,7 +55,7 @@
       >
         <el-table-column prop="appId" label="AppId" min-width="180" sortable fixed />
         <el-table-column prop="userName" label="UserName" min-width="180" sortable />
-        <el-table-columnsortable
+        <el-table-column
           prop="registrationTime"
           label="Registration Time"
           min-width="180"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Display app reg time in dashboard.

### Why are the changes needed?

Fix typo error introduced by #1868 

### Does this PR introduce _any_ user-facing change?

User can see app reg time from dashboard.

### How was this patch tested?

Open a dashboard ui and submit an application and check the app reg time.
