### PR TITLE
[MINOR] improvement(dashboard): Rename JettyServerFront to Dashboard

### DIFF
--- a/bin/start-dashboard.sh
+++ b/bin/start-dashboard.sh
@@ -31,7 +31,7 @@ JAR_DIR="${RSS_HOME}/jars"
 LOG_CONF_FILE="${RSS_CONF_DIR}/log4j2.xml"
 LOG_PATH="${RSS_LOG_DIR}/dashboard.log"
 
-MAIN_CLASS="org.apache.uniffle.dashboard.web.JettyServerFront"
+MAIN_CLASS="org.apache.uniffle.dashboard.web.Dashboard"
 
 echo "Check process existence"
 is_jvm_process_running "$JPS" $MAIN_CLASS

--- a/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
+++ b/dashboard/src/main/java/org/apache/uniffle/dashboard/web/Dashboard.java
@@ -49,9 +49,9 @@ import org.apache.uniffle.dashboard.web.config.DashboardConf;
 import org.apache.uniffle.dashboard.web.proxy.WebProxyServlet;
 import org.apache.uniffle.dashboard.web.utils.DashboardUtils;
 
-public class JettyServerFront {
+public class Dashboard {
 
-  private static final Logger LOG = LoggerFactory.getLogger(JettyServerFront.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Dashboard.class);
 
   private DashboardConf conf;
   // Jetty Server
@@ -59,7 +59,7 @@ public class JettyServerFront {
   // FrontEnd Port
   private int httpPort;
 
-  public JettyServerFront(DashboardConf coordinatorConf) {
+  public Dashboard(DashboardConf coordinatorConf) {
     this.conf = coordinatorConf;
     initialization();
   }
@@ -73,8 +73,8 @@ public class JettyServerFront {
 
     // Load configuration from config files
     final DashboardConf coodConf = new DashboardConf(configFile);
-    JettyServerFront jettyServerFront = new JettyServerFront(coodConf);
-    jettyServerFront.start();
+    Dashboard dashboard = new Dashboard(coodConf);
+    dashboard.start();
   }
 
   private void initialization() {
@@ -106,7 +106,7 @@ public class JettyServerFront {
     ResourceHandler resourceHandler = new ResourceHandler();
     resourceHandler.setDirectoriesListed(true);
     resourceHandler.setBaseResource(
-        Resource.newResource(JettyServerFront.class.getClassLoader().getResource("static")));
+        Resource.newResource(Dashboard.class.getClassLoader().getResource("static")));
     resourceHandler.setWelcomeFiles(new String[] {"index.html"});
     return resourceHandler;
   }

--- a/dev/intellij/runConfigurations/Dashboard.run.xml
+++ b/dev/intellij/runConfigurations/Dashboard.run.xml
@@ -15,9 +15,9 @@
   ~ limitations under the License.
 -->
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="JettyServerFront" type="Application" factoryName="Application" nameIsGenerated="true">
+  <configuration default="false" name="Dashboard" type="Application" factoryName="Application" nameIsGenerated="true">
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
-    <option name="MAIN_CLASS_NAME" value="org.apache.uniffle.dashboard.web.JettyServerFront" />
+    <option name="MAIN_CLASS_NAME" value="org.apache.uniffle.dashboard.web.Dashboard" />
     <module name="dashboard" />
     <option name="PROGRAM_PARAMETERS" value="--conf $PROJECT_DIR$/conf/local_dev/dashboard.conf" />
     <option name="VM_PARAMETERS" value="-Dlog4j2.configurationFile=file:$PROJECT_DIR$/conf/local_dev/log4j2.xml -Dlog.path=$PROJECT_DIR$/logs/dashboard.log" />


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the dashboard entry from `JettyServerFront` to `Dashboard`.

### Why are the changes needed?

The name `JettyServerFront` is too generic. Renaming it to `Dashboard` could improve clarity and understanding.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Start dashboard process nornally.
