### PR TITLE
[#2069] improvement: Remove reset dest buffer position and limit in decompress method of NoOpCodec

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
@@ -32,8 +32,6 @@ public class NoOpCodec extends Codec {
   @Override
   public void decompress(ByteBuffer src, int uncompressedLen, ByteBuffer dest, int destOffset) {
     dest.put(src);
-    dest.position(destOffset);
-    dest.limit(destOffset + uncompressedLen);
   }
 
   @Override

--- a/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
@@ -19,9 +19,11 @@ package org.apache.uniffle.common.compression;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -146,5 +148,20 @@ public class CompressionTest {
     byte[] res = new byte[originData.length];
     dest.get(res);
     assertArrayEquals(originData, res);
+  }
+
+  @Test
+  public void testNoop() {
+    byte[] data = RandomUtils.nextBytes(1024);
+
+    Codec codec = NoOpCodec.getInstance();
+    byte[] compressed = codec.compress(data);
+
+    ByteBuffer dest = ByteBuffer.allocate(2048);
+    codec.decompress(ByteBuffer.wrap(compressed), 1024, dest, 0);
+    assertArrayEquals(data, Arrays.copyOfRange(dest.array(), 0, 1024));
+
+    codec.decompress(ByteBuffer.wrap(compressed), 1024, dest, 1024);
+    assertArrayEquals(data, Arrays.copyOfRange(dest.array(), 1024, 2048));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Remove reset dest buffer position and limit in decompress method of NoOpCodec.

### Why are the changes needed?

We should not change the offset of external buffer in decompress method.

Fix: #2069

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

add unit test
