### PR TITLE
[#1975][FOLLOWUP] feat(dashboard): Support displaying the start time of server in dashboard

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -43,7 +43,7 @@ public class ServerNode implements Comparable<ServerNode> {
   private Map<String, StorageInfo> storageInfo;
   private int nettyPort = -1;
   private int jettyPort = -1;
-  private long startTimeMs = -1;
+  private long startTime = -1;
   private String version;
   private String gitCommitId;
 
@@ -165,7 +165,7 @@ public class ServerNode implements Comparable<ServerNode> {
       Map<String, StorageInfo> storageInfoMap,
       int nettyPort,
       int jettyPort,
-      long startTimeMs) {
+      long startTime) {
     this(
         id,
         ip,
@@ -179,7 +179,7 @@ public class ServerNode implements Comparable<ServerNode> {
         storageInfoMap,
         nettyPort,
         jettyPort,
-        startTimeMs,
+        startTime,
         "",
         "");
   }
@@ -197,7 +197,7 @@ public class ServerNode implements Comparable<ServerNode> {
       Map<String, StorageInfo> storageInfoMap,
       int nettyPort,
       int jettyPort,
-      long startTimeMs,
+      long startTime,
       String version,
       String gitCommitId) {
     this.id = id;
@@ -218,7 +218,7 @@ public class ServerNode implements Comparable<ServerNode> {
     if (jettyPort > 0) {
       this.jettyPort = jettyPort;
     }
-    this.startTimeMs = startTimeMs;
+    this.startTime = startTime;
     this.version = version;
     this.gitCommitId = gitCommitId;
   }
@@ -364,8 +364,8 @@ public class ServerNode implements Comparable<ServerNode> {
     return jettyPort;
   }
 
-  public long getStartTimeMs() {
-    return startTimeMs;
+  public long getStartTime() {
+    return startTime;
   }
 
   public String getGitCommitId() {

--- a/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
@@ -53,6 +53,13 @@
       <el-table-column prop="eventNumInFlush" label="FlushNum" min-width="80" sortable />
       <el-table-column prop="status" label="Status" min-width="80" sortable />
       <el-table-column
+        prop="startTime"
+        label="StartTime"
+        min-width="120"
+        :formatter="dateFormatter"
+        sortable
+      />
+      <el-table-column
         prop="registrationTime"
         label="RegistrationTime"
         min-width="120"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Display start time of servers within server page of dashboard.

### Why are the changes needed?

Just show the start time. Let users know when the server has been restarted.

### Does this PR introduce _any_ user-facing change?

Display start time of servers within server page of dashboard.

### How was this patch tested?

<img width="2485" alt="image" src="https://github.com/user-attachments/assets/9ab8e0ac-360b-49d5-859b-0877944d075a">

