### PR TITLE
[#2090] fix(client): use thread-safe list to store the sending status

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -600,7 +600,6 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         // todo: if setting multi replica and another replica is succeed to send, no need to resend
         resendCandidates.addAll(failedBlockStatus);
       }
-
     }
 
     if (isFastFail) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -567,47 +566,50 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     // to check whether the blocks resent exceed the max resend count.
     for (Long blockId : failedBlockIds) {
       List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-      int retryIndex =
-          failedBlockStatus.stream()
-              .map(x -> x.getShuffleBlockInfo().getRetryCnt())
-              .max(Comparator.comparing(Integer::valueOf))
-              .get();
-      if (retryIndex >= blockFailSentRetryMaxTimes) {
-        LOG.error(
-            "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
-            taskId,
-            blockFailSentRetryMaxTimes,
+      synchronized (failedBlockStatus) {
+        int retryIndex =
             failedBlockStatus.stream()
-                .map(x -> x.getShuffleServerInfo())
-                .collect(Collectors.toSet()));
-        isFastFail = true;
-        break;
-      }
-
-      for (TrackingBlockStatus status : failedBlockStatus) {
-        StatusCode code = status.getStatusCode();
-        if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
+                .map(x -> x.getShuffleBlockInfo().getRetryCnt())
+                .max(Comparator.comparing(Integer::valueOf))
+                .get();
+        if (retryIndex >= blockFailSentRetryMaxTimes) {
           LOG.error(
-              "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
+              "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
               taskId,
-              code,
-              status.getShuffleServerInfo());
+              blockFailSentRetryMaxTimes,
+              failedBlockStatus.stream()
+                  .map(x -> x.getShuffleServerInfo())
+                  .collect(Collectors.toSet()));
           isFastFail = true;
           break;
         }
+
+        for (TrackingBlockStatus status : failedBlockStatus) {
+          StatusCode code = status.getStatusCode();
+          if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
+            LOG.error(
+                "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
+                taskId,
+                code,
+                status.getShuffleServerInfo());
+            isFastFail = true;
+            break;
+          }
+        }
+
+        // todo: if setting multi replica and another replica is succeed to send, no need to resend
+        resendCandidates.addAll(failedBlockStatus);
       }
 
-      // todo: if setting multi replica and another replica is succeed to send, no need to resend
-      resendCandidates.addAll(failedBlockStatus);
     }
 
     if (isFastFail) {
       // release data and allocated memory
       for (Long blockId : failedBlockIds) {
         List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-        Optional<TrackingBlockStatus> blockStatus = failedBlockStatus.stream().findFirst();
-        if (blockStatus.isPresent()) {
-          blockStatus.get().getShuffleBlockInfo().executeCompletionCallback(true);
+        if (CollectionUtils.isNotEmpty(failedBlockStatus)) {
+          TrackingBlockStatus blockStatus = failedBlockStatus.get(0);
+          blockStatus.getShuffleBlockInfo().executeCompletionCallback(true);
         }
       }
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -567,45 +567,49 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     // to check whether the blocks resent exceed the max resend count.
     for (Long blockId : failedBlockIds) {
       List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-      int retryIndex =
-          failedBlockStatus.stream()
-              .map(x -> x.getShuffleBlockInfo().getRetryCnt())
-              .max(Comparator.comparing(Integer::valueOf))
-              .get();
-      if (retryIndex >= blockFailSentRetryMaxTimes) {
-        LOG.error(
-            "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
-            taskId,
-            blockFailSentRetryMaxTimes,
+      synchronized (failedTracker) {
+        int retryIndex =
             failedBlockStatus.stream()
-                .map(x -> x.getShuffleServerInfo())
-                .collect(Collectors.toSet()));
-        isFastFail = true;
-        break;
-      }
-
-      for (TrackingBlockStatus status : failedBlockStatus) {
-        StatusCode code = status.getStatusCode();
-        if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
+                .map(x -> x.getShuffleBlockInfo().getRetryCnt())
+                .max(Comparator.comparing(Integer::valueOf))
+                .get();
+        if (retryIndex >= blockFailSentRetryMaxTimes) {
           LOG.error(
-              "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
+              "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
               taskId,
-              code,
-              status.getShuffleServerInfo());
+              blockFailSentRetryMaxTimes,
+              failedBlockStatus.stream()
+                  .map(x -> x.getShuffleServerInfo())
+                  .collect(Collectors.toSet()));
           isFastFail = true;
           break;
         }
+        for (TrackingBlockStatus status : failedBlockStatus) {
+          StatusCode code = status.getStatusCode();
+          if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
+            LOG.error(
+                "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
+                taskId,
+                code,
+                status.getShuffleServerInfo());
+            isFastFail = true;
+            break;
+          }
+        }
+        // todo: if setting multi replica and another replica is succeed to send, no need to resend
+        resendCandidates.addAll(failedBlockStatus);
       }
-
-      // todo: if setting multi replica and another replica is succeed to send, no need to resend
-      resendCandidates.addAll(failedBlockStatus);
     }
 
     if (isFastFail) {
       // release data and allocated memory
       for (Long blockId : failedBlockIds) {
         List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-        Optional<TrackingBlockStatus> blockStatus = failedBlockStatus.stream().findFirst();
+        Optional<TrackingBlockStatus> blockStatus;
+        synchronized (failedTracker) {
+          blockStatus = failedBlockStatus.stream().findFirst();
+        }
+
         if (blockStatus.isPresent()) {
           blockStatus.get().getShuffleBlockInfo().executeCompletionCallback(true);
         }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -567,49 +567,45 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     // to check whether the blocks resent exceed the max resend count.
     for (Long blockId : failedBlockIds) {
       List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-      synchronized (failedTracker) {
-        int retryIndex =
+      int retryIndex =
+          failedBlockStatus.stream()
+              .map(x -> x.getShuffleBlockInfo().getRetryCnt())
+              .max(Comparator.comparing(Integer::valueOf))
+              .get();
+      if (retryIndex >= blockFailSentRetryMaxTimes) {
+        LOG.error(
+            "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
+            taskId,
+            blockFailSentRetryMaxTimes,
             failedBlockStatus.stream()
-                .map(x -> x.getShuffleBlockInfo().getRetryCnt())
-                .max(Comparator.comparing(Integer::valueOf))
-                .get();
-        if (retryIndex >= blockFailSentRetryMaxTimes) {
+                .map(x -> x.getShuffleServerInfo())
+                .collect(Collectors.toSet()));
+        isFastFail = true;
+        break;
+      }
+
+      for (TrackingBlockStatus status : failedBlockStatus) {
+        StatusCode code = status.getStatusCode();
+        if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
           LOG.error(
-              "Partial blocks for taskId: [{}] retry exceeding the max retry times: [{}]. Fast fail! faulty server list: {}",
+              "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
               taskId,
-              blockFailSentRetryMaxTimes,
-              failedBlockStatus.stream()
-                  .map(x -> x.getShuffleServerInfo())
-                  .collect(Collectors.toSet()));
+              code,
+              status.getShuffleServerInfo());
           isFastFail = true;
           break;
         }
-        for (TrackingBlockStatus status : failedBlockStatus) {
-          StatusCode code = status.getStatusCode();
-          if (STATUS_CODE_WITHOUT_BLOCK_RESEND.contains(code)) {
-            LOG.error(
-                "Partial blocks for taskId: [{}] failed on the illegal status code: [{}] without resend on server: {}",
-                taskId,
-                code,
-                status.getShuffleServerInfo());
-            isFastFail = true;
-            break;
-          }
-        }
-        // todo: if setting multi replica and another replica is succeed to send, no need to resend
-        resendCandidates.addAll(failedBlockStatus);
       }
+
+      // todo: if setting multi replica and another replica is succeed to send, no need to resend
+      resendCandidates.addAll(failedBlockStatus);
     }
 
     if (isFastFail) {
       // release data and allocated memory
       for (Long blockId : failedBlockIds) {
         List<TrackingBlockStatus> failedBlockStatus = failedTracker.getFailedBlockStatus(blockId);
-        Optional<TrackingBlockStatus> blockStatus;
-        synchronized (failedTracker) {
-          blockStatus = failedBlockStatus.stream().findFirst();
-        }
-
+        Optional<TrackingBlockStatus> blockStatus = failedBlockStatus.stream().findFirst();
         if (blockStatus.isPresent()) {
           blockStatus.get().getShuffleBlockInfo().executeCompletionCallback(true);
         }

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -90,7 +90,7 @@ public class FailedBlockSendTracker {
                 return l.stream();
               }
             })
-        .map(x -> x.getShuffleServerInfo())
+        .map(TrackingBlockStatus::getShuffleServerInfo)
         .collect(Collectors.toSet());
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleServerInfo;
@@ -83,14 +83,15 @@ public class FailedBlockSendTracker {
   }
 
   public Set<ShuffleServerInfo> getFaultyShuffleServers() {
-    return trackingBlockStatusMap.values().stream()
-        .flatMap(
+    Set<ShuffleServerInfo> shuffleServerInfos = Sets.newHashSet();
+    trackingBlockStatusMap.values().stream()
+        .forEach(
             l -> {
               synchronized (l) {
-                return l.stream();
+                l.stream()
+                    .forEach((status) -> shuffleServerInfos.add(status.getShuffleServerInfo()));
               }
-            })
-        .map(TrackingBlockStatus::getShuffleServerInfo)
-        .collect(Collectors.toSet());
+            });
+    return shuffleServerInfos;
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -49,7 +49,7 @@ public class FailedBlockSendTracker {
       ShuffleServerInfo shuffleServerInfo,
       StatusCode statusCode) {
     trackingBlockStatusMap
-        .computeIfAbsent(shuffleBlockInfo.getBlockId(), s -> Lists.newLinkedList())
+        .computeIfAbsent(shuffleBlockInfo.getBlockId(), s -> Lists.newCopyOnWriteArrayList())
         .add(new TrackingBlockStatus(shuffleBlockInfo, shuffleServerInfo, statusCode));
   }
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -44,7 +44,7 @@ public class FailedBlockSendTracker {
     this.trackingBlockStatusMap = Maps.newConcurrentMap();
   }
 
-  public synchronized void add(
+  public void add(
       ShuffleBlockInfo shuffleBlockInfo,
       ShuffleServerInfo shuffleServerInfo,
       StatusCode statusCode) {
@@ -61,7 +61,7 @@ public class FailedBlockSendTracker {
     trackingBlockStatusMap.remove(blockId);
   }
 
-  public synchronized void clearAndReleaseBlockResources() {
+  public void clearAndReleaseBlockResources() {
     trackingBlockStatusMap.values().stream()
         .flatMap(x -> x.stream())
         .forEach(x -> x.getShuffleBlockInfo().executeCompletionCallback(true));
@@ -76,7 +76,7 @@ public class FailedBlockSendTracker {
     return trackingBlockStatusMap.get(blockId);
   }
 
-  public synchronized Set<ShuffleServerInfo> getFaultyShuffleServers() {
+  public Set<ShuffleServerInfo> getFaultyShuffleServers() {
     return trackingBlockStatusMap.values().stream()
         .flatMap(Collection::stream)
         .map(s -> s.getShuffleServerInfo())

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -44,7 +44,7 @@ public class FailedBlockSendTracker {
     this.trackingBlockStatusMap = Maps.newConcurrentMap();
   }
 
-  public void add(
+  public synchronized void add(
       ShuffleBlockInfo shuffleBlockInfo,
       ShuffleServerInfo shuffleServerInfo,
       StatusCode statusCode) {
@@ -61,7 +61,7 @@ public class FailedBlockSendTracker {
     trackingBlockStatusMap.remove(blockId);
   }
 
-  public void clearAndReleaseBlockResources() {
+  public synchronized void clearAndReleaseBlockResources() {
     trackingBlockStatusMap.values().stream()
         .flatMap(x -> x.stream())
         .forEach(x -> x.getShuffleBlockInfo().executeCompletionCallback(true));
@@ -76,7 +76,7 @@ public class FailedBlockSendTracker {
     return trackingBlockStatusMap.get(blockId);
   }
 
-  public Set<ShuffleServerInfo> getFaultyShuffleServers() {
+  public synchronized Set<ShuffleServerInfo> getFaultyShuffleServers() {
     return trackingBlockStatusMap.values().stream()
         .flatMap(Collection::stream)
         .map(s -> s.getShuffleServerInfo())

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -49,7 +49,7 @@ public class FailedBlockSendTracker {
       ShuffleServerInfo shuffleServerInfo,
       StatusCode statusCode) {
     trackingBlockStatusMap
-        .computeIfAbsent(shuffleBlockInfo.getBlockId(), s -> Lists.newCopyOnWriteArrayList())
+        .computeIfAbsent(shuffleBlockInfo.getBlockId(), s -> Lists.newLinkedList())
         .add(new TrackingBlockStatus(shuffleBlockInfo, shuffleServerInfo, statusCode));
   }
 

--- a/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
@@ -46,25 +46,30 @@ public class FailedBlockSendTrackerTest {
         Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo2);
     ShuffleBlockInfo shuffleBlockInfo2 =
         new ShuffleBlockInfo(0, 0, 2L, 0, 0L, new byte[] {}, shuffleServerInfos2, 0, 0L, 0L);
-    new Thread(() -> {
-      tracker.add(shuffleBlockInfo1, shuffleServerInfo1, StatusCode.INTERNAL_ERROR);
-      tracker.add(shuffleBlockInfo1, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
-      tracker.add(shuffleBlockInfo2, shuffleServerInfo3, StatusCode.INTERNAL_ERROR);
-      tracker.add(shuffleBlockInfo2, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
-    }).start();
+    new Thread(
+            () -> {
+              tracker.add(shuffleBlockInfo1, shuffleServerInfo1, StatusCode.INTERNAL_ERROR);
+              tracker.add(shuffleBlockInfo1, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
+              tracker.add(shuffleBlockInfo2, shuffleServerInfo3, StatusCode.INTERNAL_ERROR);
+              tracker.add(shuffleBlockInfo2, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
+            })
+        .start();
     List<String> expected =
         Lists.newArrayList(
             shuffleServerInfo1.getId(), shuffleServerInfo2.getId(), shuffleServerInfo3.getId());
-    await().atMost(5, TimeUnit.SECONDS).until(() -> {
-      if (tracker.getFailedBlockIds().size() != 2) {
-        return false;
-      }
-      List<String> actual =
-          tracker.getFaultyShuffleServers().stream()
-              .map(ShuffleServerInfo::getId)
-              .sorted()
-              .collect(Collectors.toList());
-      return CollectionUtils.isEqualCollection(expected, actual);
-    });
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              if (tracker.getFailedBlockIds().size() != 2) {
+                return false;
+              }
+              List<String> actual =
+                  tracker.getFaultyShuffleServers().stream()
+                      .map(ShuffleServerInfo::getId)
+                      .sorted()
+                      .collect(Collectors.toList());
+              return CollectionUtils.isEqualCollection(expected, actual);
+            });
   }
 }

--- a/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.jupiter.api.Test;
+
+import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.common.rpc.StatusCode;
+
+import static org.awaitility.Awaitility.await;
+
+public class FailedBlockSendTrackerTest {
+  @Test
+  public void test() throws Exception {
+    FailedBlockSendTracker tracker = new FailedBlockSendTracker();
+    ShuffleServerInfo shuffleServerInfo1 = new ShuffleServerInfo("host1", 19999);
+    ShuffleServerInfo shuffleServerInfo2 = new ShuffleServerInfo("host2", 19999);
+    ShuffleServerInfo shuffleServerInfo3 = new ShuffleServerInfo("host3", 19999);
+    List<ShuffleServerInfo> shuffleServerInfos1 =
+        Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2);
+    ShuffleBlockInfo shuffleBlockInfo1 =
+        new ShuffleBlockInfo(0, 0, 1L, 0, 0L, new byte[] {}, shuffleServerInfos1, 0, 0L, 0L);
+    List<ShuffleServerInfo> shuffleServerInfos2 =
+        Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo2);
+    ShuffleBlockInfo shuffleBlockInfo2 =
+        new ShuffleBlockInfo(0, 0, 2L, 0, 0L, new byte[] {}, shuffleServerInfos2, 0, 0L, 0L);
+    new Thread(() -> {
+      tracker.add(shuffleBlockInfo1, shuffleServerInfo1, StatusCode.INTERNAL_ERROR);
+      tracker.add(shuffleBlockInfo1, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
+      tracker.add(shuffleBlockInfo2, shuffleServerInfo3, StatusCode.INTERNAL_ERROR);
+      tracker.add(shuffleBlockInfo2, shuffleServerInfo2, StatusCode.INTERNAL_ERROR);
+    }).start();
+    List<String> expected =
+        Lists.newArrayList(
+            shuffleServerInfo1.getId(), shuffleServerInfo2.getId(), shuffleServerInfo3.getId());
+    await().atMost(5, TimeUnit.SECONDS).until(() -> {
+      if (tracker.getFailedBlockIds().size() != 2) {
+        return false;
+      }
+      List<String> actual =
+          tracker.getFaultyShuffleServers().stream()
+              .map(ShuffleServerInfo::getId)
+              .sorted()
+              .collect(Collectors.toList());
+      return CollectionUtils.isEqualCollection(expected, actual);
+    });
+  }
+}


### PR DESCRIPTION


<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace LinkedList with CopyOnWriteArrayList to store the sending status

### Why are the changes needed?
Fix: #2090

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI
