### PR TITLE
[MINOR] chore(ci): Add a shade check step after build spark shade jar

### DIFF
--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -312,6 +312,9 @@
                 <echo message="repackaging netty jar"></echo>
                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                      basedir="${project.build.directory}/unpacked"/>
+                <exec executable="sh" failonerror="true" dir="${project.build.directory}/">
+                  <arg line="${project.basedir}/../../dev/scripts/checkshade.sh ${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+                </exec>
               </target>
             </configuration>
           </execution>

--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -312,7 +312,7 @@
                 <echo message="repackaging netty jar"></echo>
                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                      basedir="${project.build.directory}/unpacked"/>
-                <exec executable="sh" failonerror="true" dir="${project.build.directory}/">
+                <exec executable="bash" failonerror="true" dir="${project.build.directory}/">
                   <arg line="${project.basedir}/../../dev/scripts/checkshade.sh ${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
                 </exec>
               </target>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -309,7 +309,7 @@
                 <echo message="repackaging netty jar"></echo>
                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                      basedir="${project.build.directory}/unpacked"/>
-                <exec executable="sh" failonerror="true" dir="${project.build.directory}/">
+                <exec executable="bash" failonerror="true" dir="${project.build.directory}/">
                   <arg line="${project.basedir}/../../dev/scripts/checkshade.sh ${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
                 </exec>
               </target>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -309,6 +309,9 @@
                 <echo message="repackaging netty jar"></echo>
                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                      basedir="${project.build.directory}/unpacked"/>
+                <exec executable="sh" failonerror="true" dir="${project.build.directory}/">
+                  <arg line="${project.basedir}/../../dev/scripts/checkshade.sh ${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+                </exec>
               </target>
             </configuration>
           </execution>

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -27,9 +27,8 @@ if [ ! -f "${SHADED_JAR_PATH}" ]; then
 fi
 
 UNSHADED=$(unzip -l "${SHADED_JAR_PATH}" | awk 'NR>3 {print $4}' | grep -vE 'uniffle|org/apache/spark/shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$')
-if [ -z "$UNSHADED" ]; then
-    UNSHADED_COUNT=0
-else
+UNSHADED_COUNT=0
+if [ -n "$UNSHADED" ]; then
     UNSHADED_COUNT=$(wc -l <<< "$UNSHADED")
 fi
 echo "unshaded count: $UNSHADED_COUNT"

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+set -o pipefail
 set -o nounset   # exit the script if you try to use an uninitialised variable
 
 SHADED_JAR_PATH=${1}

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -27,12 +27,16 @@ if [ ! -f "${SHADED_JAR_PATH}" ]; then
     exit 1
 fi
 
-UNSHADED=$(unzip -l "$1" | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$')
-UNSHADED_COUNT=$(wc -l <<< "$UNSHADED")
+UNSHADED=$(unzip -l "${SHADED_JAR_PATH}" | awk 'NR>3 {print $4}' | grep -vE 'uniffle|org/apache/spark/shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$')
+if [ -z "$UNSHADED" ]; then
+    UNSHADED_COUNT=0
+else
+    UNSHADED_COUNT=$(wc -l <<< "$UNSHADED")
+fi
 echo "unshaded count: $UNSHADED_COUNT"
 echo "unshaded content:"
 echo "$UNSHADED"
-if [ $UNSHADED_COUNT -le 1 ]; then
+if [ $UNSHADED_COUNT -eq 0 ]; then
     echo "check success."
 else
     echo "check failed."

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-set -o pipefail
 set -o nounset   # exit the script if you try to use an uninitialised variable
 
 SHADED_JAR_PATH=${1}

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail
+set -o nounset   # exit the script if you try to use an uninitialised variable
+
+SHADED_JAR_PATH=${1}
+echo "checkShaded:"${SHADED_JAR_PATH}
+if [ ! -f "${SHADED_JAR_PATH}" ]; then
+    echo "check failed, file is not exist."
+    exit -1
+fi
+
+UNSHADED_COUNT=`unzip -l $1 | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$' | wc -l`
+echo "unshaded count = $UNSHADED_COUNT"
+echo "content is :"
+echo `unzip -l $1 | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$'`
+if [ $UNSHADED_COUNT -le 1 ]; then
+    echo "check success."
+else
+    echo "check failed."
+    exit -2
+fi

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -27,10 +27,11 @@ if [ ! -f "${SHADED_JAR_PATH}" ]; then
     exit 1
 fi
 
-UNSHADED_COUNT=`unzip -l $1 | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$' | wc -l`
-echo "unshaded count = $UNSHADED_COUNT"
-echo "content is :"
-echo `unzip -l $1 | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$'`
+UNSHADED=$(unzip -l "$1" | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$')
+UNSHADED_COUNT=$(wc -l <<< "$UNSHADED")
+echo "unshaded count: $UNSHADED_COUNT"
+echo "unshaded content:"
+echo "$UNSHADED"
 if [ $UNSHADED_COUNT -le 1 ]; then
     echo "check success."
 else

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -27,7 +27,7 @@ if [ ! -f "${SHADED_JAR_PATH}" ]; then
     exit 1
 fi
 
-UNSHADED=$(unzip -l "${SHADED_JAR_PATH}" | awk 'NR>3 {print $4}' | grep -vE 'uniffle|org/apache/spark/shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$')
+UNSHADED=$(unzip -l "${SHADED_JAR_PATH}" | awk 'NR>3 {print $4}' | grep -vE 'uniffle|org/apache/spark/shuffle|META-INF|git.properties|/$|\.html$|\.css$|\.xml$|^javax|^$')
 UNSHADED_COUNT=0
 if [ -n "$UNSHADED" ]; then
     UNSHADED_COUNT=$(wc -l <<< "$UNSHADED")

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -36,5 +36,5 @@ if [ $UNSHADED_COUNT -le 1 ]; then
     echo "check success."
 else
     echo "check failed."
-    exit -2
+    exit 2
 fi

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -23,7 +23,7 @@ set -o nounset   # exit the script if you try to use an uninitialised variable
 SHADED_JAR_PATH=${1}
 echo "checkShaded:"${SHADED_JAR_PATH}
 if [ ! -f "${SHADED_JAR_PATH}" ]; then
-    echo "check failed, file is not exist."
+    echo "check failed, file does not exist."
     exit -1
 fi
 

--- a/dev/scripts/checkshade.sh
+++ b/dev/scripts/checkshade.sh
@@ -24,7 +24,7 @@ SHADED_JAR_PATH=${1}
 echo "checkShaded:"${SHADED_JAR_PATH}
 if [ ! -f "${SHADED_JAR_PATH}" ]; then
     echo "check failed, file does not exist."
-    exit -1
+    exit 1
 fi
 
 UNSHADED_COUNT=`unzip -l $1 | awk 'NR>3 {print \$4}' | grep -vE 'uniffle|shuffle|META-INF|git.properties|/$|\.html$|\.css$|^javax|^$' | wc -l`


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add a check after build spark shaded plugin, to check whether there are new coming unshaded content.

### Why are the changes needed?

Without this, we cannot prevent to merge some PR which will break the shade client.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI Tests.
