### PR TITLE
[#1398] fix(mr)(tez): Make attempId computable and move it to taskAttemptId in BlockId layout. (#1418)

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -100,8 +100,8 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
     ApplicationAttemptId applicationAttemptId = RssMRUtils.getApplicationAttemptId();
     String appId = applicationAttemptId.toString();
     long taskAttemptId =
-        RssMRUtils.convertTaskAttemptIdToLong(
-            mapTask.getTaskID(), applicationAttemptId.getAttemptId());
+        RssMRUtils.createRssTaskAttemptId(
+            mapTask.getTaskID(), applicationAttemptId.getAttemptId(), mrJobConf);
     double sendThreshold =
         RssMRUtils.getDouble(
             rssJobConf,

--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -75,7 +75,7 @@ public class RssEventFetcher<K, V> {
     String errMsg = "TaskAttemptIDs are inconsistent with map tasks";
     for (TaskAttemptID taskAttemptID : successMaps) {
       if (!obsoleteMaps.contains(taskAttemptID)) {
-        long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, appAttemptId);
+        long rssTaskId = RssMRUtils.createRssTaskAttemptId(taskAttemptID, appAttemptId, jobConf);
         int mapIndex = taskAttemptID.getTaskID().getId();
         // There can be multiple successful attempts on same map task.
         // So we only need to accept one of them.

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -75,7 +75,7 @@ public class SortWriteBufferManagerTest {
     manager =
         new SortWriteBufferManager<BytesWritable, BytesWritable>(
             10240,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(BytesWritable.class),
             serializationFactory.getSerializer(BytesWritable.class),
@@ -139,7 +139,7 @@ public class SortWriteBufferManagerTest {
     manager =
         new SortWriteBufferManager<BytesWritable, BytesWritable>(
             100,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(BytesWritable.class),
             serializationFactory.getSerializer(BytesWritable.class),
@@ -191,7 +191,7 @@ public class SortWriteBufferManagerTest {
     manager =
         new SortWriteBufferManager<BytesWritable, BytesWritable>(
             10240,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(BytesWritable.class),
             serializationFactory.getSerializer(BytesWritable.class),
@@ -243,7 +243,7 @@ public class SortWriteBufferManagerTest {
     manager =
         new SortWriteBufferManager<BytesWritable, BytesWritable>(
             10240,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(BytesWritable.class),
             serializationFactory.getSerializer(BytesWritable.class),
@@ -310,7 +310,7 @@ public class SortWriteBufferManagerTest {
     manager =
         new SortWriteBufferManager<BytesWritable, BytesWritable>(
             10240,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(BytesWritable.class),
             serializationFactory.getSerializer(BytesWritable.class),
@@ -389,7 +389,7 @@ public class SortWriteBufferManagerTest {
     SortWriteBufferManager<Text, IntWritable> manager =
         new SortWriteBufferManager<Text, IntWritable>(
             10240,
-            1L,
+            1,
             10,
             keySerializer,
             valueSerializer,

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -45,20 +45,21 @@ public class RssMRUtilsTest {
     TaskAttemptID mrTaskAttemptId = new TaskAttemptID(taskId, 3);
     boolean isException = false;
     try {
-      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
+      RssMRUtils.createRssTaskAttemptId(mrTaskAttemptId, 1, 4);
     } catch (RssException e) {
       isException = true;
     }
     assertTrue(isException);
-    taskAttemptId = (1 << 20) + 0x123;
-    mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId, 1);
-    long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
+    taskAttemptId = (0x123 << 3) + 1;
+    mrTaskAttemptId =
+        RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId, 1, 4);
+    int testId = RssMRUtils.createRssTaskAttemptId(mrTaskAttemptId, 1, 4);
     assertEquals(taskAttemptId, testId);
-    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int) (1 << 21));
+    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, 1 << 21);
     mrTaskAttemptId = new TaskAttemptID(taskID, 2);
     isException = false;
     try {
-      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
+      RssMRUtils.createRssTaskAttemptId(mrTaskAttemptId, 1, 4);
     } catch (RssException e) {
       isException = true;
     }
@@ -70,7 +71,7 @@ public class RssMRUtilsTest {
     JobID jobID = new JobID();
     TaskID taskId = new TaskID(jobID, TaskType.MAP, 233);
     TaskAttemptID taskAttemptID = new TaskAttemptID(taskId, 1);
-    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, 1);
+    long taskAttemptId = RssMRUtils.createRssTaskAttemptId(taskAttemptID, 1, 4);
     long blockId = RssMRUtils.getBlockId(1, taskAttemptId, 0);
     long newTaskAttemptId = RssMRUtils.getTaskAttemptId(blockId);
     assertEquals(taskAttemptId, newTaskAttemptId);
@@ -85,7 +86,7 @@ public class RssMRUtilsTest {
     JobID jobID = new JobID();
     TaskID taskId = new TaskID(jobID, TaskType.MAP, 233);
     TaskAttemptID taskAttemptID = new TaskAttemptID(taskId, 1);
-    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, 1);
+    long taskAttemptId = RssMRUtils.createRssTaskAttemptId(taskAttemptID, 1, 4);
     long mask = (1L << layout.partitionIdBits) - 1;
     for (int partitionId = 0; partitionId <= 3000; partitionId++) {
       for (int seqNo = 0; seqNo <= 10; seqNo++) {

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EventFetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EventFetcherTest.java
@@ -59,8 +59,8 @@ public class EventFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId =
-          RssMRUtils.convertTaskAttemptIdToLong(
-              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+          RssMRUtils.createRssTaskAttemptId(
+              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
       expected.addLong(rssTaskId);
     }
 
@@ -89,8 +89,8 @@ public class EventFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId =
-          RssMRUtils.convertTaskAttemptIdToLong(
-              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+          RssMRUtils.createRssTaskAttemptId(
+              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
       expected.addLong(rssTaskId);
     }
 
@@ -121,8 +121,8 @@ public class EventFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId =
-          RssMRUtils.convertTaskAttemptIdToLong(
-              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+          RssMRUtils.createRssTaskAttemptId(
+              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
       expected.addLong(rssTaskId);
     }
     Roaring64NavigableMap taskIdBitmap = ef.fetchAllRssTaskIds();
@@ -146,8 +146,8 @@ public class EventFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId =
-          RssMRUtils.convertTaskAttemptIdToLong(
-              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+          RssMRUtils.createRssTaskAttemptId(
+              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
       expected.addLong(rssTaskId);
     }
     IllegalStateException ex =
@@ -172,8 +172,8 @@ public class EventFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId =
-          RssMRUtils.convertTaskAttemptIdToLong(
-              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+          RssMRUtils.createRssTaskAttemptId(
+              new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
       expected.addLong(rssTaskId);
     }
     IllegalStateException ex =
@@ -205,14 +205,14 @@ public class EventFetcherTest {
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       if (!tipFailed.contains(mapIndex) && !obsoleted.contains(mapIndex)) {
         long rssTaskId =
-            RssMRUtils.convertTaskAttemptIdToLong(
-                new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
+            RssMRUtils.createRssTaskAttemptId(
+                new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1, 4);
         expected.addLong(rssTaskId);
       }
       if (obsoleted.contains(mapIndex)) {
         long rssTaskId =
-            RssMRUtils.convertTaskAttemptIdToLong(
-                new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 1), 1);
+            RssMRUtils.createRssTaskAttemptId(
+                new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 1), 1, 4);
         expected.addLong(rssTaskId);
       }
     }

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -290,7 +290,8 @@ public class FetcherTest {
             null,
             new Progress(),
             new MROutputFiles());
-    TaskAttemptID taskAttemptID = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, 1, 1);
+    TaskAttemptID taskAttemptID =
+        RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, 1, 1, 4);
     byte[] buffer = new byte[10];
     MapOutput mapOutput1 = merger.reserve(taskAttemptID, 10, 1);
     RssBypassWriter.write(mapOutput1, buffer);
@@ -349,7 +350,7 @@ public class FetcherTest {
     SortWriteBufferManager<Text, Text> manager =
         new SortWriteBufferManager(
             10240,
-            1L,
+            1,
             10,
             serializationFactory.getSerializer(Text.class),
             serializationFactory.getSerializer(Text.class),

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -45,6 +45,7 @@ import org.apache.uniffle.client.api.CoordinatorClient;
 import org.apache.uniffle.client.factory.CoordinatorClientFactory;
 import org.apache.uniffle.client.request.RssFetchClientConfRequest;
 import org.apache.uniffle.client.response.RssFetchClientConfResponse;
+import org.apache.uniffle.client.util.ClientUtils;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.config.ConfigOption;

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -112,8 +112,10 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
               + maxPartitions);
     }
 
-    int attemptIdBits = getAttemptIdBits(getMaxAttemptNo(maxFailures, speculation));
-    int partitionIdBits = 32 - Integer.numberOfLeadingZeros(maxPartitions - 1); // [1..31]
+    int attemptIdBits =
+        ClientUtils.getNumberOfSignificantBits(
+            ClientUtils.getMaxAttemptNo(maxFailures, speculation));
+    int partitionIdBits = ClientUtils.getNumberOfSignificantBits(maxPartitions - 1); // [1..31]
     int taskAttemptIdBits = partitionIdBits + attemptIdBits; // [1+attemptIdBits..31+attemptIdBits]
     int sequenceNoBits = 63 - partitionIdBits - taskAttemptIdBits; // [1-attemptIdBits..61]
 
@@ -252,23 +254,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
     }
   }
 
-  protected static int getMaxAttemptNo(int maxFailures, boolean speculation) {
-    // attempt number is zero based: 0, 1, …, maxFailures-1
-    // max maxFailures < 1 is not allowed but for safety, we interpret that as maxFailures == 1
-    int maxAttemptNo = maxFailures < 1 ? 0 : maxFailures - 1;
-
-    // with speculative execution enabled we could observe +1 attempts
-    if (speculation) {
-      maxAttemptNo++;
-    }
-
-    return maxAttemptNo;
-  }
-
-  protected static int getAttemptIdBits(int maxAttemptNo) {
-    return 32 - Integer.numberOfLeadingZeros(maxAttemptNo);
-  }
-
   /** See static overload of this method. */
   public abstract long getTaskAttemptIdForBlockId(int mapIndex, int attemptNo);
 
@@ -287,8 +272,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
    */
   protected static long getTaskAttemptIdForBlockId(
       int mapIndex, int attemptNo, int maxFailures, boolean speculation, int maxTaskAttemptIdBits) {
-    int maxAttemptNo = getMaxAttemptNo(maxFailures, speculation);
-    int attemptBits = getAttemptIdBits(maxAttemptNo);
+    int maxAttemptNo = ClientUtils.getMaxAttemptNo(maxFailures, speculation);
+    int attemptBits = ClientUtils.getNumberOfSignificantBits(maxAttemptNo);
 
     if (attemptNo > maxAttemptNo) {
       // this should never happen, if it does, our assumptions are wrong,
@@ -302,7 +287,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
               + ".");
     }
 
-    int mapIndexBits = 32 - Integer.numberOfLeadingZeros(mapIndex);
+    int mapIndexBits = ClientUtils.getNumberOfSignificantBits(mapIndex);
     if (mapIndexBits + attemptBits > maxTaskAttemptIdBits) {
       throw new RssException(
           "Observing mapIndex["

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBaseTest.java
@@ -370,46 +370,6 @@ public class RssShuffleManagerBaseTest {
     assertTrue(e.getMessage().startsWith("All block id bit config keys must be provided "));
   }
 
-  @Test
-  public void testGetMaxAttemptNo() {
-    // without speculation
-    assertEquals(0, RssShuffleManagerBase.getMaxAttemptNo(-1, false));
-    assertEquals(0, RssShuffleManagerBase.getMaxAttemptNo(0, false));
-    assertEquals(0, RssShuffleManagerBase.getMaxAttemptNo(1, false));
-    assertEquals(1, RssShuffleManagerBase.getMaxAttemptNo(2, false));
-    assertEquals(2, RssShuffleManagerBase.getMaxAttemptNo(3, false));
-    assertEquals(3, RssShuffleManagerBase.getMaxAttemptNo(4, false));
-    assertEquals(4, RssShuffleManagerBase.getMaxAttemptNo(5, false));
-    assertEquals(1023, RssShuffleManagerBase.getMaxAttemptNo(1024, false));
-
-    // with speculation
-    assertEquals(1, RssShuffleManagerBase.getMaxAttemptNo(-1, true));
-    assertEquals(1, RssShuffleManagerBase.getMaxAttemptNo(0, true));
-    assertEquals(1, RssShuffleManagerBase.getMaxAttemptNo(1, true));
-    assertEquals(2, RssShuffleManagerBase.getMaxAttemptNo(2, true));
-    assertEquals(3, RssShuffleManagerBase.getMaxAttemptNo(3, true));
-    assertEquals(4, RssShuffleManagerBase.getMaxAttemptNo(4, true));
-    assertEquals(5, RssShuffleManagerBase.getMaxAttemptNo(5, true));
-    assertEquals(1024, RssShuffleManagerBase.getMaxAttemptNo(1024, true));
-  }
-
-  @Test
-  public void testGetAttemptIdBits() {
-    assertEquals(0, RssShuffleManagerBase.getAttemptIdBits(0));
-    assertEquals(1, RssShuffleManagerBase.getAttemptIdBits(1));
-    assertEquals(2, RssShuffleManagerBase.getAttemptIdBits(2));
-    assertEquals(2, RssShuffleManagerBase.getAttemptIdBits(3));
-    assertEquals(3, RssShuffleManagerBase.getAttemptIdBits(4));
-    assertEquals(3, RssShuffleManagerBase.getAttemptIdBits(5));
-    assertEquals(3, RssShuffleManagerBase.getAttemptIdBits(6));
-    assertEquals(3, RssShuffleManagerBase.getAttemptIdBits(7));
-    assertEquals(4, RssShuffleManagerBase.getAttemptIdBits(8));
-    assertEquals(4, RssShuffleManagerBase.getAttemptIdBits(9));
-    assertEquals(10, RssShuffleManagerBase.getAttemptIdBits(1023));
-    assertEquals(11, RssShuffleManagerBase.getAttemptIdBits(1024));
-    assertEquals(11, RssShuffleManagerBase.getAttemptIdBits(1025));
-  }
-
   private long bits(String string) {
     return Long.parseLong(string.replaceAll("[|]", ""), 2);
   }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssShuffleManager.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.common.CallableWithNdc;
 import org.apache.tez.common.InputContextUtils;
+import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.TezUtilsInternal;
 import org.apache.tez.common.UmbilicalUtils;
@@ -589,6 +590,8 @@ public class RssShuffleManager extends ShuffleManager {
                     partitionToServers.get(partition),
                     partitionToServers);
 
+                int maxAttemptNo = RssTezUtils.getMaxAttemptNo(conf);
+
                 RssTezFetcherTask fetcher =
                     new RssTezFetcherTask(
                         RssShuffleManager.this,
@@ -603,7 +606,8 @@ public class RssShuffleManager extends ShuffleManager {
                         rssAllBlockIdBitmapMap,
                         rssSuccessBlockIdBitmapMap,
                         numInputs,
-                        partitionToServers.size());
+                        partitionToServers.size(),
+                        maxAttemptNo);
                 rssRunningFetchers.add(fetcher);
                 if (isShutdown.get()) {
                   LOG.info(

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/RssTezFetcherTask.java
@@ -74,6 +74,7 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
   private final int partitionNum;
   private final int shuffleId;
   private final ApplicationAttemptId applicationAttemptId;
+  private final int maxAttemptNo;
 
   public RssTezFetcherTask(
       FetcherCallback fetcherCallback,
@@ -88,7 +89,8 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
       Map<Integer, Roaring64NavigableMap> rssAllBlockIdBitmapMap,
       Map<Integer, Roaring64NavigableMap> rssSuccessBlockIdBitmapMap,
       int numPhysicalInputs,
-      int partitionNum) {
+      int partitionNum,
+      int maxAttemptNo) {
     assert (inputs != null && inputs.size() > 0);
     this.fetcherCallback = fetcherCallback;
     this.inputContext = inputContext;
@@ -131,6 +133,7 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
         conf.getInt(
             RssTezConfig.RSS_PARTITION_NUM_PER_RANGE,
             RssTezConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
+    this.maxAttemptNo = maxAttemptNo;
     LOG.info(
         "RssTezFetcherTask fetch partition:{}, with inputs:{}, readBufferSize:{}, partitionNumPerRange:{}.",
         this.partition,
@@ -159,7 +162,8 @@ public class RssTezFetcherTask extends CallableWithNdc<FetchResult> {
     // final RssEventFetcher eventFetcher = new RssEventFetcher(inputs, numPhysicalInputs);
     int appAttemptId = applicationAttemptId.getAttemptId();
     Roaring64NavigableMap taskIdBitmap =
-        RssTezUtils.fetchAllRssTaskIds(new HashSet<>(inputs), numPhysicalInputs, appAttemptId);
+        RssTezUtils.fetchAllRssTaskIds(
+            new HashSet<>(inputs), numPhysicalInputs, appAttemptId, this.maxAttemptNo);
     LOG.info(
         "Inputs:{}, num input:{}, appAttemptId:{}, taskIdBitmap:{}",
         inputs,

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/RssShuffleScheduler.java
@@ -282,6 +282,8 @@ class RssShuffleScheduler extends ShuffleScheduler {
   private RemoteStorageInfo remoteStorageInfo;
   private int indexReadLimit;
 
+  private final int maxAttemptNo;
+
   RssShuffleScheduler(
       InputContext inputContext,
       Configuration conf,
@@ -538,6 +540,7 @@ class RssShuffleScheduler extends ShuffleScheduler {
     this.basePath = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_PATH);
     String remoteStorageConf = this.conf.get(RssTezConfig.RSS_REMOTE_STORAGE_CONF);
     this.remoteStorageInfo = new RemoteStorageInfo(basePath, remoteStorageConf);
+    this.maxAttemptNo = RssTezUtils.getMaxAttemptNo(conf);
 
     LOG.info(
         "RSSShuffleScheduler running for sourceVertex: "
@@ -1832,7 +1835,8 @@ class RssShuffleScheduler extends ShuffleScheduler {
         RssTezUtils.fetchAllRssTaskIds(
             partitionIdToSuccessMapTaskAttempts.get(mapHost.getPartitionId()),
             this.numInputs,
-            appAttemptId);
+            appAttemptId,
+            maxAttemptNo);
 
     LOG.info(
         "In reduce: {}, RSS Tez client has fetched blockIds and taskIds successfully, partitionId:{}.",

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssSorter.java
@@ -61,7 +61,8 @@ public class RssSorter extends ExternalSorter {
       long initialMemoryAvailable,
       int shuffleId,
       ApplicationAttemptId applicationAttemptId,
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers)
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      long taskAttemptId)
       throws IOException {
     super(outputContext, conf, numOutputs, initialMemoryAvailable);
     this.partitionToServers = partitionToServers;
@@ -81,7 +82,6 @@ public class RssSorter extends ExternalSorter {
         conf.getDouble(
             RssTezConfig.RSS_CLIENT_SORT_MEMORY_USE_THRESHOLD,
             RssTezConfig.RSS_CLIENT_DEFAULT_SORT_MEMORY_USE_THRESHOLD);
-    long taskAttemptId = RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptID);
 
     long maxSegmentSize =
         conf.getLong(

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorter.java
@@ -60,7 +60,8 @@ public class RssUnSorter extends ExternalSorter {
       long initialMemoryAvailable,
       int shuffleId,
       ApplicationAttemptId applicationAttemptId,
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers)
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      long taskAttemptId)
       throws IOException {
     super(outputContext, conf, numOutputs, initialMemoryAvailable);
     this.partitionToServers = partitionToServers;
@@ -80,7 +81,6 @@ public class RssUnSorter extends ExternalSorter {
         conf.getDouble(
             RssTezConfig.RSS_CLIENT_SORT_MEMORY_USE_THRESHOLD,
             RssTezConfig.RSS_CLIENT_DEFAULT_SORT_MEMORY_USE_THRESHOLD);
-    long taskAttemptId = RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptID);
     long maxSegmentSize =
         conf.getLong(
             RssTezConfig.RSS_CLIENT_MAX_BUFFER_SIZE,

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssOrderedPartitionedKVOutput.java
@@ -212,6 +212,7 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
   public void start() throws Exception {
     if (!isStarted.get()) {
       memoryUpdateCallbackHandler.validateUpdateReceived();
+      long rssTaskAttemptId = RssTezUtils.createRssTaskAttemptId(taskAttemptId, conf);
       sorter =
           new RssSorter(
               taskAttemptId,
@@ -222,7 +223,8 @@ public class RssOrderedPartitionedKVOutput extends AbstractLogicalOutput {
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
               applicationAttemptId,
-              partitionToServers);
+              partitionToServers,
+              rssTaskAttemptId);
       LOG.info("Initialized RssSorter.");
       isStarted.set(true);
     }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedKVOutput.java
@@ -217,6 +217,7 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
   public void start() throws Exception {
     if (!isStarted.get()) {
       memoryUpdateCallbackHandler.validateUpdateReceived();
+      long rssTaskAttemptId = RssTezUtils.createRssTaskAttemptId(taskAttemptId, conf);
       sorter =
           new RssUnSorter(
               taskAttemptId,
@@ -227,7 +228,8 @@ public class RssUnorderedKVOutput extends AbstractLogicalOutput {
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
               applicationAttemptId,
-              partitionToServers);
+              partitionToServers,
+              rssTaskAttemptId);
       LOG.info("Initialized RssUnSorter.");
       isStarted.set(true);
     }

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/output/RssUnorderedPartitionedKVOutput.java
@@ -215,6 +215,7 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
   public void start() throws Exception {
     if (!isStarted.get()) {
       memoryUpdateCallbackHandler.validateUpdateReceived();
+      long rssTaskAttemptId = RssTezUtils.createRssTaskAttemptId(taskAttemptId, conf);
       sorter =
           new RssUnSorter(
               taskAttemptId,
@@ -225,7 +226,8 @@ public class RssUnorderedPartitionedKVOutput extends AbstractLogicalOutput {
               memoryUpdateCallbackHandler.getMemoryAssigned(),
               shuffleId,
               applicationAttemptId,
-              partitionToServers);
+              partitionToServers,
+              rssTaskAttemptId);
       LOG.info("Initialized RssUnSorter.");
       isStarted.set(true);
     }

--- a/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
+++ b/client-tez/src/test/java/org/apache/tez/common/RssTezUtilsTest.java
@@ -56,17 +56,17 @@ public class RssTezUtilsTest {
 
     boolean isException = false;
     try {
-      RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptId);
+      RssTezUtils.createRssTaskAttemptId(tezTaskAttemptId, 3);
     } catch (RssException e) {
       isException = true;
     }
     assertTrue(isException);
 
-    taskId = TezTaskID.getInstance(vId, (int) (1 << 21));
+    taskId = TezTaskID.getInstance(vId, 1 << 21);
     tezTaskAttemptId = TezTaskAttemptID.getInstance(taskId, 2);
     isException = false;
     try {
-      RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptId);
+      RssTezUtils.createRssTaskAttemptId(tezTaskAttemptId, 3);
     } catch (RssException e) {
       isException = true;
     }
@@ -80,7 +80,7 @@ public class RssTezUtilsTest {
     TezVertexID vId = TezVertexID.getInstance(dagId, 35);
     TezTaskID tId = TezTaskID.getInstance(vId, 389);
     TezTaskAttemptID tezTaskAttemptId = TezTaskAttemptID.getInstance(tId, 2);
-    long taskAttemptId = RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptId);
+    long taskAttemptId = RssTezUtils.createRssTaskAttemptId(tezTaskAttemptId, 3);
     long blockId = RssTezUtils.getBlockId(1, taskAttemptId, 0);
     long newTaskAttemptId = RssTezUtils.getTaskAttemptId(blockId);
     assertEquals(taskAttemptId, newTaskAttemptId);
@@ -97,7 +97,7 @@ public class RssTezUtilsTest {
     TezVertexID vId = TezVertexID.getInstance(dagId, 35);
     TezTaskID tId = TezTaskID.getInstance(vId, 389);
     TezTaskAttemptID tezTaskAttemptId = TezTaskAttemptID.getInstance(tId, 2);
-    long taskAttemptId = RssTezUtils.convertTaskAttemptIdToLong(tezTaskAttemptId);
+    long taskAttemptId = RssTezUtils.createRssTaskAttemptId(tezTaskAttemptId, 3);
     long mask = (1L << layout.partitionIdBits) - 1;
     for (int partitionId = 0; partitionId <= 3000; partitionId++) {
       for (int seqNo = 0; seqNo <= 10; seqNo++) {

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssSorterTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssSorterTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.runtime.api.OutputContext;
@@ -87,6 +88,7 @@ public class RssSorterTest {
 
     long initialMemoryAvailable = 10240000;
     int shuffleId = 1001;
+    long rssTaskAttemptId = RssTezUtils.createRssTaskAttemptId(tezTaskAttemptID, 3);
 
     RssSorter rssSorter =
         new RssSorter(
@@ -98,7 +100,8 @@ public class RssSorterTest {
             initialMemoryAvailable,
             shuffleId,
             applicationAttemptId,
-            partitionToServers);
+            partitionToServers,
+            rssTaskAttemptId);
 
     rssSorter.collect(new Text("0"), new Text("0"), 0);
     rssSorter.collect(new Text("0"), new Text("1"), 0);

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorterTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/impl/RssUnSorterTest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.tez.common.RssTezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.runtime.api.OutputContext;
@@ -82,6 +83,7 @@ public class RssUnSorterTest {
 
     long initialMemoryAvailable = 10240000;
     int shuffleId = 1001;
+    long rssTaskAttemptId = RssTezUtils.createRssTaskAttemptId(tezTaskAttemptID, 3);
 
     RssUnSorter rssSorter =
         new RssUnSorter(
@@ -93,7 +95,8 @@ public class RssUnSorterTest {
             initialMemoryAvailable,
             shuffleId,
             APPATTEMPT_ID,
-            partitionToServers);
+            partitionToServers,
+            rssTaskAttemptId);
 
     rssSorter.collect(new Text("0"), new Text("0"), 0);
     rssSorter.collect(new Text("0"), new Text("1"), 0);

--- a/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
+++ b/client/src/main/java/org/apache/uniffle/client/util/ClientUtils.java
@@ -112,4 +112,21 @@ public class ClientUtils {
           String.format("The value of %s should be one of %s", clientType, types));
     }
   }
+
+  public static int getMaxAttemptNo(int maxFailures, boolean speculation) {
+    // attempt number is zero based: 0, 1, …, maxFailures-1
+    // max maxFailures < 1 is not allowed but for safety, we interpret that as maxFailures == 1
+    int maxAttemptNo = maxFailures < 1 ? 0 : maxFailures - 1;
+
+    // with speculative execution enabled we could observe +1 attempts
+    if (speculation) {
+      maxAttemptNo++;
+    }
+
+    return maxAttemptNo;
+  }
+
+  public static int getNumberOfSignificantBits(int number) {
+    return 32 - Integer.numberOfLeadingZeros(number);
+  }
 }

--- a/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/ClientUtilsTest.java
@@ -36,6 +36,8 @@ import org.apache.uniffle.client.util.DefaultIdHelper;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.RssUtils;
 
+import static org.apache.uniffle.client.util.ClientUtils.getMaxAttemptNo;
+import static org.apache.uniffle.client.util.ClientUtils.getNumberOfSignificantBits;
 import static org.apache.uniffle.client.util.ClientUtils.waitUntilDoneOrFail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -133,5 +135,45 @@ public class ClientUtilsTest {
     } catch (Exception e) {
       // Ignore
     }
+  }
+
+  @Test
+  public void testGetMaxAttemptNo() {
+    // without speculation
+    assertEquals(0, getMaxAttemptNo(-1, false));
+    assertEquals(0, getMaxAttemptNo(0, false));
+    assertEquals(0, getMaxAttemptNo(1, false));
+    assertEquals(1, getMaxAttemptNo(2, false));
+    assertEquals(2, getMaxAttemptNo(3, false));
+    assertEquals(3, getMaxAttemptNo(4, false));
+    assertEquals(4, getMaxAttemptNo(5, false));
+    assertEquals(1023, getMaxAttemptNo(1024, false));
+
+    // with speculation
+    assertEquals(1, getMaxAttemptNo(-1, true));
+    assertEquals(1, getMaxAttemptNo(0, true));
+    assertEquals(1, getMaxAttemptNo(1, true));
+    assertEquals(2, getMaxAttemptNo(2, true));
+    assertEquals(3, getMaxAttemptNo(3, true));
+    assertEquals(4, getMaxAttemptNo(4, true));
+    assertEquals(5, getMaxAttemptNo(5, true));
+    assertEquals(1024, getMaxAttemptNo(1024, true));
+  }
+
+  @Test
+  public void testGetNumberOfSignificantBits() {
+    assertEquals(0, getNumberOfSignificantBits(0));
+    assertEquals(1, getNumberOfSignificantBits(1));
+    assertEquals(2, getNumberOfSignificantBits(2));
+    assertEquals(2, getNumberOfSignificantBits(3));
+    assertEquals(3, getNumberOfSignificantBits(4));
+    assertEquals(3, getNumberOfSignificantBits(5));
+    assertEquals(3, getNumberOfSignificantBits(6));
+    assertEquals(3, getNumberOfSignificantBits(7));
+    assertEquals(4, getNumberOfSignificantBits(8));
+    assertEquals(4, getNumberOfSignificantBits(9));
+    assertEquals(10, getNumberOfSignificantBits(1023));
+    assertEquals(11, getNumberOfSignificantBits(1024));
+    assertEquals(11, getNumberOfSignificantBits(1025));
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/BlockId.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/BlockId.java
@@ -32,10 +32,10 @@ public class BlockId {
   public final BlockIdLayout layout;
   public final int sequenceNo;
   public final int partitionId;
-  public final int taskAttemptId;
+  public final long taskAttemptId;
 
   protected BlockId(
-      long blockId, BlockIdLayout layout, int sequenceNo, int partitionId, int taskAttemptId) {
+      long blockId, BlockIdLayout layout, int sequenceNo, int partitionId, long taskAttemptId) {
     this.blockId = blockId;
     this.layout = layout;
     this.sequenceNo = sequenceNo;

--- a/integration-test/tez/src/test/java/org/apache/uniffle/test/TezWordCountWithFailuresTest.java
+++ b/integration-test/tez/src/test/java/org/apache/uniffle/test/TezWordCountWithFailuresTest.java
@@ -362,7 +362,7 @@ public class TezWordCountWithFailuresTest extends IntegrationTestBase {
         // verifyMode is 0: avoid recompute succeeded task is true
         Assertions.assertEquals(0, progressMap.get("Tokenizer").getKilledTaskAttemptCount());
       } else if (verifyMode == 1) {
-        // verifyMode is 1: avoid recompute succeeded task is true
+        // verifyMode is 1: avoid recompute succeeded task is false
         Assertions.assertTrue(progressMap.get("Tokenizer").getKilledTaskAttemptCount() > 0);
       }
       return 0;

--- a/server/src/test/java/org/apache/uniffle/server/buffer/BufferTestBase.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/BufferTestBase.java
@@ -50,7 +50,7 @@ public abstract class BufferTestBase {
     return createData(partitionId, 0, len);
   }
 
-  protected ShufflePartitionedData createData(int partitionId, int taskAttemptId, int len) {
+  protected ShufflePartitionedData createData(int partitionId, long taskAttemptId, int len) {
     byte[] buf = new byte[len];
     new Random().nextBytes(buf);
     ShufflePartitionedBlock block =

--- a/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/handler/impl/HadoopShuffleReadHandlerTest.java
@@ -108,7 +108,7 @@ public class HadoopShuffleReadHandlerTest extends HadoopTestBase {
     int totalBlockNum = 0;
     int expectTotalBlockNum = 6;
     int blockSize = 7;
-    int taskAttemptId = 0;
+    long taskAttemptId = 0;
 
     // write expectTotalBlockNum - 1 complete block
     HadoopShuffleHandlerTestBase.writeTestData(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Before this PR, in MR and TEZ engine:
1. attemptId is in sequenceNo of BlockId instead of taskAttemptId.
2. attempId is fixed 6 bit.

After this PR:
1. attemptId is in taskAttemptId. This is more reasonable.
2. attempId is calculated from max num of allowed failures and whether speculative execution is enabled.

### Why are the changes needed?

Fix: #1398

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT and integrated tests.