### PR TITLE
[MINOR] feat(server/coordinator): Heartbeat server startTimeMs to coordinator

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorGrpcService.java
@@ -434,6 +434,7 @@ public class CoordinatorGrpcService extends CoordinatorServerGrpc.CoordinatorSer
         serverStatus,
         StorageInfoUtils.fromProto(request.getStorageInfoMap()),
         request.getServerId().getNettyPort(),
-        request.getServerId().getJettyPort());
+        request.getServerId().getJettyPort(),
+        request.getStartTimeMs());
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -43,6 +43,7 @@ public class ServerNode implements Comparable<ServerNode> {
   private Map<String, StorageInfo> storageInfo;
   private int nettyPort = -1;
   private int jettyPort = -1;
+  private long startTimeMs = -1;
 
   public ServerNode(String id) {
     this(id, "", 0, 0, 0, 0, 0, Sets.newHashSet(), ServerStatus.EXCLUDED);
@@ -117,6 +118,7 @@ public class ServerNode implements Comparable<ServerNode> {
         status,
         storageInfoMap,
         -1,
+        -1,
         -1);
   }
 
@@ -144,7 +146,8 @@ public class ServerNode implements Comparable<ServerNode> {
         status,
         storageInfoMap,
         nettyPort,
-        -1);
+        -1,
+        -1L);
   }
 
   public ServerNode(
@@ -159,7 +162,8 @@ public class ServerNode implements Comparable<ServerNode> {
       ServerStatus status,
       Map<String, StorageInfo> storageInfoMap,
       int nettyPort,
-      int jettyPort) {
+      int jettyPort,
+      long startTimeMs) {
     this.id = id;
     this.ip = ip;
     this.grpcPort = grpcPort;
@@ -178,6 +182,7 @@ public class ServerNode implements Comparable<ServerNode> {
     if (jettyPort > 0) {
       this.jettyPort = jettyPort;
     }
+    this.startTimeMs = startTimeMs;
   }
 
   public ShuffleServerId convertToGrpcProto() {
@@ -316,5 +321,9 @@ public class ServerNode implements Comparable<ServerNode> {
 
   public int getJettyPort() {
     return jettyPort;
+  }
+
+  public long getStartTimeMs() {
+    return startTimeMs;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
@@ -125,7 +125,8 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
       ServerStatus serverStatus,
       Map<String, StorageInfo> storageInfo,
       int nettyPort,
-      int jettyPort) {
+      int jettyPort,
+      long startTimeMs) {
     ShuffleServerId serverId =
         ShuffleServerId.newBuilder()
             .setId(id)
@@ -144,6 +145,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
             .addAllTags(tags)
             .setStatusValue(serverStatus.ordinal())
             .putAllStorageInfo(StorageInfoUtils.toProto(storageInfo))
+            .setStartTimeMs(startTimeMs)
             .build();
 
     RssProtos.StatusCode status;
@@ -219,7 +221,8 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
             request.getServerStatus(),
             request.getStorageInfo(),
             request.getNettyPort(),
-            request.getJettyPort());
+            request.getJettyPort(),
+            request.getStartTimeMs());
 
     RssSendHeartBeatResponse response;
     RssProtos.StatusCode statusCode = rpcResponse.getStatus();

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendHeartBeatRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssSendHeartBeatRequest.java
@@ -38,6 +38,7 @@ public class RssSendHeartBeatRequest {
   private final Map<String, StorageInfo> storageInfo;
   private final int nettyPort;
   private final int jettyPort;
+  private final long startTimeMs;
 
   public RssSendHeartBeatRequest(
       String shuffleServerId,
@@ -52,7 +53,8 @@ public class RssSendHeartBeatRequest {
       ServerStatus serverStatus,
       Map<String, StorageInfo> storageInfo,
       int nettyPort,
-      int jettyPort) {
+      int jettyPort,
+      long startTimeMs) {
     this.shuffleServerId = shuffleServerId;
     this.shuffleServerIp = shuffleServerIp;
     this.shuffleServerPort = shuffleServerPort;
@@ -66,6 +68,7 @@ public class RssSendHeartBeatRequest {
     this.storageInfo = storageInfo;
     this.nettyPort = nettyPort;
     this.jettyPort = jettyPort;
+    this.startTimeMs = startTimeMs;
   }
 
   public String getShuffleServerId() {
@@ -118,5 +121,9 @@ public class RssSendHeartBeatRequest {
 
   public int getJettyPort() {
     return jettyPort;
+  }
+
+  public long getStartTimeMs() {
+    return startTimeMs;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -275,6 +275,7 @@ message ShuffleServerHeartBeatRequest {
   google.protobuf.BoolValue isHealthy = 7;
   optional ServerStatus status = 8;
   map<string, StorageInfo> storageInfo = 21; // mount point to storage info mapping.
+  optional int64 startTimeMs = 24;
 }
 
 message ShuffleServerHeartBeatResponse {

--- a/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
+++ b/server/src/main/java/org/apache/uniffle/server/RegisterHeartBeat.java
@@ -86,7 +86,8 @@ public class RegisterHeartBeat {
                 shuffleServer.getServerStatus(),
                 shuffleServer.getStorageManager().getStorageInfo(),
                 shuffleServer.getNettyPort(),
-                shuffleServer.getJettyPort());
+                shuffleServer.getJettyPort(),
+                shuffleServer.getStartTimeMs());
           } catch (Exception e) {
             LOG.warn("Error happened when send heart beat to coordinator");
           }
@@ -108,7 +109,8 @@ public class RegisterHeartBeat {
       ServerStatus serverStatus,
       Map<String, StorageInfo> localStorageInfo,
       int nettyPort,
-      int jettyPort) {
+      int jettyPort,
+      long startTimeMs) {
     AtomicBoolean sendSuccessfully = new AtomicBoolean(false);
     // use `rss.server.heartbeat.interval` as the timeout option
     RssSendHeartBeatRequest request =
@@ -125,7 +127,8 @@ public class RegisterHeartBeat {
             serverStatus,
             localStorageInfo,
             nettyPort,
-            jettyPort);
+            jettyPort,
+            startTimeMs);
 
     ThreadUtils.executeTasks(
         heartBeatExecutorService,

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServer.java
@@ -104,8 +104,11 @@ public class ShuffleServer {
   private StreamServer streamServer;
   private JvmPauseMonitor jvmPauseMonitor;
 
+  private final long startTimeMs;
+
   public ShuffleServer(ShuffleServerConf shuffleServerConf) throws Exception {
     this.shuffleServerConf = shuffleServerConf;
+    this.startTimeMs = System.currentTimeMillis();
     try {
       initialization();
     } catch (Exception e) {
@@ -542,6 +545,10 @@ public class ShuffleServer {
     return StringUtils.join(tags, ",");
   }
 
+  public long getStartTimeMs() {
+    return startTimeMs;
+  }
+
   @VisibleForTesting
   public void sendHeartbeat() {
     ShuffleServer shuffleServer = this;
@@ -557,6 +564,7 @@ public class ShuffleServer {
         shuffleServer.getServerStatus(),
         shuffleServer.getStorageManager().getStorageInfo(),
         shuffleServer.getNettyPort(),
-        shuffleServer.getJettyPort());
+        shuffleServer.getJettyPort(),
+        shuffleServer.getStartTimeMs());
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Server send start time to coordinator through heartbeat.

### Why are the changes needed?

Get each server start time to know well which server ever restarted.

### Does this PR introduce _any_ user-facing change?

User can the the server start time from rest api.

### How was this patch tested?

curl http://<COORDINATOR_HOST>: <COORDINATOR_JETTY_PORT>/api/server/nodes