### PR TITLE
[#2061]fix(server): Fix netty memory leak when removeBuffer and cacheShuffle…

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
@@ -44,8 +44,12 @@ public abstract class AbstractShuffleBuffer implements ShuffleBuffer {
 
   protected AtomicLong inFlushSize = new AtomicLong();
 
+  protected volatile boolean evicted;
+  public static final long BUFFER_EVICTED = -1L;
+
   public AbstractShuffleBuffer() {
     this.size = 0;
+    this.evicted = false;
   }
 
   /** Only for test */

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -219,6 +219,9 @@ public class ShuffleBufferManager {
 
     ShuffleBuffer buffer = entry.getValue();
     long size = buffer.append(spd);
+    if (size == AbstractShuffleBuffer.BUFFER_EVICTED) {
+      return StatusCode.NO_REGISTER;
+    }
     if (!isPreAllocated) {
       updateUsedMemory(size);
     }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -58,25 +58,26 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   }
 
   @Override
-  public long append(ShufflePartitionedData data) {
-    long size = 0;
+  public synchronized long append(ShufflePartitionedData data) {
+    if (evicted) {
+      return BUFFER_EVICTED;
+    }
+    long currentSize = 0;
 
-    synchronized (this) {
       for (ShufflePartitionedBlock block : data.getBlockList()) {
         // If sendShuffleData retried, we may receive duplicate block. The duplicate
         // block would gc without release. Here we must release the duplicated block.
         if (!blocksMap.containsKey(block.getBlockId())) {
           blocksMap.put(block.getBlockId(), block);
           blockCount++;
-          size += block.getEncodedLength();
+          currentSize += block.getEncodedLength();
         } else {
           block.getData().release();
         }
       }
-      this.size += size;
-    }
+      this.size += currentSize;
 
-    return size;
+    return currentSize;
   }
 
   @Override
@@ -120,10 +121,11 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   }
 
   @Override
-  public long release() {
+  public synchronized long release() {
     Throwable lastException = null;
     int failedToReleaseSize = 0;
     long releasedSize = 0;
+    evicted = true;
     for (ShufflePartitionedBlock spb : blocksMap.values()) {
       try {
         spb.getData().release();


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Fix netty memory leak when removeBuffer and cacheShuffleData happen concurrent

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: https://github.com/apache/incubator-uniffle/issues/2061

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
