### PR TITLE
[#2065] Fix QuorumTest to use random port

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/CoordinatorServer.java
@@ -72,6 +72,7 @@ public class CoordinatorServer {
   private GRPCMetrics grpcMetrics;
   private MetricReporter metricReporter;
   private String id;
+  private int rpcListenPort;
 
   public CoordinatorServer(CoordinatorConf coordinatorConf) throws Exception {
     this.startTimeMs = System.currentTimeMillis();
@@ -106,7 +107,7 @@ public class CoordinatorServer {
     LOG.info(
         "{} version: {}", this.getClass().getSimpleName(), Constants.VERSION_AND_REVISION_SHORT);
     jettyServer.start();
-    server.start();
+    rpcListenPort = server.start();
     if (metricReporter != null) {
       metricReporter.start();
     }
@@ -279,5 +280,9 @@ public class CoordinatorServer {
 
   public long getStartTimeMs() {
     return startTimeMs;
+  }
+
+  public int getRpcListenPort() {
+    return rpcListenPort;
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

As title.

### Why are the changes needed?

Fix: #2065

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
