### PR TITLE
 [#1401] feat(dashboard): Add mock data to the Dashboard front end.

### DIFF
--- a/dashboard/src/main/webapp/package.json
+++ b/dashboard/src/main/webapp/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.2.0",
     "eslint-plugin-vue": "^9.26.0",
+    "mockjs": "^1.1.0",
     "node-sass": "^9.0.0",
     "prettier": "^3.3.2",
     "sass-loader": "^13.3.1",

--- a/dashboard/src/main/webapp/src/mock/applicationpage.js
+++ b/dashboard/src/main/webapp/src/mock/applicationpage.js
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Mock from 'mockjs'
+
+Mock.mock(/\/app\/total/, 'get', function (options) {
+  return { code: 0, data: { appTotality: 10 }, errMsg: 'success' }
+})
+
+Mock.mock(/\/app\/appInfos/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        userName: 'pro_sale',
+        appId: 'application_1709707920318_70148215_192.168.2.15-3900494',
+        updateTime: '2024-07-31 14:03:03'
+      },
+      {
+        userName: 'pro_sale',
+        appId: 'application_1709707920318_70149011_192.168.2.15-3900581',
+        updateTime: '2024-07-31 14:03:07'
+      },
+      {
+        userName: 'pro_sale',
+        appId: 'application_1709707920318_70149008_192.168.2.15-3900578',
+        updateTime: '2024-07-31 14:03:06'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70144711_192.168.2.15-3900288',
+        updateTime: '2024-07-31 14:03:04'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70144710_192.168.2.15-3900312',
+        updateTime: '2024-07-31 14:02:22'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70147234_192.168.2.15-3900424',
+        updateTime: '2024-07-31 14:03:02'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70145262_192.168.2.15-3900291',
+        updateTime: '2024-07-31 14:03:07'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70144709_192.168.2.15-3900287',
+        updateTime: '2024-07-31 14:03:05'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70133543_192.168.2.15-3899697',
+        updateTime: '2024-07-31 14:03:03'
+      },
+      {
+        userName: 'pro_conpany',
+        appId: 'application_1709707920318_70147213_192.168.2.15-3900423',
+        updateTime: '2024-07-31 14:03:11'
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+
+Mock.mock(/\/app\/userTotal/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        userName: 'pro_conpany',
+        appNum: 7
+      },
+      {
+        userName: 'pro_sale',
+        appNum: 3
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+export default Mock

--- a/dashboard/src/main/webapp/src/mock/coordinatorserverpage.js
+++ b/dashboard/src/main/webapp/src/mock/coordinatorserverpage.js
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Mock from 'mockjs'
+
+Mock.mock(/\/coordinator\/conf/, 'get', {
+  code: 0,
+  data: [
+    {
+      argumentKey: 'awt.toolkit',
+      argumentValue: 'sun.awt.X11.XToolkit'
+    },
+    {
+      argumentKey: 'java.specification.version',
+      argumentValue: '11'
+    },
+    {
+      argumentKey: 'sun.cpu.isalist',
+      argumentValue: ''
+    },
+    {
+      argumentKey: 'sun.jnu.encoding',
+      argumentValue: 'UTF-8'
+    },
+    {
+      argumentKey: 'rss.jetty.http.port',
+      argumentValue: '29998'
+    },
+    {
+      argumentKey: 'rss.coordinator.default.app.priority',
+      argumentValue: '5'
+    },
+    {
+      argumentKey: 'java.vm.vendor',
+      argumentValue: 'Oracle Corporation'
+    },
+    {
+      argumentKey: 'sun.arch.data.model',
+      argumentValue: '64'
+    },
+    {
+      argumentKey: 'log4j2.configurationFile',
+      argumentValue: 'file:/root/rss-0.10.0-SNAPSHOT-hadoop2.8/conf/log4j2.xml'
+    },
+    {
+      argumentKey: 'java.vendor.url',
+      argumentValue: 'http://java.oracle.com/'
+    },
+    {
+      argumentKey: 'rss.coordinator.app.expired',
+      argumentValue: '60000'
+    },
+    {
+      argumentKey: 'user.timezone',
+      argumentValue: 'Asia/Shanghai'
+    },
+    {
+      argumentKey: 'java.vm.specification.version',
+      argumentValue: '11'
+    },
+    {
+      argumentKey: 'os.name',
+      argumentValue: 'Linux'
+    },
+    {
+      argumentKey: 'sun.java.launcher',
+      argumentValue: 'SUN_STANDARD'
+    },
+    {
+      argumentKey: 'user.country',
+      argumentValue: 'US'
+    },
+    {
+      argumentKey: 'sun.boot.library.path',
+      argumentValue: '/home/hadoop/jdk-11.0.2/lib'
+    },
+    {
+      argumentKey: 'rss.coordinator.select.partition.strategy',
+      argumentValue: 'CONTINUOUS'
+    },
+    {
+      argumentKey: 'sun.java.command',
+      argumentValue:
+        'org.apache.uniffle.coordinator.CoordinatorServer --conf /root/rss-0.10.0-SNAPSHOT-hadoop2.8/conf/coordinator.conf'
+    },
+    {
+      argumentKey: 'jdk.debug',
+      argumentValue: 'release'
+    },
+    {
+      argumentKey: 'sun.cpu.endian',
+      argumentValue: 'little'
+    },
+    {
+      argumentKey: 'user.home',
+      argumentValue: '/home/hadoop'
+    },
+    {
+      argumentKey: 'rss.coordinator.server.heartbeat.timeout',
+      argumentValue: '30000'
+    },
+    {
+      argumentKey: 'user.language',
+      argumentValue: 'en'
+    },
+    {
+      argumentKey: 'java.specification.vendor',
+      argumentValue: 'Oracle Corporation'
+    },
+    {
+      argumentKey: 'java.version.date',
+      argumentValue: '2019-01-15'
+    },
+    {
+      argumentKey: 'java.home',
+      argumentValue: '/home/hadoop/jdk-11.0.2'
+    },
+    {
+      argumentKey: 'file.separator',
+      argumentValue: '/'
+    },
+    {
+      argumentKey: 'line.separator',
+      argumentValue: '\n'
+    },
+    {
+      argumentKey: 'rss.coordinator.quota.default.app.num',
+      argumentValue: '25'
+    },
+    {
+      argumentKey: 'java.specification.name',
+      argumentValue: 'Java Platform API Specification'
+    },
+    {
+      argumentKey: 'java.vm.specification.vendor',
+      argumentValue: 'Oracle Corporation'
+    },
+    {
+      argumentKey: 'java.awt.graphicsenv',
+      argumentValue: 'sun.awt.X11GraphicsEnvironment'
+    },
+    {
+      argumentKey: 'sun.management.compiler',
+      argumentValue: 'HotSpot 64-Bit Tiered Compilers'
+    },
+    {
+      argumentKey: 'rss.coordinator.dynamicClientConf.enabled',
+      argumentValue: 'true'
+    },
+    {
+      argumentKey: 'rss.coordinator.quota.default.path',
+      argumentValue: 'file:///root/rss-0.10.0-SNAPSHOT-hadoop2.8/conf/userQuota.properties'
+    },
+    {
+      argumentKey: 'java.runtime.version',
+      argumentValue: '11.0.2+9'
+    },
+    {
+      argumentKey: 'user.name',
+      argumentValue: 'hadoop'
+    },
+    {
+      argumentKey: 'path.separator',
+      argumentValue: ':'
+    },
+    {
+      argumentKey: 'os.version',
+      argumentValue: '4.18.0-193.6.3.el8_2.v1.4.x86_64'
+    },
+    {
+      argumentKey: 'java.runtime.name',
+      argumentValue: 'OpenJDK Runtime Environment'
+    },
+    {
+      argumentKey: 'rss.coordinator.access.loadChecker.memory.percentage',
+      argumentValue: '10.0'
+    },
+    {
+      argumentKey: 'rss.coordinator.dynamicClientConf.path',
+      argumentValue: 'file:///root/rss-0.10.0-SNAPSHOT-hadoop2.8/conf/dynamic_client.conf'
+    },
+    {
+      argumentKey: 'file.encoding',
+      argumentValue: 'UTF-8'
+    },
+    {
+      argumentKey: 'java.vm.name',
+      argumentValue: 'OpenJDK 64-Bit Server VM'
+    },
+    {
+      argumentKey: 'java.vendor.version',
+      argumentValue: '18.9'
+    },
+    {
+      argumentKey: 'log.path',
+      argumentValue: '/root/cluster-data/logs/coordinator.log'
+    },
+    {
+      argumentKey: 'rss.coordinator.exclude.nodes.file.path',
+      argumentValue: 'file:///root/rss-0.10.0-SNAPSHOT-hadoop2.8/conf/exclude_nodes'
+    },
+    {
+      argumentKey: 'java.vendor.url.bug',
+      argumentValue: 'http://bugreport.java.com/bugreport/'
+    },
+    {
+      argumentKey: 'java.io.tmpdir',
+      argumentValue: '/tmp'
+    },
+    {
+      argumentKey: 'java.version',
+      argumentValue: '11.0.2'
+    },
+    {
+      argumentKey: 'user.dir',
+      argumentValue: '/root/rss-0.10.0-SNAPSHOT-hadoop2.8'
+    },
+    {
+      argumentKey: 'os.arch',
+      argumentValue: 'amd64'
+    },
+    {
+      argumentKey: 'java.vm.specification.name',
+      argumentValue: 'Java Virtual Machine Specification'
+    },
+    {
+      argumentKey: 'java.awt.printerjob',
+      argumentValue: 'sun.print.PSPrinterJob'
+    },
+    {
+      argumentKey: 'coordinator.id',
+      argumentValue: '10.55.123.88-29997'
+    },
+    {
+      argumentKey: 'sun.os.patch.level',
+      argumentValue: 'unknown'
+    },
+    {
+      argumentKey: 'rss.rpc.server.port',
+      argumentValue: '29997'
+    },
+    {
+      argumentKey: 'java.library.path',
+      argumentValue: '/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib'
+    },
+    {
+      argumentKey: 'java.vendor',
+      argumentValue: 'Oracle Corporation'
+    },
+    {
+      argumentKey: 'java.vm.info',
+      argumentValue: 'mixed mode'
+    },
+    {
+      argumentKey: 'java.vm.version',
+      argumentValue: '11.0.2+9'
+    },
+    {
+      argumentKey: 'sun.io.unicode.encoding',
+      argumentValue: 'UnicodeLittle'
+    },
+    {
+      argumentKey: 'rss.coordinator.shuffle.nodes.max',
+      argumentValue: '2'
+    },
+    {
+      argumentKey: 'java.class.version',
+      argumentValue: '55.0'
+    }
+  ],
+  errMsg: 'success'
+})
+
+Mock.mock(/\/coordinator\/info/, 'get', {
+  code: 0,
+  data: {
+    serverIp: '192.168.1.1',
+    coordinatorId: '192.168.1.1-29997',
+    serverPort: '29997',
+    serverWebPort: '29998'
+  },
+  errMsg: 'success'
+})
+
+export default Mock

--- a/dashboard/src/main/webapp/src/mock/excludenodelist.js
+++ b/dashboard/src/main/webapp/src/mock/excludenodelist.js
@@ -15,18 +15,29 @@
  * limitations under the License.
  */
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
-import ElementPlus from 'element-plus'
-import * as ElementPlusIconsVue from '@element-plus/icons-vue'
-import 'element-plus/dist/index.css'
-import router from '@/router'
-// import '@/mock'  // With this annotation turned on, you can use the front-end mock data without requesting a background interface.
+import Mock from 'mockjs'
 
-const app = createApp(App)
-const pinia = createPinia()
-Object.keys(ElementPlusIconsVue).forEach((key) => {
-  app.component(key, ElementPlusIconsVue[key])
+Mock.mock(/\/server\/nodes\?status=excluded/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.10-29999-29997'
+      },
+      {
+        id: '192.168.1.11-29999-29997'
+      },
+      {
+        id: '192.168.1.12-29999-29997'
+      },
+      {
+        id: '192.168.1.3-29999-29997'
+      },
+      {
+        id: '192.168.1.4-29999-29997'
+      }
+    ],
+    errMsg: 'success'
+  }
 })
-app.use(router).use(pinia).use(ElementPlus).mount('#app')
+export default Mock

--- a/dashboard/src/main/webapp/src/mock/index.js
+++ b/dashboard/src/main/webapp/src/mock/index.js
@@ -15,18 +15,9 @@
  * limitations under the License.
  */
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
-import ElementPlus from 'element-plus'
-import * as ElementPlusIconsVue from '@element-plus/icons-vue'
-import 'element-plus/dist/index.css'
-import router from '@/router'
-// import '@/mock'  // With this annotation turned on, you can use the front-end mock data without requesting a background interface.
-
-const app = createApp(App)
-const pinia = createPinia()
-Object.keys(ElementPlusIconsVue).forEach((key) => {
-  app.component(key, ElementPlusIconsVue[key])
-})
-app.use(router).use(pinia).use(ElementPlus).mount('#app')
+import '@/mock/coordinatorserverpage'
+import '@/mock/layoutpage'
+import '@/mock/shuffleserverpage'
+import '@/mock/nodelistpage'
+import '@/mock/excludenodelist'
+import '@/mock/applicationpage'

--- a/dashboard/src/main/webapp/src/mock/layoutpage.js
+++ b/dashboard/src/main/webapp/src/mock/layoutpage.js
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
-import ElementPlus from 'element-plus'
-import * as ElementPlusIconsVue from '@element-plus/icons-vue'
-import 'element-plus/dist/index.css'
-import router from '@/router'
-// import '@/mock'  // With this annotation turned on, you can use the front-end mock data without requesting a background interface.
+import Mock from 'mockjs'
 
-const app = createApp(App)
-const pinia = createPinia()
-Object.keys(ElementPlusIconsVue).forEach((key) => {
-  app.component(key, ElementPlusIconsVue[key])
+Mock.mock(/\/web\/coordinator\/coordinatorServers/, 'get', function (options) {
+  return {
+    code: 0,
+    data: {
+      'sports.sina.com.cn': 'http://sports.sina.com.cn:29998',
+      'sports.faceback.com.cn': 'http://sports.faceback.com.cn:29998',
+      'sports.twiter.com.cn': 'http://sports.twiter.com.cn:29998'
+    },
+    errMsg: 'success'
+  }
 })
-app.use(router).use(pinia).use(ElementPlus).mount('#app')
+export default Mock

--- a/dashboard/src/main/webapp/src/mock/nodelistpage.js
+++ b/dashboard/src/main/webapp/src/mock/nodelistpage.js
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Mock from 'mockjs'
+
+Mock.mock(/\/server\/nodes\?status=active/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.1-29999-29997',
+        ip: '192.168.1.1',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057265853,
+        timestamp: 1722404445850,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.2-29999-29997',
+        ip: '192.168.1.2',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057259803,
+        timestamp: 1722404449663,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.3-29999-29997',
+        ip: '192.168.1.3',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057274269,
+        timestamp: 1722404454266,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.4-29999-29997',
+        ip: '192.168.1.4',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057272201,
+        timestamp: 1722404452198,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.5-29999-29997',
+        ip: '192.168.1.5',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+
+Mock.mock(/\/server\/nodes\?status=decommissioning/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.1-29999-29997',
+        ip: '192.168.1.1',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057265853,
+        timestamp: 1722404445850,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+
+Mock.mock(/\/server\/nodes\?status=decommissioned/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.1-29999-29997',
+        ip: '192.168.1.1',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057265853,
+        timestamp: 1722404445850,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+
+Mock.mock(/\/server\/nodes\?status=lost/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.1-29999-29997',
+        ip: '192.168.1.1',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057265853,
+        timestamp: 1722404445850,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+
+Mock.mock(/\/server\/nodes\?status=unhealthy/, 'get', function (options) {
+  return {
+    code: 0,
+    data: [
+      {
+        id: '192.168.1.1-29999-29997',
+        ip: '192.168.1.1',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057265853,
+        timestamp: 1722404445850,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/nvme1n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/nvme0n1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      }
+    ],
+    errMsg: 'success'
+  }
+})
+export default Mock

--- a/dashboard/src/main/webapp/src/mock/shuffleserverpage.js
+++ b/dashboard/src/main/webapp/src/mock/shuffleserverpage.js
@@ -15,18 +15,20 @@
  * limitations under the License.
  */
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
-import ElementPlus from 'element-plus'
-import * as ElementPlusIconsVue from '@element-plus/icons-vue'
-import 'element-plus/dist/index.css'
-import router from '@/router'
-// import '@/mock'  // With this annotation turned on, you can use the front-end mock data without requesting a background interface.
+import Mock from 'mockjs'
 
-const app = createApp(App)
-const pinia = createPinia()
-Object.keys(ElementPlusIconsVue).forEach((key) => {
-  app.component(key, ElementPlusIconsVue[key])
+Mock.mock(/\/server\/nodes\/summary/, 'get', function (options) {
+  return {
+    code: 0,
+    data: {
+      ACTIVE: 5,
+      DECOMMISSIONED: 1,
+      DECOMMISSIONING: 1,
+      EXCLUDED: 19,
+      LOST: 12,
+      UNHEALTHY: 10
+    },
+    errMsg: 'success'
+  }
 })
-app.use(router).use(pinia).use(ElementPlus).mount('#app')
+export default Mock

--- a/docs/dashboard_guide.md
+++ b/docs/dashboard_guide.md
@@ -48,3 +48,11 @@ sh start-dashboard.sh
 ## Close dashboard
 sh stop-dashboard.sh
 ```
+
+### Dashboard front-end development
+
+In the main.js file, open the import '@/mock' comment and you can use the front-end mock data for interface development.
+
+```js
+import '@/mock' 
+```


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the Dashboard front-end development needs to show some effects, it is necessary to start the backend to provide the corresponding interface to see the effect. After the mock data is added, you can see the page effect by intercepting the network request and directly using the mock data of the front-end.

### Why are the changes needed?

Fix: #1401 

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Develop UT.
