### PR TITLE
[#1977][FOLLOWUP] fix(coordinator): When resolving merge conflicts, some changes were reverted

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/ServerNode.java
@@ -312,7 +312,7 @@ public class ServerNode implements Comparable<ServerNode> {
         + "], version["
         + version
         + "], gitCommitId["
-        + storageInfo.size()
+        + gitCommitId
         + "]";
   }
 
@@ -366,6 +366,10 @@ public class ServerNode implements Comparable<ServerNode> {
 
   public long getStartTimeMs() {
     return startTimeMs;
+  }
+
+  public String getVersion() {
+    return version;
   }
 
   public String getGitCommitId() {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/CoordinatorGrpcClient.java
@@ -48,6 +48,7 @@ import org.apache.uniffle.client.response.RssFetchRemoteStorageResponse;
 import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
 import org.apache.uniffle.client.response.RssSendHeartBeatResponse;
 import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.ProjectConstants;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ServerStatus;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -146,6 +147,8 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
             .setStatusValue(serverStatus.ordinal())
             .putAllStorageInfo(StorageInfoUtils.toProto(storageInfo))
             .setStartTimeMs(startTimeMs)
+            .setVersion(ProjectConstants.VERSION)
+            .setGitCommitId(ProjectConstants.getGitCommitId())
             .build();
 
     RssProtos.StatusCode status;
@@ -265,6 +268,8 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
         ApplicationInfoRequest.newBuilder()
             .setAppId(request.getAppId())
             .setUser(request.getUser())
+            .setVersion(ProjectConstants.VERSION)
+            .setGitCommitId(ProjectConstants.getGitCommitId())
             .build();
     ApplicationInfoResponse rpcResponse =
         blockingStub


### PR DESCRIPTION
What changes were proposed in this pull request?
Display version and git commit id in dashboard

Why are the changes needed?
The version and git commit id can be used to easily locate whether the component has been upgraded and troubleshoot problems.

Does this PR introduce any user-facing change?
User can view version and git commit id from dashboard

How was this patch tested?
Use the latest version, open the dashboard ui, and you can see the version and git commit id on the Coordinator and Shuffle server pages.
Submit a task, and you can see the version and git commit id of each application task in the Apps module on the Application page. 

Issue: #1977 
Prev PR: #1964 