### PR TITLE
[#2077] improvement: Check java version in release scripts

### DIFF
--- a/release/create-package.sh
+++ b/release/create-package.sh
@@ -21,6 +21,9 @@ set -o pipefail
 set -e
 set -x
 
+source "$(dirname "$0")/utils.sh"
+check_use_java8
+
 SKIP_GPG=${SKIP_GPG:-false}
 
 exit_with_usage() {

--- a/release/publish_maven_artifacts.sh
+++ b/release/publish_maven_artifacts.sh
@@ -21,6 +21,9 @@ set -o pipefail
 set -e
 set -x
 
+source "$(dirname "$0")/utils.sh"
+check_use_java8
+
 ASF_USERNAME=${ASF_USERNAME:?"ASF_USERNAME is required"}
 ASF_PASSWORD=${ASF_PASSWORD:?"ASF_PASSWORD is required"}
 

--- a/release/publish_to_svn.sh
+++ b/release/publish_to_svn.sh
@@ -21,6 +21,9 @@ set -o pipefail
 set -e
 set -x
 
+source "$(dirname "$0")/utils.sh"
+check_use_java8
+
 PROJECT_DIR="$(cd "$(dirname "$0")"/..; pwd)"
 
 ASF_USERNAME=${ASF_USERNAME:?"ASF_USERNAME is required"}

--- a/release/utils.sh
+++ b/release/utils.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Common utils
+set -o nounset   # exit the script if you try to use an uninitialised variable
+set -o errexit   # exit the script if any statement returns a non-true return value
+
+function check_use_java8() {
+    set +o nounset
+    if [ -n "${JAVA_HOME}" ]; then
+      JAVA="${JAVA_HOME}/bin/java"
+    elif [ "$(command -v java)" ]; then
+      JAVA="java"
+    else
+      echo "JAVA_HOME is not set" >&2
+      exit 1
+    fi
+    set -o nounset
+
+    JAVA_VERSION=$($JAVA -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    if [[ $JAVA_VERSION != 1.8.* ]]; then
+      echo "Unexpected Java version: $JAVA_VERSION. Java 8 is required for release."
+      exit 1
+    fi
+}
+


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Check java version in release scripts

### Why are the changes needed?

Use a fixed java version in the release scripts

Fix: #2077

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test:

Use mismatched java version:
```
./release/create-package.sh binary
```
output:
```
Unexpected Java version: 17.0.10. Java 8 is required for release.
```

When using matched Java version, release scripts execute successfully.
