### PR TITLE
[MINOR] improve(server): Add return value to server rpc audit log

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/audit/CoordinatorRPCAuditContext.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/audit/CoordinatorRPCAuditContext.java
@@ -48,7 +48,7 @@ public class CoordinatorRPCAuditContext implements AuditContext {
    * @param command the command associated with shuffle server rpc
    * @return this {@link AuditContext} instance
    */
-  public CoordinatorRPCAuditContext setCommand(String command) {
+  public CoordinatorRPCAuditContext withCommand(String command) {
     this.command = command;
     return this;
   }
@@ -60,7 +60,7 @@ public class CoordinatorRPCAuditContext implements AuditContext {
    *     compute operation mExecutionTime
    * @return this {@link AuditContext} instance
    */
-  public CoordinatorRPCAuditContext setCreationTimeNs(long creationTimeNs) {
+  public CoordinatorRPCAuditContext withCreationTimeNs(long creationTimeNs) {
     this.creationTimeNs = creationTimeNs;
     return this;
   }
@@ -71,7 +71,7 @@ public class CoordinatorRPCAuditContext implements AuditContext {
    * @param statusCode the status code
    * @return this {@link AuditContext} instance
    */
-  public CoordinatorRPCAuditContext setStatusCode(StatusCode statusCode) {
+  public CoordinatorRPCAuditContext withStatusCode(StatusCode statusCode) {
     if (statusCode == null) {
       this.statusCode = "UNKNOWN";
     } else {
@@ -86,7 +86,7 @@ public class CoordinatorRPCAuditContext implements AuditContext {
    * @param statusCode the status code
    * @return this {@link AuditContext} instance
    */
-  public CoordinatorRPCAuditContext setStatusCode(
+  public CoordinatorRPCAuditContext withStatusCode(
       org.apache.uniffle.proto.RssProtos.StatusCode statusCode) {
     if (statusCode == null) {
       this.statusCode = "UNKNOWN";
@@ -102,7 +102,7 @@ public class CoordinatorRPCAuditContext implements AuditContext {
    * @param statusCode the status code
    * @return this {@link AuditContext} instance
    */
-  public CoordinatorRPCAuditContext setStatusCode(String statusCode) {
+  public CoordinatorRPCAuditContext withStatusCode(String statusCode) {
     this.statusCode = statusCode;
     return this;
   }
@@ -128,17 +128,17 @@ public class CoordinatorRPCAuditContext implements AuditContext {
     return line;
   }
 
-  public CoordinatorRPCAuditContext setAppId(String appId) {
+  public CoordinatorRPCAuditContext withAppId(String appId) {
     this.appId = appId;
     return this;
   }
 
-  public CoordinatorRPCAuditContext setShuffleId(int shuffleId) {
+  public CoordinatorRPCAuditContext withShuffleId(int shuffleId) {
     this.shuffleId = shuffleId;
     return this;
   }
 
-  public CoordinatorRPCAuditContext setArgs(String args) {
+  public CoordinatorRPCAuditContext withArgs(String args) {
     this.args = args;
     return this;
   }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -521,6 +521,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         }
         commitCount =
             shuffleServer.getShuffleTaskManager().updateAndGetCommitCount(appId, shuffleId);
+        auditContext.setReturnValue("commitCount=" + commitCount);
         if (LOG.isDebugEnabled()) {
           LOG.debug(
               "Get commitShuffleTask request for appId["
@@ -649,6 +650,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         ShuffleServerMetrics.counterTotalRequireBufferFailed.inc();
       }
       auditContext.setStatusCode(status);
+      auditContext.setReturnValue("requireBufferId=" + requireBufferId);
       RequireBufferResponse response =
           RequireBufferResponse.newBuilder()
               .setStatus(status.toProto())
@@ -1056,6 +1058,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .build();
       }
       auditContext.setStatusCode(status);
+      auditContext.setReturnValue("len=" + (sdr == null ? 0 : sdr.getDataLength()));
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
@@ -1144,6 +1147,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
           builder.setIndexData(UnsafeByteOperations.unsafeWrap(data));
           builder.setDataFileLen(shuffleIndexResult.getDataFileLen());
+          auditContext.setReturnValue("len=" + shuffleIndexResult.getDataFileLen());
           reply = builder.build();
         } catch (FileNotFoundException indexFileNotFoundException) {
           LOG.warn(
@@ -1268,6 +1272,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               costTime,
               data.length,
               requestInfo);
+          auditContext.setReturnValue(
+              "len=" + data.length + ", bufferSegmentSize=" + bufferSegments.size());
           reply =
               GetMemoryShuffleDataResponse.newBuilder()
                   .setStatus(status.toProto())

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -115,10 +115,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       StreamObserver<RssProtos.ShuffleUnregisterByAppIdResponse> responseStreamObserver) {
     try (ServerRPCAuditContext auditContext = createAuditContext("unregisterShuffleByAppId")) {
       String appId = request.getAppId();
-      auditContext.setAppId(appId);
+      auditContext.withAppId(appId);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         RssProtos.ShuffleUnregisterByAppIdResponse reply =
             RssProtos.ShuffleUnregisterByAppIdResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -136,7 +136,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         status = StatusCode.INTERNAL_ERROR;
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       RssProtos.ShuffleUnregisterByAppIdResponse reply =
           RssProtos.ShuffleUnregisterByAppIdResponse.newBuilder()
               .setStatus(status.toProto())
@@ -154,10 +154,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     try (ServerRPCAuditContext auditContext = createAuditContext("unregisterShuffle")) {
       String appId = request.getAppId();
       int shuffleId = request.getShuffleId();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         RssProtos.ShuffleUnregisterResponse reply =
             RssProtos.ShuffleUnregisterResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -174,7 +174,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         status = StatusCode.INTERNAL_ERROR;
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       RssProtos.ShuffleUnregisterResponse reply =
           RssProtos.ShuffleUnregisterResponse.newBuilder()
               .setStatus(status.toProto())
@@ -195,8 +195,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       String remoteStoragePath = req.getRemoteStorage().getPath();
       String user = req.getUser();
       int stageAttemptNumber = req.getStageAttemptNumber();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "remoteStoragePath="
               + remoteStoragePath
               + ", user="
@@ -228,7 +228,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   shuffleId,
                   e);
               StatusCode code = StatusCode.INTERNAL_ERROR;
-              auditContext.setStatusCode(code);
+              auditContext.withStatusCode(code);
               reply = ShuffleRegisterResponse.newBuilder().setStatus(code.toProto()).build();
               responseObserver.onNext(reply);
               responseObserver.onCompleted();
@@ -238,7 +238,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
             // When a Stage retry occurs, the first or last registration of a Stage may need to be
             // ignored and the ignored status quickly returned.
             StatusCode code = StatusCode.STAGE_RETRY_IGNORE;
-            auditContext.setStatusCode(code);
+            auditContext.withStatusCode(code);
             reply = ShuffleRegisterResponse.newBuilder().setStatus(code.toProto()).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -284,7 +284,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   user,
                   shuffleDataDistributionType,
                   maxConcurrencyPerPartitionToWrite);
-      auditContext.setStatusCode(result);
+      auditContext.withStatusCode(result);
       reply = ShuffleRegisterResponse.newBuilder().setStatus(result.toProto()).build();
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
@@ -302,8 +302,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       long timestamp = req.getTimestamp();
       int stageAttemptNumber = req.getStageAttemptNumber();
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "requireBufferId="
               + requireBufferId
               + ", timestamp="
@@ -330,7 +330,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .setStatus(StatusCode.APP_NOT_FOUND.toProto())
                 .setRetMsg(errorMsg)
                 .build();
-        auditContext.setStatusCode(StatusCode.fromProto(reply.getStatus()));
+        auditContext.withStatusCode(StatusCode.fromProto(reply.getStatus()));
         responseObserver.onNext(reply);
         responseObserver.onCompleted();
         return;
@@ -345,7 +345,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .setStatus(StatusCode.STAGE_RETRY_IGNORE.toProto())
                 .setRetMsg(responseMessage)
                 .build();
-        auditContext.setStatusCode(StatusCode.fromProto(reply.getStatus()));
+        auditContext.withStatusCode(StatusCode.fromProto(reply.getStatus()));
         responseObserver.onNext(reply);
         responseObserver.onCompleted();
         return;
@@ -391,7 +391,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   .setStatus(StatusCode.INTERNAL_ERROR.toProto())
                   .setRetMsg(responseMessage)
                   .build();
-          auditContext.setStatusCode(StatusCode.fromProto(reply.getStatus()));
+          auditContext.withStatusCode(StatusCode.fromProto(reply.getStatus()));
           responseObserver.onNext(reply);
           responseObserver.onCompleted();
           return;
@@ -487,7 +487,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .build();
       }
 
-      auditContext.setStatusCode(StatusCode.fromProto(reply.getStatus()));
+      auditContext.withStatusCode(StatusCode.fromProto(reply.getStatus()));
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
@@ -499,10 +499,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     try (ServerRPCAuditContext auditContext = createAuditContext("commitShuffleTask")) {
       String appId = req.getAppId();
       int shuffleId = req.getShuffleId();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         ShuffleCommitResponse response =
             ShuffleCommitResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -521,7 +521,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         }
         commitCount =
             shuffleServer.getShuffleTaskManager().updateAndGetCommitCount(appId, shuffleId);
-        auditContext.setReturnValue("commitCount=" + commitCount);
+        auditContext.withReturnValue("commitCount=" + commitCount);
         if (LOG.isDebugEnabled()) {
           LOG.debug(
               "Get commitShuffleTask request for appId["
@@ -538,7 +538,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         LOG.error(msg, e);
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       ShuffleCommitResponse reply =
           ShuffleCommitResponse.newBuilder()
               .setCommitCount(commitCount)
@@ -556,10 +556,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     try (ServerRPCAuditContext auditContext = createAuditContext("finishShuffle")) {
       String appId = req.getAppId();
       int shuffleId = req.getShuffleId();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         FinishShuffleResponse response =
             FinishShuffleResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -590,7 +590,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         LOG.error(errorMsg, e);
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       FinishShuffleResponse response =
           FinishShuffleResponse.newBuilder().setStatus(status.toProto()).setRetMsg(msg).build();
       responseObserver.onNext(response);
@@ -603,15 +603,15 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       RequireBufferRequest request, StreamObserver<RequireBufferResponse> responseObserver) {
     try (ServerRPCAuditContext auditContext = createAuditContext("requireBuffer")) {
       String appId = request.getAppId();
-      auditContext.setAppId(appId).setShuffleId(request.getShuffleId());
+      auditContext.withAppId(appId).withShuffleId(request.getShuffleId());
       String auditArgs = "requireSize=" + request.getRequireSize();
       if (request.getPartitionIdsList() != null) {
         auditArgs += ", partitionIdsSize=" + request.getPartitionIdsList().size();
       }
-      auditContext.setArgs(auditArgs);
+      auditContext.withArgs(auditArgs);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         RequireBufferResponse response =
             RequireBufferResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -649,8 +649,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         status = StatusCode.NO_REGISTER;
         ShuffleServerMetrics.counterTotalRequireBufferFailed.inc();
       }
-      auditContext.setStatusCode(status);
-      auditContext.setReturnValue("requireBufferId=" + requireBufferId);
+      auditContext.withStatusCode(status);
+      auditContext.withReturnValue("requireBufferId=" + requireBufferId);
       RequireBufferResponse response =
           RequireBufferResponse.newBuilder()
               .setStatus(status.toProto())
@@ -666,10 +666,10 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       AppHeartBeatRequest request, StreamObserver<AppHeartBeatResponse> responseObserver) {
     try (ServerRPCAuditContext auditContext = createAuditContext("appHeartbeat")) {
       String appId = request.getAppId();
-      auditContext.setAppId(appId);
+      auditContext.withAppId(appId);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         AppHeartBeatResponse response =
             AppHeartBeatResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -681,7 +681,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       }
 
       if (Context.current().isCancelled()) {
-        auditContext.setStatusCode("CANCELLED");
+        auditContext.withStatusCode("CANCELLED");
         responseObserver.onError(
             Status.CANCELLED.withDescription("Cancelled by client").asRuntimeException());
         LOG.warn("Cancelled by client {} for after deadline.", appId);
@@ -689,7 +689,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       }
 
       LOG.info("Get heartbeat from {}", appId);
-      auditContext.setStatusCode(StatusCode.SUCCESS);
+      auditContext.withStatusCode(StatusCode.SUCCESS);
       shuffleServer.getShuffleTaskManager().refreshAppId(appId);
       AppHeartBeatResponse response =
           AppHeartBeatResponse.newBuilder()
@@ -713,8 +713,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       Map<Integer, long[]> partitionToBlockIds =
           toPartitionBlocksMap(request.getPartitionToBlockIdsList());
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "taskAttemptId="
               + taskAttemptId
               + ", bitmapNum="
@@ -724,7 +724,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         ReportShuffleResultResponse response =
             ReportShuffleResultResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -771,7 +771,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         LOG.error("Error happened when report shuffle result for " + requestInfo, e);
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       reply =
           ReportShuffleResultResponse.newBuilder()
               .setStatus(status.toProto())
@@ -795,12 +795,12 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               request.getBlockIdLayout().getPartitionIdBits(),
               request.getBlockIdLayout().getTaskAttemptIdBits());
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs("partitionId=" + partitionId + ", blockIdLayout=" + blockIdLayout);
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs("partitionId=" + partitionId + ", blockIdLayout=" + blockIdLayout);
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetShuffleResultResponse response =
             GetShuffleResultResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -836,7 +836,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         LOG.error("Error happened when get shuffle result for {}", requestInfo, e);
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       reply =
           GetShuffleResultResponse.newBuilder()
               .setStatus(status.toProto())
@@ -863,13 +863,13 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               request.getBlockIdLayout().getPartitionIdBits(),
               request.getBlockIdLayout().getTaskAttemptIdBits());
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "partitionsListSize=" + partitionsList.size() + ", blockIdLayout=" + blockIdLayout);
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetShuffleResultForMultiPartResponse response =
             GetShuffleResultForMultiPartResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -906,7 +906,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         LOG.error("Error happened when get shuffle result for {}", requestInfo, e);
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       reply =
           GetShuffleResultForMultiPartResponse.newBuilder()
               .setStatus(status.toProto())
@@ -931,8 +931,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       long offset = request.getOffset();
       int length = request.getLength();
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "partitionId="
               + partitionId
               + ", partitionNumPerRange="
@@ -946,7 +946,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetLocalShuffleDataResponse response =
             GetLocalShuffleDataResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -1057,8 +1057,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .setRetMsg(msg)
                 .build();
       }
-      auditContext.setStatusCode(status);
-      auditContext.setReturnValue("len=" + (sdr == null ? 0 : sdr.getDataLength()));
+      auditContext.withStatusCode(status);
+      auditContext.withReturnValue("len=" + (sdr == null ? 0 : sdr.getDataLength()));
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
@@ -1074,8 +1074,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       int partitionId = request.getPartitionId();
       int partitionNumPerRange = request.getPartitionNumPerRange();
       int partitionNum = request.getPartitionNum();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "partitionId="
               + partitionId
               + ", partitionNumPerRange="
@@ -1085,7 +1085,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetLocalShuffleIndexResponse reply =
             GetLocalShuffleIndexResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -1147,7 +1147,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
           builder.setIndexData(UnsafeByteOperations.unsafeWrap(data));
           builder.setDataFileLen(shuffleIndexResult.getDataFileLen());
-          auditContext.setReturnValue("len=" + shuffleIndexResult.getDataFileLen());
+          auditContext.withReturnValue("len=" + shuffleIndexResult.getDataFileLen());
           reply = builder.build();
         } catch (FileNotFoundException indexFileNotFoundException) {
           LOG.warn(
@@ -1182,7 +1182,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .setRetMsg(msg)
                 .build();
       }
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
@@ -1199,8 +1199,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       long blockId = request.getLastBlockId();
       int readBufferSize = request.getReadBufferSize();
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "partitionId="
               + partitionId
               + ", blockId="
@@ -1210,7 +1210,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetMemoryShuffleDataResponse reply =
             GetMemoryShuffleDataResponse.newBuilder()
                 .setStatus(status.toProto())
@@ -1272,7 +1272,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               costTime,
               data.length,
               requestInfo);
-          auditContext.setReturnValue(
+          auditContext.withReturnValue(
               "len=" + data.length + ", bufferSegmentSize=" + bufferSegments.size());
           reply =
               GetMemoryShuffleDataResponse.newBuilder()
@@ -1317,7 +1317,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                 .build();
       }
 
-      auditContext.setStatusCode(status);
+      auditContext.withStatusCode(status);
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
@@ -1421,7 +1421,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
     }
     ServerRPCAuditContext auditContext = new ServerRPCAuditContext(auditLogger);
     if (auditLogger != null) {
-      auditContext.setCommand(command).setCreationTimeNs(System.nanoTime());
+      auditContext.withCommand(command).withCreationTimeNs(System.nanoTime());
     }
     return auditContext;
   }

--- a/server/src/main/java/org/apache/uniffle/server/audit/ServerRPCAuditContext.java
+++ b/server/src/main/java/org/apache/uniffle/server/audit/ServerRPCAuditContext.java
@@ -32,6 +32,7 @@ public class ServerRPCAuditContext implements AuditContext {
   private String appId = "N/A";
   private int shuffleId = -1;
   private String args;
+  private String returnValue;
 
   /**
    * Constructor of {@link ServerRPCAuditContext}.
@@ -100,10 +101,13 @@ public class ServerRPCAuditContext implements AuditContext {
   public String toString() {
     String line =
         String.format(
-            "cmd=%s\tstatusCode=%s\tappId=%s\tshuffleId=%s\texecutionTimeUs=%d\t",
+            "cmd=%s\tstatusCode=%s\tappId=%s\tshuffleId=%s\texecutionTimeUs=%d",
             command, statusCode, appId, shuffleId, executionTimeNs / 1000);
     if (args != null) {
-      line += String.format("args{%s}", args);
+      line += String.format("\targs{%s}", args);
+    }
+    if (returnValue != null) {
+      line += String.format("\treturn{%s}", returnValue);
     }
     return line;
   }
@@ -120,6 +124,11 @@ public class ServerRPCAuditContext implements AuditContext {
 
   public ServerRPCAuditContext setArgs(String args) {
     this.args = args;
+    return this;
+  }
+
+  public ServerRPCAuditContext setReturnValue(String returnValue) {
+    this.returnValue = returnValue;
     return this;
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/audit/ServerRPCAuditContext.java
+++ b/server/src/main/java/org/apache/uniffle/server/audit/ServerRPCAuditContext.java
@@ -49,7 +49,7 @@ public class ServerRPCAuditContext implements AuditContext {
    * @param command the command associated with shuffle server rpc
    * @return this {@link AuditContext} instance
    */
-  public ServerRPCAuditContext setCommand(String command) {
+  public ServerRPCAuditContext withCommand(String command) {
     this.command = command;
     return this;
   }
@@ -61,7 +61,7 @@ public class ServerRPCAuditContext implements AuditContext {
    *     compute operation mExecutionTime
    * @return this {@link AuditContext} instance
    */
-  public ServerRPCAuditContext setCreationTimeNs(long creationTimeNs) {
+  public ServerRPCAuditContext withCreationTimeNs(long creationTimeNs) {
     this.creationTimeNs = creationTimeNs;
     return this;
   }
@@ -72,7 +72,7 @@ public class ServerRPCAuditContext implements AuditContext {
    * @param statusCode the status code
    * @return this {@link AuditContext} instance
    */
-  public ServerRPCAuditContext setStatusCode(StatusCode statusCode) {
+  public ServerRPCAuditContext withStatusCode(StatusCode statusCode) {
     this.statusCode = statusCode.name();
     return this;
   }
@@ -83,7 +83,7 @@ public class ServerRPCAuditContext implements AuditContext {
    * @param statusCode the status code
    * @return this {@link AuditContext} instance
    */
-  public ServerRPCAuditContext setStatusCode(String statusCode) {
+  public ServerRPCAuditContext withStatusCode(String statusCode) {
     this.statusCode = statusCode;
     return this;
   }
@@ -112,22 +112,22 @@ public class ServerRPCAuditContext implements AuditContext {
     return line;
   }
 
-  public ServerRPCAuditContext setAppId(String appId) {
+  public ServerRPCAuditContext withAppId(String appId) {
     this.appId = appId;
     return this;
   }
 
-  public ServerRPCAuditContext setShuffleId(int shuffleId) {
+  public ServerRPCAuditContext withShuffleId(int shuffleId) {
     this.shuffleId = shuffleId;
     return this;
   }
 
-  public ServerRPCAuditContext setArgs(String args) {
+  public ServerRPCAuditContext withArgs(String args) {
     this.args = args;
     return this;
   }
 
-  public ServerRPCAuditContext setReturnValue(String returnValue) {
+  public ServerRPCAuditContext withReturnValue(String returnValue) {
     this.returnValue = returnValue;
     return this;
   }

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -128,8 +128,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
 
       boolean isPreAllocated = info != null;
 
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "requireBufferId="
               + requireBufferId
               + ", requireSize="
@@ -167,7 +167,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             shuffleBufferManager,
             info,
             isPreAllocated);
-        auditContext.setStatusCode(rpcResponse.getStatusCode());
+        auditContext.withStatusCode(rpcResponse.getStatusCode());
         client.getChannel().writeAndFlush(rpcResponse);
         return;
       }
@@ -197,7 +197,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             shuffleBufferManager,
             info,
             isPreAllocated);
-        auditContext.setStatusCode(rpcResponse.getStatusCode());
+        auditContext.withStatusCode(rpcResponse.getStatusCode());
         client.getChannel().writeAndFlush(rpcResponse);
         return;
       }
@@ -240,7 +240,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                   + " in ShuffleServer's configuration";
           LOG.warn(errorMsg);
           rpcResponse = new RpcResponse(req.getRequestId(), StatusCode.INTERNAL_ERROR, errorMsg);
-          auditContext.setStatusCode(rpcResponse.getStatusCode());
+          auditContext.withStatusCode(rpcResponse.getStatusCode());
           client.getChannel().writeAndFlush(rpcResponse);
           return;
         }
@@ -329,7 +329,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
         rpcResponse =
             new RpcResponse(req.getRequestId(), StatusCode.INTERNAL_ERROR, "No data in request");
       }
-      auditContext.setStatusCode(rpcResponse.getStatusCode());
+      auditContext.withStatusCode(rpcResponse.getStatusCode());
       client.getChannel().writeAndFlush(rpcResponse);
     }
   }
@@ -369,8 +369,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       int partitionId = req.getPartitionId();
       long blockId = req.getLastBlockId();
       int readBufferSize = req.getReadBufferSize();
-      auditContext.setAppId(appId).setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId).withShuffleId(shuffleId);
+      auditContext.withArgs(
           "requestId="
               + req.getRequestId()
               + ", partitionId="
@@ -381,7 +381,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
               + readBufferSize);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetMemoryShuffleDataResponse response =
             new GetMemoryShuffleDataResponse(
                 req.getRequestId(),
@@ -432,8 +432,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             ShuffleServerMetrics.gaugeReadMemoryDataThreadNum.inc();
             ShuffleServerMetrics.gaugeReadMemoryDataBufferSize.inc(readBufferSize);
           }
-          auditContext.setStatusCode(status);
-          auditContext.setReturnValue(
+          auditContext.withStatusCode(status);
+          auditContext.withReturnValue(
               "len=" + data.size() + ", bufferSegments=" + bufferSegments.size());
           response =
               new GetMemoryShuffleDataResponse(
@@ -467,7 +467,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             new GetMemoryShuffleDataResponse(
                 req.getRequestId(), status, msg, Lists.newArrayList(), Unpooled.EMPTY_BUFFER);
       }
-      auditContext.setStatusCode(response.getStatusCode());
+      auditContext.withStatusCode(response.getStatusCode());
       client.getChannel().writeAndFlush(response);
     }
   }
@@ -482,9 +482,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       int partitionNum = req.getPartitionNum();
       String requestInfo =
           "appId[" + appId + "], shuffleId[" + shuffleId + "], partitionId[" + partitionId + "]";
-      auditContext.setAppId(appId);
-      auditContext.setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId);
+      auditContext.withShuffleId(shuffleId);
+      auditContext.withArgs(
           "requestId="
               + req.getRequestId()
               + ", partitionId="
@@ -495,7 +495,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
               + partitionNum);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         GetLocalShuffleIndexResponse response =
             new GetLocalShuffleIndexResponse(
                 req.getRequestId(), status, status.toString(), Unpooled.EMPTY_BUFFER, 0L);
@@ -536,8 +536,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
           ShuffleServerMetrics.counterTotalReadLocalIndexFileSize.inc(data.size());
           ShuffleServerMetrics.gaugeReadLocalIndexFileThreadNum.inc();
           ShuffleServerMetrics.gaugeReadLocalIndexFileBufferSize.inc(assumedFileSize);
-          auditContext.setStatusCode(status);
-          auditContext.setReturnValue("len=" + data.size());
+          auditContext.withStatusCode(status);
+          auditContext.withReturnValue("len=" + data.size());
           response =
               new GetLocalShuffleIndexResponse(
                   req.getRequestId(), status, msg, data, shuffleIndexResult.getDataFileLen());
@@ -578,7 +578,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             new GetLocalShuffleIndexResponse(
                 req.getRequestId(), status, msg, Unpooled.EMPTY_BUFFER, 0L);
       }
-      auditContext.setStatusCode(response.getStatusCode());
+      auditContext.withStatusCode(response.getStatusCode());
       client.getChannel().writeAndFlush(response);
     }
   }
@@ -593,9 +593,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       int partitionNum = req.getPartitionNum();
       long offset = req.getOffset();
       int length = req.getLength();
-      auditContext.setAppId(appId);
-      auditContext.setShuffleId(shuffleId);
-      auditContext.setArgs(
+      auditContext.withAppId(appId);
+      auditContext.withShuffleId(shuffleId);
+      auditContext.withArgs(
           "requestId="
               + req.getRequestId()
               + ", partitionId="
@@ -610,7 +610,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
               + length);
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
-        auditContext.setStatusCode(status);
+        auditContext.withStatusCode(status);
         response =
             new GetLocalShuffleDataResponse(
                 req.getRequestId(),
@@ -682,8 +682,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
               new ReleaseMemoryAndRecordReadTimeListener(
                   start, length, sdr.getDataLength(), requestInfo, req, response, client);
           client.getChannel().writeAndFlush(response).addListener(listener);
-          auditContext.setStatusCode(response.getStatusCode());
-          auditContext.setReturnValue("len=" + sdr.getDataLength());
+          auditContext.withStatusCode(response.getStatusCode());
+          auditContext.withReturnValue("len=" + sdr.getDataLength());
           return;
         } catch (Exception e) {
           shuffleServer.getShuffleBufferManager().releaseReadMemory(length);
@@ -705,7 +705,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             new GetLocalShuffleDataResponse(
                 req.getRequestId(), status, msg, new NettyManagedBuffer(Unpooled.EMPTY_BUFFER));
       }
-      auditContext.setStatusCode(response.getStatusCode());
+      auditContext.withStatusCode(response.getStatusCode());
       client.getChannel().writeAndFlush(response);
     }
   }
@@ -867,7 +867,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
     }
     ServerRPCAuditContext auditContext = new ServerRPCAuditContext(auditLogger);
     if (auditLogger != null) {
-      auditContext.setCommand(command).setCreationTimeNs(System.nanoTime());
+      auditContext.withCommand(command).withCreationTimeNs(System.nanoTime());
     }
     return auditContext;
   }

--- a/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/ShuffleServerNettyHandler.java
@@ -371,7 +371,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       int readBufferSize = req.getReadBufferSize();
       auditContext.setAppId(appId).setShuffleId(shuffleId);
       auditContext.setArgs(
-          "partitionId="
+          "requestId="
+              + req.getRequestId()
+              + ", partitionId="
               + partitionId
               + ", blockId="
               + blockId
@@ -431,6 +433,8 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
             ShuffleServerMetrics.gaugeReadMemoryDataBufferSize.inc(readBufferSize);
           }
           auditContext.setStatusCode(status);
+          auditContext.setReturnValue(
+              "len=" + data.size() + ", bufferSegments=" + bufferSegments.size());
           response =
               new GetMemoryShuffleDataResponse(
                   req.getRequestId(), status, msg, bufferSegments, data);
@@ -481,7 +485,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       auditContext.setAppId(appId);
       auditContext.setShuffleId(shuffleId);
       auditContext.setArgs(
-          "partitionId="
+          "requestId="
+              + req.getRequestId()
+              + ", partitionId="
               + partitionId
               + ", partitionNumPerRange="
               + partitionNumPerRange
@@ -531,6 +537,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
           ShuffleServerMetrics.gaugeReadLocalIndexFileThreadNum.inc();
           ShuffleServerMetrics.gaugeReadLocalIndexFileBufferSize.inc(assumedFileSize);
           auditContext.setStatusCode(status);
+          auditContext.setReturnValue("len=" + data.size());
           response =
               new GetLocalShuffleIndexResponse(
                   req.getRequestId(), status, msg, data, shuffleIndexResult.getDataFileLen());
@@ -589,7 +596,9 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
       auditContext.setAppId(appId);
       auditContext.setShuffleId(shuffleId);
       auditContext.setArgs(
-          "partitionId="
+          "requestId="
+              + req.getRequestId()
+              + ", partitionId="
               + partitionId
               + ", partitionNumPerRange="
               + partitionNumPerRange
@@ -674,6 +683,7 @@ public class ShuffleServerNettyHandler implements BaseMessageHandler {
                   start, length, sdr.getDataLength(), requestInfo, req, response, client);
           client.getChannel().writeAndFlush(response).addListener(listener);
           auditContext.setStatusCode(response.getStatusCode());
+          auditContext.setReturnValue("len=" + sdr.getDataLength());
           return;
         } catch (Exception e) {
           shuffleServer.getShuffleBufferManager().releaseReadMemory(length);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add return value for server rpc audit log

### Why are the changes needed?

With the return value, we can know clear about the effect of the rpc call.

E.g. A bundle of `requireBuffer` calls appear in the rpc audit log, then followed some `sendShuffleData` rpc call with `requireBufferId`, but we don't know which `requireBuffer` call match the sendShuffleData call.

With this PR, we record the requireBufferId also which generated by `requireBuffer` call, and search the sendShuffleData call with the `requireBufferId`, this can be possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test Locally.