### PR TITLE
[#2030] fix(client-spark): Remove javax and logging from relocation list to solve NoClassDefFoundError

### DIFF
--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -112,6 +112,8 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>**/*.proto</exclude>
+                    <exclude>**/*.css</exclude>
+                    <exclude>**/*.html</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -156,8 +158,10 @@
                   <pattern>org.apache</pattern>
                   <shadedPattern>${rss.shade.packageName}.org.apache</shadedPattern>
                   <excludes>
+                    <!-- Exclude the provided dependencies -->
                     <!-- Exclude the packages belonging to uniffle -->
                     <exclude>org/apache/uniffle/**/*</exclude>
+                    <!-- Exclude the packages belonging to hadoop -->
                     <exclude>org/apache/hadoop/*</exclude>
                     <exclude>org/apache/hadoop/**/*</exclude>
                     <!-- Exclude the logging packages-->
@@ -166,10 +170,13 @@
                     <exclude>org/apache/commons/logging/**/*</exclude>
                     <exclude>org/apache/log4j/*</exclude>
                     <exclude>org/apache/log4j/**/*</exclude>
+                    <exclude>org/apache/logging/**/*</exclude>
                     <!-- Exclude spark packages -->
                     <exclude>org/apache/spark/**/*</exclude>
                     <!-- Exclude commons-io packages -->
                     <exclude>org/apache/commons/io/**/*</exclude>
+                    <!-- Exclude the packages belonging to collections 3 -->
+                    <exclude>org/apache/commons/collections/**/*</exclude>
                   </excludes>
                 </relocation>
                 <relocation>

--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -181,18 +181,6 @@
                   <shadedPattern>${rss.shade.packageName}.android.annotation</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>javax</pattern>
-                  <shadedPattern>${rss.shade.packageName}.javax</shadedPattern>
-                  <includes>
-                    <include>javax/annotation/**/*</include>
-                    <include>javax/activation/**/*</include>
-                    <include>javax/xml/**/*</include>
-                    <include>javax/inject/**/*</include>
-                    <include>javax/validation/**/*</include>
-                    <include>javax/servlet/**/*</include>
-                  </includes>
-                </relocation>
-                <relocation>
                   <pattern>javassist</pattern>
                   <shadedPattern>${rss.shade.packageName}.javassist</shadedPattern>
                 </relocation>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -158,8 +158,10 @@
                   <pattern>org.apache</pattern>
                   <shadedPattern>${rss.shade.packageName}.org.apache</shadedPattern>
                   <excludes>
+                    <!-- Exclude the provided dependencies -->
                     <!-- Exclude the packages belonging to uniffle -->
                     <exclude>org/apache/uniffle/**/*</exclude>
+                    <!-- Exclude the packages belonging to hadoop -->
                     <exclude>org/apache/hadoop/*</exclude>
                     <exclude>org/apache/hadoop/**/*</exclude>
                     <!-- Exclude the logging packages-->
@@ -168,10 +170,13 @@
                     <exclude>org/apache/commons/logging/**/*</exclude>
                     <exclude>org/apache/log4j/*</exclude>
                     <exclude>org/apache/log4j/**/*</exclude>
+                    <exclude>org/apache/logging/**/*</exclude>
                     <!-- Exclude spark packages -->
                     <exclude>org/apache/spark/**/*</exclude>
                     <!-- Exclude commons-io packages -->
                     <exclude>org/apache/commons/io/**/*</exclude>
+                    <!-- Exclude the packages belonging to collections 3 -->
+                    <exclude>org/apache/commons/collections/**/*</exclude>
                   </excludes>
                 </relocation>
                 <relocation>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -112,6 +112,8 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>**/*.proto</exclude>
+                    <exclude>**/*.css</exclude>
+                    <exclude>**/*.html</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -179,18 +181,6 @@
                 <relocation>
                   <pattern>android.annotation</pattern>
                   <shadedPattern>${rss.shade.packageName}.android.annotation</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>javax</pattern>
-                  <shadedPattern>${rss.shade.packageName}.javax</shadedPattern>
-                  <includes>
-                    <include>javax/annotation/**/*</include>
-                    <include>javax/activation/**/*</include>
-                    <include>javax/xml/**/*</include>
-                    <include>javax/inject/**/*</include>
-                    <include>javax/validation/**/*</include>
-                    <include>javax/servlet/**/*</include>
-                  </includes>
                 </relocation>
                 <relocation>
                   <pattern>javassist</pattern>


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Do not relocate javax to avoid NoClassDefFoundError issue.

### Why are the changes needed?


Fix: #2030

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Thanks for the verify check by @zhengchenyu . This is not reproduced on my env.
