### PR TITLE
[MINOR] feat(coordinator/dashboard): Show start time of CoordinatorServer to dashboard

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -61,6 +61,7 @@ public class CoordinatorServer {
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorServer.class);
 
   private final CoordinatorConf coordinatorConf;
+  private final long startTimeMs;
   private JettyServer jettyServer;
   private ServerInterface server;
   private ClusterManager clusterManager;
@@ -73,6 +74,7 @@ public class CoordinatorServer {
   private String id;
 
   public CoordinatorServer(CoordinatorConf coordinatorConf) throws Exception {
+    this.startTimeMs = System.currentTimeMillis();
     this.coordinatorConf = coordinatorConf;
     try {
       initialization();
@@ -273,5 +275,9 @@ public class CoordinatorServer {
   /** Await termination on the main thread since the grpc library uses daemon threads. */
   protected void blockUntilShutdown() throws InterruptedException {
     server.blockUntilShutdown();
+  }
+
+  public long getStartTimeMs() {
+    return startTimeMs;
   }
 }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/CoordinatorServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/CoordinatorServerResource.java
@@ -83,6 +83,7 @@ public class CoordinatorServerResource extends BaseResource {
               "serverWebPort", String.valueOf(coordinatorConf.get(JETTY_HTTP_PORT)));
           coordinatorServerInfo.put("version", Constants.VERSION);
           coordinatorServerInfo.put("gitCommitId", Constants.REVISION_SHORT);
+          coordinatorServerInfo.put("startTime", String.valueOf(getCoordinatorServer().getStartTimeMs()));
           return coordinatorServerInfo;
         });
   }

--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/CoordinatorServerResource.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/web/resource/CoordinatorServerResource.java
@@ -69,11 +69,11 @@ public class CoordinatorServerResource extends BaseResource {
 
   @GET
   @Path("/info")
-  public Response<Map<String, String>> getCoordinatorInfo() {
+  public Response<Map<String, Object>> getCoordinatorInfo() {
     return execute(
         () -> {
           final CoordinatorConf coordinatorConf = getCoordinatorServer().getCoordinatorConf();
-          Map<String, String> coordinatorServerInfo = new HashMap<>();
+          Map<String, Object> coordinatorServerInfo = new HashMap<>();
           coordinatorServerInfo.put(
               "coordinatorId", coordinatorConf.getString(CoordinatorUtils.COORDINATOR_ID, "none"));
           coordinatorServerInfo.put("serverIp", RssUtils.getHostIp());
@@ -83,7 +83,7 @@ public class CoordinatorServerResource extends BaseResource {
               "serverWebPort", String.valueOf(coordinatorConf.get(JETTY_HTTP_PORT)));
           coordinatorServerInfo.put("version", Constants.VERSION);
           coordinatorServerInfo.put("gitCommitId", Constants.REVISION_SHORT);
-          coordinatorServerInfo.put("startTime", String.valueOf(getCoordinatorServer().getStartTimeMs()));
+          coordinatorServerInfo.put("startTime", getCoordinatorServer().getStartTimeMs());
           return coordinatorServerInfo;
         });
   }

--- a/dashboard/src/main/webapp/src/pages/CoordinatorServerPage.vue
+++ b/dashboard/src/main/webapp/src/pages/CoordinatorServerPage.vue
@@ -89,7 +89,7 @@
                   Version
                 </div>
               </template>
-              {{ pageData.serverInfo.version}}
+              {{ pageData.serverInfo.version }}_{{ pageData.serverInfo.gitCommitId }}
             </el-descriptions-item>
             <el-descriptions-item>
               <template #label>
@@ -97,10 +97,10 @@
                   <el-icon :style="iconStyle">
                     <Wallet />
                   </el-icon>
-                  Git CommitId
+                  Start Time
                 </div>
               </template>
-              {{ pageData.serverInfo.gitCommitId}}
+              {{ pageData.serverInfo.startTime }}
             </el-descriptions-item>
           </el-descriptions>
         </div>

--- a/dashboard/src/main/webapp/src/pages/CoordinatorServerPage.vue
+++ b/dashboard/src/main/webapp/src/pages/CoordinatorServerPage.vue
@@ -100,7 +100,9 @@
                   Start Time
                 </div>
               </template>
-              {{ pageData.serverInfo.startTime }}
+              <template #default>
+                {{ dateFormatter(null, null, pageData.serverInfo.startTime) }}
+              </template>
             </el-descriptions-item>
           </el-descriptions>
         </div>
@@ -131,6 +133,7 @@ import {
   getCoordinatorStacks
 } from '@/api/api'
 import { useCurrentServerStore } from '@/store/useCurrentServerStore'
+import { dateFormatter } from '@/utils/common'
 
 export default {
   setup() {
@@ -254,7 +257,8 @@ export default {
       handlerPromMetrics,
       handlerStacks,
       filteredTableData,
-      searchKeyword
+      searchKeyword,
+      dateFormatter
     }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add start time of coordinator in dashboard

### Why are the changes needed?

Without this PR, I don't know whether the coordinator has been restarted.

### Does this PR introduce _any_ user-facing change?

Add start time of coordinator in dashboard

### How was this patch tested?

<img width="2371" alt="image" src="https://github.com/user-attachments/assets/7cf3b338-3ae8-484b-8586-dcfc1b8ac25e">

