### PR TITLE
[#2056] feat(common): add a NONE type to compression.codec

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -96,7 +97,7 @@ public class SortWriteBufferManager<K, V> {
   private final long maxBufferSize;
   private final ExecutorService sendExecutorService;
   private final RssConf rssConf;
-  private final Codec codec;
+  private final Optional<Codec> codec;
   private final Task.CombinerRunner<K, V> combinerRunner;
 
   public SortWriteBufferManager(
@@ -383,7 +384,7 @@ public class SortWriteBufferManager<K, V> {
     int partitionId = wb.getPartitionId();
     final int uncompressLength = data.length;
     long start = System.currentTimeMillis();
-    final byte[] compressed = codec.compress(data);
+    final byte[] compressed = codec.map(c -> c.compress(data)).orElse(data);
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     compressTime += System.currentTimeMillis() - start;
     final long blockId =

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -19,6 +19,7 @@ package org.apache.spark.shuffle.reader;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -171,8 +172,9 @@ public abstract class AbstractRssReaderTest extends HadoopTestBase {
   protected ShufflePartitionedBlock createShuffleBlock(
       byte[] data, long blockId, boolean compress) {
     byte[] compressData = data;
-    if (compress) {
-      compressData = Codec.newInstance(new RssConf()).compress(data);
+    Optional<Codec> codec = Codec.newInstance(new RssConf());
+    if (compress && codec.isPresent()) {
+      compressData = codec.get().compress(data);
     }
     long crc = ChecksumUtils.getCrc32(compressData);
     return new ShufflePartitionedBlock(

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.reader;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
@@ -46,6 +47,7 @@ import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.common.ClientType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
@@ -321,11 +323,12 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
     RssShuffleDataIterator rssShuffleDataIterator =
         getDataIterator(
             basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(ssi1, ssi2), compress);
-    Object codec = FieldUtils.readField(rssShuffleDataIterator, "codec", true);
+    Optional<Codec> codec =
+        (Optional<Codec>) FieldUtils.readField(rssShuffleDataIterator, "codec", true);
     if (compress) {
-      Assertions.assertNotNull(codec);
+      Assertions.assertTrue(codec.isPresent());
     } else {
-      Assertions.assertNull(codec);
+      Assertions.assertFalse(codec.isPresent());
     }
 
     validateResult(rssShuffleDataIterator, expectedData, 20);

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -46,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.util.BlockIdLayout;
@@ -122,11 +124,11 @@ public class WriteBufferManagerTest {
       conf.set(RssSparkConfig.SPARK_SHUFFLE_COMPRESS_KEY, String.valueOf(false));
     }
     WriteBufferManager wbm = createManager(conf);
-    Object codec = FieldUtils.readField(wbm, "codec", true);
+    Optional<Codec> codec = (Optional<Codec>) FieldUtils.readField(wbm, "codec", true);
     if (compress) {
-      Assertions.assertNotNull(codec);
+      Assertions.assertTrue(codec.isPresent());
     } else {
-      Assertions.assertNull(codec);
+      Assertions.assertFalse(codec.isPresent());
     }
     wbm.setShuffleWriteMetrics(new ShuffleWriteMetrics());
     String testKey = "Key";

--- a/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
+++ b/client-tez/src/main/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManager.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -84,7 +85,7 @@ public class WriteBufferManager<K, V> {
   private final double memoryThreshold;
   private final double sendThreshold;
   private final int batch;
-  private final Codec codec;
+  private final Optional<Codec> codec;
   private final Map<Integer, List<ShuffleServerInfo>> partitionToServers;
   private final Set<Long> allBlockIds = Sets.newConcurrentHashSet();
   // server -> partitionId -> blockIds
@@ -370,7 +371,7 @@ public class WriteBufferManager<K, V> {
     final int uncompressLength = data.length;
     long start = System.currentTimeMillis();
 
-    final byte[] compressed = codec.compress(data);
+    final byte[] compressed = codec.map(c -> c.compress(data)).orElse(data);
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     compressTime += System.currentTimeMillis() - start;
     final long blockId =

--- a/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.common.compression;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 import org.apache.uniffle.common.config.RssConf;
 
@@ -26,20 +27,20 @@ import static org.apache.uniffle.common.config.RssClientConf.ZSTD_COMPRESSION_LE
 
 public abstract class Codec {
 
-  public static Codec newInstance(RssConf rssConf) {
+  public static Optional<Codec> newInstance(RssConf rssConf) {
     Type type = rssConf.get(COMPRESSION_TYPE);
     switch (type) {
       case NONE:
-        return null;
+        return Optional.empty();
       case ZSTD:
-        return ZstdCodec.getInstance(rssConf.get(ZSTD_COMPRESSION_LEVEL));
+        return Optional.of(ZstdCodec.getInstance(rssConf.get(ZSTD_COMPRESSION_LEVEL)));
       case SNAPPY:
-        return SnappyCodec.getInstance();
+        return Optional.of(SnappyCodec.getInstance());
       case NOOP:
-        return NoOpCodec.getInstance();
+        return Optional.of(NoOpCodec.getInstance());
       case LZ4:
       default:
-        return Lz4Codec.getInstance();
+        return Optional.of(Lz4Codec.getInstance());
     }
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
@@ -29,6 +29,8 @@ public abstract class Codec {
   public static Codec newInstance(RssConf rssConf) {
     Type type = rssConf.get(COMPRESSION_TYPE);
     switch (type) {
+      case NONE:
+        return null;
       case ZSTD:
         return ZstdCodec.getInstance(rssConf.get(ZSTD_COMPRESSION_LEVEL));
       case SNAPPY:
@@ -72,5 +74,6 @@ public abstract class Codec {
     ZSTD,
     NOOP,
     SNAPPY,
+    NONE,
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/ByteBufferUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/ByteBufferUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.util;
+
+import java.nio.ByteBuffer;
+
+public class ByteBufferUtils {
+
+  public static byte[] bufferToArray(ByteBuffer buffer) {
+    if (buffer.hasArray()
+        && buffer.arrayOffset() == 0
+        && buffer.array().length == buffer.remaining()) {
+      return buffer.array();
+    } else {
+      byte[] bytes = new byte[buffer.remaining()];
+      buffer.get(bytes);
+      return bytes;
+    }
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
@@ -56,7 +56,7 @@ public class CompressionTest {
     conf.set(COMPRESSION_TYPE, type);
 
     // case1: heap bytebuffer
-    Codec codec = Codec.newInstance(conf);
+    Codec codec = Codec.newInstance(conf).get();
     byte[] compressed = codec.compress(data);
 
     ByteBuffer dest = ByteBuffer.allocate(size);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

add a NONE type to compression.codec

### Why are the changes needed?

Allow disabling rss client compression when spark.shuffle.compress is enabled

Fix: #2056

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

yes. add a none compression type

### How was this patch tested?

existing unit tests