### PR TITLE
[#1972] fix(server): Fix clear leak shuffle data accidentally remove data of new coming appId issue

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/log/TestLoggerExtension.java
+++ b/common/src/test/java/org/apache/uniffle/common/log/TestLoggerExtension.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.log;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.annotation.concurrent.GuardedBy;
+
+import org.apache.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class TestLoggerExtension implements BeforeEachCallback, AfterEachCallback {
+  private static final ExtensionContext.Namespace NAMESPACE =
+      ExtensionContext.Namespace.create(TestLoggerExtension.class);
+  private static final String LOG_COLLECTOR_KEY = "TestLogAppender";
+  private TestAppender appender;
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    appender = new TestAppender();
+    if (LogManager.getLogger(LogManager.ROOT_LOGGER_NAME) instanceof Logger) {
+      org.apache.logging.log4j.core.Logger log4jlogger =
+          (org.apache.logging.log4j.core.Logger)
+              org.apache.logging.log4j.LogManager.getLogger(LogManager.ROOT_LOGGER_NAME);
+      appender.start();
+      log4jlogger.addAppender(appender);
+    }
+    context.getStore(NAMESPACE).put(LOG_COLLECTOR_KEY, this);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    if (LogManager.getLogger(LogManager.ROOT_LOGGER_NAME) instanceof Logger) {
+      Logger log4jlogger = (Logger) LogManager.getLogger(LogManager.ROOT_LOGGER_NAME);
+      appender.stop();
+      log4jlogger.removeAppender(appender);
+    }
+  }
+
+  public static TestLoggerExtension getTestLogger(ExtensionContext context) {
+    return context.getStore(NAMESPACE).get(LOG_COLLECTOR_KEY, TestLoggerExtension.class);
+  }
+
+  /**
+   * Determine if a specific pattern appears in log output.
+   *
+   * @param pattern a pattern text to search for in log events
+   * @return true if a log message containing the pattern exists, false otherwise
+   */
+  public boolean wasLogged(String pattern) {
+    return appender.wasLogged(Pattern.compile(".*" + pattern + ".*"));
+  }
+
+  /**
+   * Determine if a specific pattern appears in log output with the specified level.
+   *
+   * @param pattern a pattern text to search for in log events
+   * @return true if a log message containing the pattern exists, false otherwise
+   */
+  public boolean wasLoggedWithLevel(String pattern, Level level) {
+    return appender.wasLoggedWithLevel(Pattern.compile(".*" + pattern + ".*"), level);
+  }
+
+  /**
+   * Count the number of times a specific pattern appears in log messages.
+   *
+   * @param pattern Pattern to search for in log events
+   * @return The number of log messages which match the pattern
+   */
+  public int logCount(String pattern) {
+    // [\s\S] will match all character include line break
+    return appender.logCount(Pattern.compile("[\\s\\S]*" + pattern + "[\\s\\S]*"));
+  }
+
+  public class TestAppender extends AbstractAppender {
+    @GuardedBy("this") private final List<LogEvent> events = new ArrayList<>();
+
+    protected TestAppender() {
+      super("", null, null, false, null);
+    }
+
+    /** Determines whether a message with the given pattern was logged. */
+    public synchronized boolean wasLogged(Pattern pattern) {
+      for (LogEvent e : events) {
+        if (pattern.matcher(e.getMessage().getFormattedMessage()).matches()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Determines whether a message with the given pattern was logged. */
+    public synchronized boolean wasLoggedWithLevel(Pattern pattern, Level level) {
+      for (LogEvent e : events) {
+        if (e.getLevel().equals(level)
+            && pattern.matcher(e.getMessage().getFormattedMessage()).matches()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Counts the number of log message with a given pattern. */
+    public synchronized int logCount(Pattern pattern) {
+      int logCount = 0;
+      for (LogEvent e : events) {
+        if (pattern.matcher(e.getMessage().getFormattedMessage()).matches()) {
+          logCount++;
+        }
+      }
+      return logCount;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      events.add(event);
+    }
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/log/TestLoggerParamResolver.java
+++ b/common/src/test/java/org/apache/uniffle/common/log/TestLoggerParamResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.log;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class TestLoggerParamResolver implements ParameterResolver {
+  @Override
+  public boolean supportsParameter(
+      final ParameterContext parameterContext, final ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return ExtensionContext.class.isAssignableFrom(parameterContext.getParameter().getType())
+        && parameterContext.getIndex() == 0;
+  }
+
+  @Override
+  public Object resolveParameter(
+      final ParameterContext parameterContext, final ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return extensionContext;
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -832,8 +832,8 @@ public class ShuffleTaskManager {
   public void checkLeakShuffleData() {
     LOG.info("Start check leak shuffle data");
     try {
-      Set<String> appIds = Sets.newHashSet(shuffleTaskInfos.keySet());
-      storageManager.checkAndClearLeakedShuffleData(appIds);
+      storageManager.checkAndClearLeakedShuffleData(
+          () -> Sets.newHashSet(shuffleTaskInfos.keySet()));
       LOG.info("Finish check leak shuffle data");
     } catch (Exception e) {
       LOG.warn("Error happened in checkLeakShuffleData", e);

--- a/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HadoopStorageManager.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -181,7 +182,7 @@ public class HadoopStorageManager extends SingleStorageManager {
   }
 
   @Override
-  public void checkAndClearLeakedShuffleData(Collection<String> appIds) {}
+  public void checkAndClearLeakedShuffleData(Supplier<Collection<String>> appIdsSupplier) {}
 
   @Override
   public Map<String, StorageInfo> getStorageInfo() {

--- a/server/src/main/java/org/apache/uniffle/server/storage/HybridStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/HybridStorageManager.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.server.storage;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,8 +146,8 @@ public class HybridStorageManager implements StorageManager {
   }
 
   @Override
-  public void checkAndClearLeakedShuffleData(Collection<String> appIds) {
-    warmStorageManager.checkAndClearLeakedShuffleData(appIds);
+  public void checkAndClearLeakedShuffleData(Supplier<Collection<String>> appIdsSupplier) {
+    warmStorageManager.checkAndClearLeakedShuffleData(appIdsSupplier);
   }
 
   @Override

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -375,7 +376,7 @@ public class LocalStorageManager extends SingleStorageManager {
   }
 
   @Override
-  public void checkAndClearLeakedShuffleData(Collection<String> appIds) {
+  public void checkAndClearLeakedShuffleData(Supplier<Collection<String>> appIdsSupplier) {
     Set<String> appIdsOnStorages = new HashSet<>();
     for (LocalStorage localStorage : localStorages) {
       if (!localStorage.isCorrupted()) {
@@ -384,6 +385,7 @@ public class LocalStorageManager extends SingleStorageManager {
       }
     }
 
+    Collection<String> appIds = appIdsSupplier.get();
     for (String appId : appIdsOnStorages) {
       if (!appIds.contains(appId)) {
         ShuffleDeleteHandler deleteHandler =

--- a/server/src/main/java/org/apache/uniffle/server/storage/StorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/StorageManager.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.server.storage;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.storage.StorageInfo;
@@ -55,7 +56,7 @@ public interface StorageManager {
 
   // todo: add an interface that check storage isHealthy
 
-  void checkAndClearLeakedShuffleData(Collection<String> appIds);
+  void checkAndClearLeakedShuffleData(Supplier<Collection<String>> appIdsSupplier);
 
   /**
    * Report a map of storage mount point -> storage info mapping. For local storages, the mount


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix clear leak shuffle data accidentally remove data of new coming appId issue

### Why are the changes needed?

Fix: #1972

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
