### PR TITLE
[MINOR] feat(dashboard/coordinator): Display total app num in dashboard

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
@@ -29,7 +29,6 @@ import org.apache.hbase.thirdparty.javax.ws.rs.Path;
 import org.apache.hbase.thirdparty.javax.ws.rs.Produces;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
-import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +36,7 @@ import org.apache.uniffle.common.web.resource.BaseResource;
 import org.apache.uniffle.common.web.resource.Response;
 import org.apache.uniffle.coordinator.AppInfo;
 import org.apache.uniffle.coordinator.ApplicationManager;
+import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.apache.uniffle.coordinator.web.vo.AppInfoVO;
 import org.apache.uniffle.coordinator.web.vo.UserAppNumVO;
 
@@ -52,8 +52,7 @@ public class ApplicationResource extends BaseResource {
         () -> {
           Map<String, Integer> appTotalityMap = Maps.newHashMap();
           appTotalityMap.put("appTotality", getApplicationManager().getAppIds().size());
-          appTotalityMap.put("appCurrent",
-              (int) CoordinatorMetrics.counterTotalAppNum.get());
+          appTotalityMap.put("appCurrent", (int) CoordinatorMetrics.counterTotalAppNum.get());
           return appTotalityMap;
         });
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/ApplicationResource.java
@@ -29,6 +29,7 @@ import org.apache.hbase.thirdparty.javax.ws.rs.Path;
 import org.apache.hbase.thirdparty.javax.ws.rs.Produces;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
 import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
+import org.apache.uniffle.coordinator.metric.CoordinatorMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,8 @@ public class ApplicationResource extends BaseResource {
         () -> {
           Map<String, Integer> appTotalityMap = Maps.newHashMap();
           appTotalityMap.put("appTotality", getApplicationManager().getAppIds().size());
+          appTotalityMap.put("appCurrent",
+              (int) CoordinatorMetrics.counterTotalAppNum.get());
           return appTotalityMap;
         });
   }

--- a/dashboard/src/main/webapp/src/mock/applicationpage.js
+++ b/dashboard/src/main/webapp/src/mock/applicationpage.js
@@ -18,7 +18,7 @@
 import Mock from 'mockjs'
 
 Mock.mock(/\/app\/total/, 'get', function (options) {
-  return { code: 0, data: { appTotality: 10 }, errMsg: 'success' }
+  return { code: 0, data: { appTotality: 10, appCurrent: 10 }, errMsg: 'success' }
 })
 
 Mock.mock(/\/app\/appInfos/, 'get', function (options) {

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -23,20 +23,10 @@
           <template #header>
             <div class="card-header">
               <span class="cardtile">APPS TOTAL</span>
-            </div>
-          </template>
-          <div class="appcnt">{{ pageData.apptotal.appTotality }}</div>
-        </el-card>
-      </el-col>
-    </el-row>
-    <el-row :gutter="20">
-      <el-col :span="4">
-        <el-card class="box-card" shadow="hover">
-          <template #header>
-            <div class="card-header">
               <span class="cardtile">APPS CURRENT TOTAL</span>
             </div>
           </template>
+          <div class="appcnt">{{ pageData.apptotal.appTotality }}</div>
           <div class="appcnt">{{ pageData.apptotal.appCurrent }}</div>
         </el-card>
       </el-col>

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -23,10 +23,18 @@
           <template #header>
             <div class="card-header">
               <span class="cardtile">APPS TOTAL</span>
-              <span class="cardtile">APPS CURRENT TOTAL</span>
             </div>
           </template>
           <div class="appcnt">{{ pageData.apptotal.appTotality }}</div>
+        </el-card>
+      </el-col>
+      <el-col :span="4">
+        <el-card class="box-card" shadow="hover">
+          <template #header>
+            <div class="card-header">
+              <span class="cardtile">APPS CURRENT TOTAL</span>
+            </div>
+          </template>
           <div class="appcnt">{{ pageData.apptotal.appCurrent }}</div>
         </el-card>
       </el-col>

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -27,6 +27,10 @@
           </template>
           <div class="appcnt">{{ pageData.apptotal.appTotality }}</div>
         </el-card>
+      </el-col>
+    </el-row>
+    <el-row :gutter="20">
+      <el-col :span="4">
         <el-card class="box-card" shadow="hover">
           <template #header>
             <div class="card-header">

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -27,6 +27,14 @@
           </template>
           <div class="appcnt">{{ pageData.apptotal.appTotality }}</div>
         </el-card>
+        <el-card class="box-card" shadow="hover">
+          <template #header>
+            <div class="card-header">
+              <span class="cardtile">APPS CURRENT TOTAL</span>
+            </div>
+          </template>
+          <div class="appcnt">{{ pageData.apptotal.appCurrent }}</div>
+        </el-card>
       </el-col>
     </el-row>
     <el-divider />


### PR DESCRIPTION
### What changes are proposed in this pull request?

Display the total number of applications in the dashboard and update the original `total app num` to `current app num`.

### Why are these changes needed?

We want to view the number of running and completed applications from the beginning until now.

### Does this PR introduce _any_ user-facing changes?

- Display the total number of applications in the dashboard
- Update the original `total app num` to `current app num`

### How was this patch tested?

Start the cluster, run a Spark application, and check the dashboard.

<img width="683" alt="image" src="https://github.com/user-attachments/assets/e4aa1c93-b329-4891-844f-f89d29ee7a8b">