### PR TITLE
[#2039] fix(docker): Make docker build script work for Hadoop3.2

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -47,17 +47,15 @@ done
 mkdir -p "${RSS_LOG_DIR}"
 mkdir -p "${RSS_PID_DIR}"
 
-set +u
-if [ $HADOOP_HOME ]; then
+if [ -n "${HADOOP_HOME:-}" ]; then
   HADOOP_DEPENDENCY="$("$HADOOP_HOME/bin/hadoop" classpath --glob)"
   CLASSPATH=$CLASSPATH:$HADOOP_DEPENDENCY
   JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 fi
 
-if [ $HADOOP_CONF_DIR ]; then
+if [ -n "${HADOOP_CONF_DIR:-}" ]; then
   CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR
 fi
-set -u
 
 echo "class path is $CLASSPATH"
 

--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -68,17 +68,15 @@ done
 mkdir -p "${RSS_LOG_DIR}"
 mkdir -p "${RSS_PID_DIR}"
 
-set +u
-if [ $HADOOP_HOME ]; then
+if [ -n "${HADOOP_HOME:-}" ]; then
   HADOOP_DEPENDENCY="$("$HADOOP_HOME/bin/hadoop" classpath --glob)"
   CLASSPATH=$CLASSPATH:$HADOOP_DEPENDENCY
   JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 fi
 
-if [ "$HADOOP_CONF_DIR" ]; then
+if [ -n "${HADOOP_CONF_DIR:-}" ]; then
   CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR
 fi
-set -u
 
 echo "class path is $CLASSPATH"
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -185,17 +185,15 @@ function load_rss_env {
   fi
 
   # export default value
-  set +o nounset
-  if [ -z "$HADOOP_CONF_DIR" ] && [ "$HADOOP_HOME" ]; then
+  if [ -z "${HADOOP_CONF_DIR:-}" ] && [ -n "${HADOOP_HOME:-}" ]; then
     HADOOP_CONF_DIR="${HADOOP_HOME}/etc/hadoop"
   fi
-  if [ -z "$RSS_LOG_DIR" ]; then
+  if [ -z "${RSS_LOG_DIR:-}" ]; then
     RSS_LOG_DIR="${RSS_HOME}/logs"
   fi
-  if [ -z "$RSS_PID_DIR" ]; then
+  if [ -z "${RSS_PID_DIR:-}" ]; then
     RSS_PID_DIR="${RSS_HOME}"
   fi
-  set -o nounset
 
   RUNNER="${JAVA_HOME}/bin/java"
   JPS="${JAVA_HOME}/bin/jps"
@@ -208,14 +206,12 @@ function load_rss_env {
     echo "Using RSS from ${RSS_HOME}"
     echo "Using RSS conf from ${RSS_CONF_DIR}"
 
-    set +u
-    if [ $HADOOP_HOME ]; then
+    if [ -n "${HADOOP_HOME:-}" ]; then
       echo "Using Hadoop from ${HADOOP_HOME}"
     fi
-    if [ $HADOOP_CONF_DIR ]; then
+    if [ -n "${HADOOP_CONF_DIR:-}" ]; then
       echo "Using Hadoop conf from ${HADOOP_CONF_DIR}"
     fi
-    set -u
 
     echo "Write log file to ${RSS_LOG_DIR}"
     echo "Write pid file to ${RSS_PID_DIR}"

--- a/deploy/kubernetes/docker/Dockerfile
+++ b/deploy/kubernetes/docker/Dockerfile
@@ -34,21 +34,12 @@ RUN mkdir -p /data/rssadmin/
 RUN chown -R rssadmin:rssadmin /data
 USER rssadmin
 
-COPY rss-${RSS_VERSION}-hadoop${HADOOP_SHORT_VERSION}.tgz /data/rssadmin
-RUN tar -xvf /data/rssadmin/rss-${RSS_VERSION}-hadoop${HADOOP_SHORT_VERSION}.tgz -C /data/rssadmin
-RUN mv /data/rssadmin/rss-${RSS_VERSION}-hadoop${HADOOP_SHORT_VERSION} /data/rssadmin/rss
-RUN rm /data/rssadmin/rss/conf/rss-env.sh
-RUN rm -rf /data/rssadmin/rss-${RSS_VERSION}-hadoop${HADOOP_SHORT_VERSION}.tgz
+COPY rss.tgz /data/rssadmin
+RUN tar -xvf /data/rssadmin/rss.tgz -C /data/rssadmin
+RUN rm -rf /data/rssadmin/rss.tgz
 
-COPY rss-env.sh /data/rssadmin/rss/conf
-
-COPY start.sh /data/rssadmin/rss/bin
-
-COPY hadoop-${HADOOP_VERSION}.tar.gz /data/rssadmin
-RUN tar -zxvf /data/rssadmin/hadoop-${HADOOP_VERSION}.tar.gz -C /data/rssadmin
-RUN mv /data/rssadmin/hadoop-${HADOOP_VERSION} /data/rssadmin/hadoop
-RUN rm -rf /data/rssadmin/hadoop-${HADOOP_VERSION}.tar.gz
-COPY hadoopconfig/ /data/rssadmin/hadoop/etc/hadoop
+COPY --chown=rssadmin:rssadmin --chmod=744 rss-env.sh /data/rssadmin/rss/conf
+COPY --chown=rssadmin:rssadmin --chmod=744 start.sh /data/rssadmin/rss/bin
 
 ENV RSS_VERSION ${RSS_VERSION}
 ENV HADOOP_VERSION ${HADOOP_VERSION}

--- a/deploy/kubernetes/docker/rss-env.sh
+++ b/deploy/kubernetes/docker/rss-env.sh
@@ -21,7 +21,10 @@ set -o pipefail
 set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
 
-HADOOP_HOME="/data/rssadmin/hadoop"
+if [ -d "/data/rssadmin/hadoop" ]; then
+  export HADOOP_HOME="/data/rssadmin/hadoop"
+fi
+
 RUNNER="${JAVA_HOME}/bin/java"
 JPS="${JAVA_HOME}/bin/jps"
 

--- a/docs/operator/install.md
+++ b/docs/operator/install.md
@@ -34,6 +34,10 @@ Run the following command:
 cd deploy/kubernetes/docker && sh build.sh --registry ${our-registry}
 ```
 
+This compiles RSS with Hadoop 2.8 support und add the Hadoop binaries to the Docker image.
+Use `--hadoop-version x.y.z` to choose a different Hadoop version. Use `--hadoop-provided false` to **not**
+include the Hadoop installation in the image.
+
 ## Creating or Updating CRD
 
 We can refer

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -522,6 +530,14 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -655,6 +671,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -2294,6 +2314,12 @@
       </modules>
     </profile>
     <profile>
+      <id>hadoop-dependencies-provided</id>
+      <properties>
+        <hadoop.scope>provided</hadoop.scope>
+      </properties>
+    </profile>
+    <profile>
       <id>hadoop-dependencies-included</id>
       <properties>
         <hadoop.scope>compile</hadoop.scope>
@@ -2328,6 +2354,15 @@
           <scope>test</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>netty-4.1.68.Final</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <netty.version>4.1.68.Final</netty.version>
+      </properties>
     </profile>
 
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fixes Docker build script option `--hadoop-version`
- Allows to build the Docker image without Hadoop binaries
- Fixes building the Docker image for Hadoop3.2 to work with Hadoop binaries and Epoll.
- Add Maven profile `netty-4.1.68.Final` to downgrade netty version

### Why are the changes needed?

Currently, building with option `--hadoop-version 3.2.4` does not work, as `HADOOP_SHORT_VERSION` is not updated when `--hadoop-version` is set. Further, even if built with Hadoop 3.2.4, using Netty and Epoll currently fails with

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: failed to load the required native library
	at io.netty.channel.epoll.Epoll.ensureAvailability(Epoll.java:81)
	at io.netty.channel.epoll.EpollEventLoop.<clinit>(EpollEventLoop.java:57)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:189)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:37)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:60)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:49)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:117)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:104)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:81)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:57)
	at org.apache.uniffle.server.netty.StreamServer.<init>(StreamServer.java:88)
	at org.apache.uniffle.server.ShuffleServer.initialization(ShuffleServer.java:300)
	at org.apache.uniffle.server.ShuffleServer.<init>(ShuffleServer.java:113)
	at org.apache.uniffle.server.ShuffleServer.main(ShuffleServer.java:131)
Caused by: java.lang.ExceptionInInitializerError
	at io.netty.channel.epoll.Epoll.<clinit>(Epoll.java:40)
	... 15 more
Caused by: java.lang.IllegalStateException: Multiple resources found for 'META-INF/native/libnetty_transport_native_epoll_x86_64.so' with different content: [jar:file:/data/rssadmin/rss/jars/server/netty-transport-native-epoll-4.1.109.Final-linux-x86_64.jar!/META-INF/native/libnetty_transport_native_epoll_x86_64.so, jar:file:/data/rssadmin/hadoop/share/hadoop/hdfs/lib/netty-all-4.1.68.Final.jar!/META-INF/native/libnetty_transport_native_epoll_x86_64.so]
	at io.netty.util.internal.NativeLibraryLoader.getResource(NativeLibraryLoader.java:301)
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:173)
	at io.netty.channel.epoll.Native.loadNativeLibrary(Native.java:334)
	at io.netty.channel.epoll.Native.<clinit>(Native.java:96)
	... 16 more
```

Reason is the Hadoop binaries contain a different `netty-all` jar then the RSS shuffle server.

This can be fixed by
- either not include the Hadoop binaries in the Docker image
- or by downgrading netty version to match the version contained in the Hadoop binaries

Fix: #2039

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually running:
```
./build.sh --hadoop-version 2.8.5 --hadoop-provided true --push-image false
./build.sh --hadoop-version 2.8.5 --hadoop-provided false --push-image false
./build.sh --hadoop-version 3.2.4 --hadoop-provided true --push-image false
./build.sh --hadoop-version 3.2.4 --hadoop-provided false --push-image false
```

And testing coordinator and shuffle server manages to start in each of the images.

    docker run --rm -it rss-server:0.10.0-SNAPSHOT-release.0.4.0.1030.g906c5517.dirty /bin/bash -c "rss/bin/start-coordinator.sh && sleep 3 && XMX_SIZE=1g rss/bin/start-shuffle-server.sh && sleep 10"

Note you have to run this before each `./build.sh`:

    rm rss.tgz rss-0.10.0-SNAPSHOT-hadoop3.2.tgz ../../../rss-0.10.0-SNAPSHOT-hadoop3.2.tgz

Use this `conf/server.conf`:

```conf
rss.rpc.server.port 29999
rss.jetty.http.port 29998
rss.storage.basePath /tmp/rss
rss.storage.type MEMORY_LOCALFILE_HDFS
rss.coordinator.quorum localhost:19999
rss.server.buffer.capacity 40gb
rss.server.read.buffer.capacity 20gb
rss.server.flush.thread.alive 5
rss.server.flush.localfile.threadPool.size 10
rss.server.flush.hadoop.threadPool.size 60
rss.server.disk.capacity 100m
rss.server.single.buffer.flush.enabled true
rss.server.single.buffer.flush.threshold 128m

# Enable Netty mode
rss.rpc.server.type GRPC_NETTY
rss.server.netty.epoll.enable true
rss.server.netty.port 17000
rss.server.netty.connect.backlog 128
```