### PR TITLE
[#1945] Improvement(server): Remove PreAllocated buffer earlier by unregisterPureEvent

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -366,14 +366,16 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   ShuffleServerGrpcMetrics.SEND_SHUFFLE_DATA_METHOD, transportTime);
         }
       }
-      int requireSize = shuffleServer.getShuffleTaskManager().getRequireBufferSize(requireBufferId);
+      int requireSize =
+          shuffleServer.getShuffleTaskManager().getRequireBufferSize(appId, requireBufferId);
 
       StatusCode ret = StatusCode.SUCCESS;
       String responseMessage = "OK";
       if (req.getShuffleDataCount() > 0) {
         ShuffleServerMetrics.counterTotalReceivedDataSize.inc(requireSize);
         ShuffleTaskManager manager = shuffleServer.getShuffleTaskManager();
-        PreAllocatedBufferInfo info = manager.getAndRemovePreAllocatedBuffer(requireBufferId);
+        PreAllocatedBufferInfo info =
+            manager.getAndRemovePreAllocatedBuffer(appId, requireBufferId);
         boolean isPreAllocated = info != null;
         if (!isPreAllocated) {
           String errorMsg =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -992,8 +992,8 @@ public class ShuffleTaskManager {
   }
 
   @VisibleForTesting
-  Map<Long, PreAllocatedBufferInfo> getRequireBufferIds(String appId) {
-    return appIdToRequireBufferIdsMap.get(appId);
+  Supplier<Map<Long, PreAllocatedBufferInfo>> getRequireBufferIdSizeByAppId(String appId) {
+    return () -> appIdToRequireBufferIdsMap.get(appId);
   }
 
   @VisibleForTesting

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -121,7 +121,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       // thread,
       // otherwise we need to release the required size.
       PreAllocatedBufferInfo info =
-          shuffleTaskManager.getAndRemovePreAllocatedBuffer(requireBufferId);
+          shuffleTaskManager.getAndRemovePreAllocatedBuffer(appId, requireBufferId);
       int requireSize = info == null ? 0 : info.getRequireSize();
       int requireBlocksSize =
           requireSize - req.encodedLength() < 0 ? 0 : requireSize - req.encodedLength();

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -365,7 +365,8 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
         StringUtils.EMPTY);
     final List<ShufflePartitionedBlock> expectedBlocks1 = Lists.newArrayList();
     final List<ShufflePartitionedBlock> expectedBlocks2 = Lists.newArrayList();
-    final Map<Long, PreAllocatedBufferInfo> bufferIds = shuffleTaskManager.getRequireBufferIds();
+    final Map<Long, PreAllocatedBufferInfo> bufferIds =
+        shuffleTaskManager.getRequireBufferIds(appId);
 
     shuffleTaskManager.requireBuffer(10);
     shuffleTaskManager.requireBuffer(10);
@@ -391,7 +392,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     assertEquals(StatusCode.SUCCESS, sc);
     shuffleTaskManager.commitShuffle(appId, shuffleId);
     // manually release the pre allocate buffer
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
 
     ShuffleFlushManager shuffleFlushManager = shuffleServer.getShuffleFlushManager();
     assertEquals(
@@ -404,7 +405,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     sc = shuffleTaskManager.cacheShuffleData(appId, shuffleId, true, partitionedData1);
     shuffleTaskManager.updateCachedBlockIds(appId, shuffleId, partitionedData1.getBlockList());
     assertEquals(StatusCode.SUCCESS, sc);
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
     waitForFlush(shuffleFlushManager, appId, shuffleId, 2 + 1);
 
     // won't flush for partition 1-1
@@ -421,7 +422,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     bufferId = shuffleTaskManager.requireBuffer(30);
     sc = shuffleTaskManager.cacheShuffleData(appId, shuffleId, true, partitionedData3);
     shuffleTaskManager.updateCachedBlockIds(appId, shuffleId, partitionedData3.getBlockList());
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
     assertEquals(StatusCode.SUCCESS, sc);
 
     // flush for partition 2-2
@@ -430,7 +431,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     bufferId = shuffleTaskManager.requireBuffer(35);
     sc = shuffleTaskManager.cacheShuffleData(appId, shuffleId, true, partitionedData4);
     shuffleTaskManager.updateCachedBlockIds(appId, shuffleId, partitionedData4.getBlockList());
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
     assertEquals(StatusCode.SUCCESS, sc);
 
     shuffleTaskManager.commitShuffle(appId, shuffleId);
@@ -444,7 +445,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     bufferId = shuffleTaskManager.requireBuffer(70);
     sc = shuffleTaskManager.cacheShuffleData(appId, shuffleId, true, partitionedData5);
     assertEquals(StatusCode.SUCCESS, sc);
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
 
     // 2 new blocks should be committed
     waitForFlush(shuffleFlushManager, appId, shuffleId, 2 + 1 + 3 + 2);
@@ -460,7 +461,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     bufferId = shuffleTaskManager.requireBuffer(70);
     sc = shuffleTaskManager.cacheShuffleData(appId, shuffleId, true, partitionedData7);
     assertEquals(StatusCode.SUCCESS, sc);
-    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(bufferId);
+    shuffleTaskManager.removeAndReleasePreAllocatedBuffer(appId, bufferId);
 
     // 2 new blocks should be committed
     waitForFlush(shuffleFlushManager, appId, shuffleId, 2 + 1 + 3 + 2 + 2);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Index PreAllocatedBufferInfo by appId, base on this, remove all PreAllocatedBufferInfos related an appId which invoked by `UnregisterAppPurgeEvent` handle method.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #1945

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test pressure test case on our test cluster.
