### PR TITLE
[MINOR] fix(spark-common) Fix typo of ShuffleManagerGrpcService#shuffleWrtieStatus and ShuffleBufferWithXXX

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -47,7 +47,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleManagerGrpcService.class);
   private final Map<Integer, RssShuffleStatus> shuffleStatus = JavaUtils.newConcurrentMap();
   // The shuffleId mapping records the number of ShuffleServer write failures
-  private final Map<Integer, ShuffleServerFailureRecord> shuffleWrtieStatus =
+  private final Map<Integer, ShuffleServerFailureRecord> shuffleWriteStatus =
       JavaUtils.newConcurrentMap();
   private final RssShuffleManagerInterface shuffleManager;
 
@@ -83,7 +83,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
             shuffleServerInfoIntegerMap.put(shuffleServerInfo.getId(), new AtomicInteger(0));
           });
       ShuffleServerFailureRecord shuffleServerFailureRecord =
-          shuffleWrtieStatus.computeIfAbsent(
+          shuffleWriteStatus.computeIfAbsent(
               shuffleId,
               key ->
                   new ShuffleServerFailureRecord(shuffleServerInfoIntegerMap, stageAttemptNumber));

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -49,17 +49,17 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
 
   @Override
   public long append(ShufflePartitionedData data) {
-    long mSize = 0;
+    long size = 0;
 
     synchronized (this) {
       for (ShufflePartitionedBlock block : data.getBlockList()) {
         blocks.add(block);
-        mSize += block.getSize();
+        size += block.getSize();
       }
-      size += mSize;
+      this.size += size;
     }
 
-    return mSize;
+    return size;
   }
 
   @Override

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -58,18 +58,18 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
 
   @Override
   public long append(ShufflePartitionedData data) {
-    long mSize = 0;
+    long size = 0;
 
     synchronized (this) {
       for (ShufflePartitionedBlock block : data.getBlockList()) {
         blocksMap.put(block.getBlockId(), block);
         blockCount++;
-        mSize += block.getSize();
+        size += block.getSize();
       }
-      size += mSize;
+      this.size += size;
     }
 
-    return mSize;
+    return size;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix typo of ShuffleManagerGrpcService#shuffleWrtieStatus

### Why are the changes needed?

Fix typo.

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including

No.

### How was this patch tested?

No need.
