### PR TITLE
[MINOR] fix(test): remove useless code from ServletTest.testRequestWithWrongCredentials

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -376,9 +376,6 @@ public class ServletTest extends IntegrationTestBase {
             CANCEL_DECOMMISSION_URL,
             objectMapper.writeValueAsString(decommissionRequest),
             ImmutableMap.of("Authorization", "Basic " + wrongCredentials));
-    for (int i = 0; i < 1000; i++) {
-      Thread.sleep(1000);
-    }
     assertEquals("Authentication Failed", content);
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Remove useless code from ServletTest.testRequestWithWrongCredentials.

### Why are the changes needed?

The logic of sleep is useless. This is a mistake.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI
