### PR TITLE
[#2087] feat(operator): support closing leader election of webhook of rss-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ testbin/*
 *.swo
 *~
 deploy/kubernetes/operator/bin
+deploy/kubernetes/operator/local
 common/build/
 integration-test/common/build/
 storage/build/

--- a/deploy/kubernetes/operator/pkg/webhook/config/config.go
+++ b/deploy/kubernetes/operator/pkg/webhook/config/config.go
@@ -38,12 +38,14 @@ const (
 	flagServerCertFile       = "server-cert-file"
 	flagServerPrivateKeyFile = "server-private-key-file"
 	flagCACertFile           = "ca-cert-file"
+	flagLeaderElection       = "leader-election"
 )
 
 // Config contains all configurations.
 type Config struct {
 	IgnoreLastApps bool
 	IgnoreRSS      bool
+	LeaderElection bool
 	HTTPConfig
 	utils.GenericConfig
 }
@@ -113,6 +115,7 @@ func (c *Config) AddFlags() {
 		"Used when debugging, it means we will ignore checking last apps.")
 	flag.BoolVar(&c.IgnoreRSS, flagIgnoreRSS, false,
 		"Used when debugging, it means we will ignore checking rss objects.")
+	flag.BoolVar(&c.LeaderElection, flagLeaderElection, false, "whether we need to enable leader election.")
 	c.HTTPConfig.AddFlags()
 	c.GenericConfig.AddFlags()
 }

--- a/deploy/kubernetes/operator/pkg/webhook/manager.go
+++ b/deploy/kubernetes/operator/pkg/webhook/manager.go
@@ -69,8 +69,11 @@ func newAdmissionManager(cfg *config.Config) *admissionManager {
 	} else {
 		am.loadCertsFromSecret()
 	}
+
+	klog.Infof("leader election enabled?: %v", cfg.LeaderElection)
+
 	mgr, err := ctrl.NewManager(cfg.RESTConfig, ctrl.Options{
-		LeaderElection:          true,
+		LeaderElection:          cfg.LeaderElection,
 		LeaderElectionID:        cfg.LeaderElectionID(),
 		LeaderElectionNamespace: utils.GetCurrentNamespace(),
 	})

--- a/deploy/kubernetes/operator/pkg/webhook/manager_test.go
+++ b/deploy/kubernetes/operator/pkg/webhook/manager_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -85,6 +86,7 @@ var _ = BeforeSuite(
 		// +kubebuilder:scaffold:scheme
 
 		cfg := &config.Config{
+			LeaderElection: false,
 			HTTPConfig: config.HTTPConfig{
 				Port:            9876,
 				ExternalService: webhookconstants.ComponentName,
@@ -141,6 +143,11 @@ var _ = Describe("AdmissionManager", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mwc).ToNot(BeNil())
+
+			By("Check lease object when disabling leader election")
+			leaseList, leaseErr := kubeClient.CoordinationV1().Leases(corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+			Expect(leaseErr).ToNot(HaveOccurred())
+			Expect(len(leaseList.Items)).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

In this PR, we set a flag to open or close leader election of webhook of rss-operator.

We set the default value to false because leader election is only involved when synchronizing configuration objects used by webhook. Even if leader election is disabled, there will be no conflicts because the configuration objects rarely change. We plan to consider removing leader election completely in the future.

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #2087 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added ut or Manually verified.
