### PR TITLE
[#2072] improvement: Corrected buffer offsets in NoOpCodec.decompress

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
@@ -31,9 +31,9 @@ public class NoOpCodec extends Codec {
 
   @Override
   public void decompress(ByteBuffer src, int uncompressedLen, ByteBuffer dest, int destOffset) {
-    dest.position(destOffset);
-    dest.put(src.duplicate());
-    dest.rewind();
+    ByteBuffer destDuplicated = dest.duplicate();
+    destDuplicated.position(destOffset);
+    destDuplicated.put(src.duplicate());
   }
 
   @Override

--- a/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/NoOpCodec.java
@@ -31,9 +31,9 @@ public class NoOpCodec extends Codec {
 
   @Override
   public void decompress(ByteBuffer src, int uncompressedLen, ByteBuffer dest, int destOffset) {
-    dest.put(src);
     dest.position(destOffset);
-    dest.limit(destOffset + uncompressedLen);
+    dest.put(src.duplicate());
+    dest.rewind();
   }
 
   @Override

--- a/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
@@ -182,9 +182,8 @@ public class CompressionTest {
         assertEquals(compressed.length, src.limit());
         assertEquals(0, dest.position());
         assertEquals(2048, dest.limit());
-        assertArrayEquals(data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest), 0, 1024));
-
-        dest.clear();
+        assertArrayEquals(
+            data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest.duplicate()), 0, 1024));
 
         codec.decompress(src, 1024, dest, 1024);
         assertEquals(0, src.position());
@@ -192,7 +191,7 @@ public class CompressionTest {
         assertEquals(0, dest.position());
         assertEquals(2048, dest.limit());
         assertArrayEquals(
-            data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest), 1024, 2048));
+            data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest.duplicate()), 1024, 2048));
       }
     }
   }

--- a/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/compression/CompressionTest.java
@@ -19,14 +19,17 @@ package org.apache.uniffle.common.compression;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.uniffle.common.config.RssConf;
+import org.apache.uniffle.common.util.ByteBufferUtils;
 
 import static org.apache.uniffle.common.config.RssClientConf.COMPRESSION_TYPE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -146,5 +149,51 @@ public class CompressionTest {
     byte[] res = new byte[originData.length];
     dest.get(res);
     assertArrayEquals(originData, res);
+  }
+
+  @Test
+  public void checkDecompressBufferOffsets() {
+    byte[] data = RandomUtils.nextBytes(1024);
+    // Snappy decompression does not support non-zero offset for destination direct ByteBuffer
+    Codec.Type[] types = {Codec.Type.ZSTD, Codec.Type.LZ4, Codec.Type.NOOP};
+    Boolean[] isDirects = {true, false};
+    for (Boolean isDirect : isDirects) {
+      for (Codec.Type type : types) {
+        Codec codec = Codec.newInstance(new RssConf().set(COMPRESSION_TYPE, type)).get();
+        byte[] compressed = codec.compress(data);
+
+        ByteBuffer src;
+        if (isDirect) {
+          src = ByteBuffer.allocateDirect(compressed.length);
+        } else {
+          src = ByteBuffer.allocate(compressed.length);
+        }
+        src.put(compressed);
+        src.flip();
+
+        ByteBuffer dest;
+        if (isDirect) {
+          dest = ByteBuffer.allocateDirect(2048);
+        } else {
+          dest = ByteBuffer.allocate(2048);
+        }
+        codec.decompress(src, 1024, dest, 0);
+        assertEquals(0, src.position());
+        assertEquals(compressed.length, src.limit());
+        assertEquals(0, dest.position());
+        assertEquals(2048, dest.limit());
+        assertArrayEquals(data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest), 0, 1024));
+
+        dest.clear();
+
+        codec.decompress(src, 1024, dest, 1024);
+        assertEquals(0, src.position());
+        assertEquals(compressed.length, src.limit());
+        assertEquals(0, dest.position());
+        assertEquals(2048, dest.limit());
+        assertArrayEquals(
+            data, Arrays.copyOfRange(ByteBufferUtils.bufferToArray(dest), 1024, 2048));
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Corrected buffer offsets in NoOpCodec.decompress

### Why are the changes needed?

Make NoOpCodec.decompress logic consistent with other codecs.

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

added unit tests