### PR TITLE
[#2086] feat(spark): Support cut partition to slices and served by multiply server

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/handle/ShuffleHandleInfo.java
@@ -31,7 +31,8 @@ public interface ShuffleHandleInfo {
 
   /**
    * Get the assignment of available servers for writer to write partitioned blocks to corresponding
-   * shuffleServers. Implementations might return dynamic, up-to-date information here.
+   * shuffleServers. Implementations might return dynamic, up-to-date information here. Returns
+   * partitionId -> [replica1, replica2, ...]
    */
   Map<Integer, List<ShuffleServerInfo>> getAvailablePartitionServersForWriter();
 

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerInterface.java
@@ -86,5 +86,6 @@ public interface RssShuffleManagerInterface {
       int stageId,
       int stageAttemptNumber,
       int shuffleId,
-      Map<Integer, List<ReceivingFailureServer>> partitionToFailureServers);
+      Map<Integer, List<ReceivingFailureServer>> partitionToFailureServers,
+      boolean partitionSplit);
 }

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -267,12 +267,13 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
     RssProtos.ReassignOnBlockSendFailureResponse reply;
     try {
       LOG.info(
-          "Accepted reassign request on block sent failure for shuffleId: {}, stageId: {}, stageAttemptNumber: {} from taskAttemptId: {} on executorId: {}",
+          "Accepted reassign request on block sent failure for shuffleId: {}, stageId: {}, stageAttemptNumber: {} from taskAttemptId: {} on executorId: {} while partition split:{}",
           request.getShuffleId(),
           request.getStageId(),
           request.getStageAttemptNumber(),
           request.getTaskAttemptId(),
-          request.getExecutorId());
+          request.getExecutorId(),
+          request.getPartitionSplit());
       MutableShuffleHandleInfo handle =
           shuffleManager.reassignOnBlockSendFailure(
               request.getStageId(),
@@ -281,7 +282,8 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
               request.getFailurePartitionToServerIdsMap().entrySet().stream()
                   .collect(
                       Collectors.toMap(
-                          Map.Entry::getKey, x -> ReceivingFailureServer.fromProto(x.getValue()))));
+                          Map.Entry::getKey, x -> ReceivingFailureServer.fromProto(x.getValue()))),
+              request.getPartitionSplit());
       code = RssProtos.StatusCode.SUCCESS;
       reply =
           RssProtos.ReassignOnBlockSendFailureResponse.newBuilder()

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfoTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/handle/MutableShuffleHandleInfoTest.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.handle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -141,5 +142,66 @@ public class MutableShuffleHandleInfoTest {
     assertEquals(a, inventory.get(1).get(0).get(0));
     assertEquals(b, inventory.get(1).get(1).get(0));
     assertEquals(c, inventory.get(2).get(0).get(0));
+  }
+
+  @Test
+  public void testUpdateAssignmentOnPartitionSplit() {
+    Map<Integer, List<ShuffleServerInfo>> partitionToServers = new HashMap<>();
+    partitionToServers.put(1, Arrays.asList(createFakeServerInfo("a"), createFakeServerInfo("b")));
+    partitionToServers.put(2, Arrays.asList(createFakeServerInfo("c")));
+
+    MutableShuffleHandleInfo handleInfo =
+        new MutableShuffleHandleInfo(1, partitionToServers, new RemoteStorageInfo(""));
+
+    // case1: update the replacement servers but has existing servers
+    Set<ShuffleServerInfo> updated =
+        handleInfo.updateAssignment(
+            1, "a", Sets.newHashSet(createFakeServerInfo("a"), createFakeServerInfo("d")));
+    assertTrue(updated.stream().findFirst().get().getId().equals("d"));
+
+    // case2: update when having multiple servers
+    Map<Integer, Map<Integer, List<ShuffleServerInfo>>> partitionReplicaAssignedServers =
+        new HashMap<>();
+    List<ShuffleServerInfo> servers =
+        new ArrayList<>(
+            Arrays.asList(
+                createFakeServerInfo("a"),
+                createFakeServerInfo("b"),
+                createFakeServerInfo("c"),
+                createFakeServerInfo("d")));
+    partitionReplicaAssignedServers
+        .computeIfAbsent(1, x -> new HashMap<>())
+        .computeIfAbsent(0, x -> servers);
+    handleInfo =
+        new MutableShuffleHandleInfo(1, new RemoteStorageInfo(""), partitionReplicaAssignedServers);
+
+    Map<Integer, List<ShuffleServerInfo>> availablePartitionServers =
+        handleInfo.getAvailablePartitionServersForWriter();
+    assertEquals("d", availablePartitionServers.get(1).get(0).getHost());
+    Map<Integer, List<ShuffleServerInfo>> assignment = handleInfo.getAllPartitionServersForReader();
+    assertEquals(4, assignment.get(1).size());
+
+    int partitionId = 1;
+
+    handleInfo.getReplacementsForPartition(1, "a");
+    HashSet<ShuffleServerInfo> replacements =
+        Sets.newHashSet(
+            createFakeServerInfo("b"),
+            createFakeServerInfo("d"),
+            createFakeServerInfo("e"),
+            createFakeServerInfo("f"));
+    updated = handleInfo.updateAssignmentOnPartitionSplit(partitionId, "a", replacements);
+    assertEquals(updated, Sets.newHashSet(createFakeServerInfo("e"), createFakeServerInfo("f")));
+
+    Set<String> excludedServers = handleInfo.listExcludedServersForPartition(partitionId);
+    assertEquals(1, excludedServers.size());
+    assertEquals("a", excludedServers.iterator().next());
+    assertEquals(replacements, handleInfo.getReplacementsForPartition(1, "a"));
+    availablePartitionServers = handleInfo.getAvailablePartitionServersForWriter();
+    // The current writer is the last one
+    assertEquals("f", availablePartitionServers.get(1).get(0).getHost());
+    assignment = handleInfo.getAllPartitionServersForReader();
+    // All the servers were selected as writer are available as reader
+    assertEquals(6, assignment.get(1).size());
   }
 }

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/manager/DummyRssShuffleManager.java
@@ -80,7 +80,8 @@ public class DummyRssShuffleManager implements RssShuffleManagerInterface {
       int stageId,
       int stageAttemptNumber,
       int shuffleId,
-      Map<Integer, List<ReceivingFailureServer>> partitionToFailureServers) {
+      Map<Integer, List<ReceivingFailureServer>> partitionToFailureServers,
+      boolean partitionSplit) {
     return null;
   }
 }

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -218,6 +218,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
                             .forEach(
                                 blockId ->
                                     blockIdsSendSuccessTracker.get(blockId).incrementAndGet());
+                        recordNeedSplitPartition(
+                            failedBlockSendTracker, ssi, response.getNeedSplitPartitionIds());
                         if (defectiveServers != null) {
                           defectiveServers.remove(ssi);
                         }
@@ -281,6 +283,16 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         .forEach(block -> blockIdsSendFailTracker.add(block, shuffleServerInfo, statusCode));
   }
 
+  void recordNeedSplitPartition(
+      FailedBlockSendTracker blockIdsSendFailTracker,
+      ShuffleServerInfo shuffleServerInfo,
+      Set<Integer> needSplitPartitions) {
+    if (needSplitPartitions != null) {
+      needSplitPartitions.forEach(
+          partition -> blockIdsSendFailTracker.addNeedSplitPartition(partition, shuffleServerInfo));
+    }
+  }
+
   void genServerToBlocks(
       ShuffleBlockInfo sbi,
       List<ShuffleServerInfo> serverList,
@@ -322,6 +334,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
   }
 
   @Override
+  @VisibleForTesting
   public SendShuffleDataResult sendShuffleData(
       String appId,
       List<ShuffleBlockInfo> shuffleBlockInfoList,

--- a/client/src/main/java/org/apache/uniffle/client/impl/TrackingPartitionStatus.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/TrackingPartitionStatus.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.client.impl;
+
+import org.apache.uniffle.common.ShuffleServerInfo;
+
+public class TrackingPartitionStatus {
+  private int partitionId;
+  private ShuffleServerInfo shuffleServerInfo;
+
+  public TrackingPartitionStatus(int partitionId, ShuffleServerInfo shuffleServerInfo) {
+    this.shuffleServerInfo = shuffleServerInfo;
+    this.partitionId = partitionId;
+  }
+
+  public ShuffleServerInfo getShuffleServerInfo() {
+    return shuffleServerInfo;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+}

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssReassignOnBlockSendFailureRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssReassignOnBlockSendFailureRequest.java
@@ -25,6 +25,7 @@ import org.apache.uniffle.common.ReceivingFailureServer;
 import org.apache.uniffle.proto.RssProtos;
 
 public class RssReassignOnBlockSendFailureRequest {
+  private final boolean partitionSplit;
   private int shuffleId;
   private Map<Integer, List<ReceivingFailureServer>> failurePartitionToServers;
   private String executorId;
@@ -38,13 +39,15 @@ public class RssReassignOnBlockSendFailureRequest {
       String executorId,
       long taskAttemptId,
       int stageId,
-      int stageAttemptNum) {
+      int stageAttemptNum,
+      boolean partitionSplit) {
     this.shuffleId = shuffleId;
     this.failurePartitionToServers = failurePartitionToServers;
     this.executorId = executorId;
     this.taskAttemptId = taskAttemptId;
     this.stageId = stageId;
     this.stageAttemptNumber = stageAttemptNum;
+    this.partitionSplit = partitionSplit;
   }
 
   public static RssProtos.RssReassignOnBlockSendFailureRequest toProto(
@@ -60,6 +63,7 @@ public class RssReassignOnBlockSendFailureRequest {
         .setStageId(request.stageId)
         .setStageAttemptNumber(request.stageAttemptNumber)
         .setTaskAttemptId(request.taskAttemptId)
+        .setPartitionSplit(request.partitionSplit)
         .build();
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/response/RssSendShuffleDataResponse.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/response/RssSendShuffleDataResponse.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.response;
 
 import java.util.List;
+import java.util.Set;
 
 import org.apache.uniffle.common.rpc.StatusCode;
 
@@ -25,6 +26,7 @@ public class RssSendShuffleDataResponse extends ClientResponse {
 
   private List<Long> successBlockIds;
   private List<Long> failedBlockIds;
+  private Set<Integer> needSplitPartitionIds;
 
   public RssSendShuffleDataResponse(StatusCode statusCode) {
     super(statusCode);
@@ -44,5 +46,13 @@ public class RssSendShuffleDataResponse extends ClientResponse {
 
   public void setFailedBlockIds(List<Long> failedBlockIds) {
     this.failedBlockIds = failedBlockIds;
+  }
+
+  public void setNeedSplitPartitionIds(Set<Integer> needSplitPartitionIds) {
+    this.needSplitPartitionIds = needSplitPartitionIds;
+  }
+
+  public Set<Integer> getNeedSplitPartitionIds() {
+    return needSplitPartitionIds;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -64,6 +64,8 @@ message RequireBufferResponse {
   int64 requireBufferId = 1;
   StatusCode status = 2;
   string retMsg = 3;
+  // need split partitions
+  repeated int32 needSplitPartitionIds = 4;
 }
 
 message ShuffleDataBlockSegment {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -671,6 +671,7 @@ message RssReassignOnBlockSendFailureRequest {
   int32 stageId = 4;
   int32 stageAttemptNumber = 5;
   string executorId = 6;
+  optional bool partitionSplit = 7;
 }
 
 message ReceivingFailureServers {

--- a/server/src/main/java/org/apache/uniffle/server/HugePartitionUtils.java
+++ b/server/src/main/java/org/apache/uniffle/server/HugePartitionUtils.java
@@ -147,4 +147,9 @@ public class HugePartitionUtils {
     }
     return false;
   }
+
+  public static boolean hasExceedPartitionSplitLimit(
+      ShuffleBufferManager shuffleBufferManager, long usedPartitionDataSize) {
+    return usedPartitionDataSize > shuffleBufferManager.getHugePartitionSplitLimit();
+  }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -516,6 +516,16 @@ public class ShuffleServerConf extends RssBaseConf {
                   + "will be terminated. This helps to significantly improve the "
                   + "stability of the cluster by preventing partitions from becoming too large.");
 
+  public static final ConfigOption<Long> HUGE_PARTITION_SPLIT_LIMIT =
+      ConfigOptions.key("rss.server.huge-partition.split.limit")
+          .longType()
+          .defaultValue(Long.MAX_VALUE)
+          .withDescription(
+              "This option sets the maximum partition slice size threshold. "
+                  + "If the partition size exceeds this threshold, the rss client will "
+                  + "receive the need split partition list and resend the failed blocks to "
+                  + "new servers through reassign mechanism.");
+
   public static final ConfigOption<Long> SERVER_DECOMMISSION_CHECK_INTERVAL =
       ConfigOptions.key("rss.server.decommission.check.interval")
           .longType()

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.server;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,6 +35,7 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -727,21 +729,24 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       long requireBufferId = -1;
       String responseMessage = "";
       String shuffleDataInfo = "appId[" + appId + "], shuffleId[" + request.getShuffleId() + "]";
+      List<Integer> needSplitPartitionIds = Collections.emptyList();
       try {
         if (StringUtils.isEmpty(appId)) {
           // To be compatible with older client version
           requireBufferId =
               shuffleServer.getShuffleTaskManager().requireBuffer(request.getRequireSize());
         } else {
-          requireBufferId =
+          Pair<Long, List<Integer>> pair =
               shuffleServer
                   .getShuffleTaskManager()
-                  .requireBuffer(
+                  .requireBufferReturnPair(
                       appId,
                       request.getShuffleId(),
                       request.getPartitionIdsList(),
                       request.getPartitionRequireSizesList(),
                       request.getRequireSize());
+          requireBufferId = pair.getLeft();
+          needSplitPartitionIds = pair.getRight();
         }
       } catch (NoBufferException e) {
         responseMessage = e.getMessage();
@@ -775,6 +780,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               .setStatus(status.toProto())
               .setRequireBufferId(requireBufferId)
               .setRetMsg(responseMessage)
+              .addAllNeedSplitPartitionIds(needSplitPartitionIds)
               .build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -81,6 +81,7 @@ public class ShuffleBufferManager {
   // Huge partition vars
   private ReconfigurableConfManager.Reconfigurable<Long> hugePartitionSizeThresholdRef;
   private ReconfigurableConfManager.Reconfigurable<Long> hugePartitionSizeHardLimitRef;
+  private ReconfigurableConfManager.Reconfigurable<Long> hugePartitionSplitLimitRef;
   private long hugePartitionMemoryLimitSize;
   protected AtomicLong preAllocatedSize = new AtomicLong(0L);
   protected AtomicLong inFlushSize = new AtomicLong(0L);
@@ -141,6 +142,8 @@ public class ShuffleBufferManager {
         conf.getReconfigurableConf(ShuffleServerConf.HUGE_PARTITION_SIZE_THRESHOLD);
     this.hugePartitionSizeHardLimitRef =
         conf.getReconfigurableConf(ShuffleServerConf.HUGE_PARTITION_SIZE_HARD_LIMIT);
+    this.hugePartitionSplitLimitRef =
+        conf.getReconfigurableConf(ShuffleServerConf.HUGE_PARTITION_SPLIT_LIMIT);
     this.hugePartitionMemoryLimitSize =
         Math.round(
             capacity * conf.get(ShuffleServerConf.HUGE_PARTITION_MEMORY_USAGE_LIMITATION_RATIO));
@@ -838,5 +841,9 @@ public class ShuffleBufferManager {
 
   public ShuffleBufferType getShuffleBufferType() {
     return shuffleBufferType;
+  }
+
+  public long getHugePartitionSplitLimit() {
+    return hugePartitionSplitLimitRef.getSizeAsBytes();
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support sliced store partition to multiply server.

Limitation:

- Only finished tested the netty mode.

### Why are the changes needed?

Fix: #2086

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Start multiply servers and coordinator on local
- Start a spark standalone env on local
- Start spark-shell and execute `test.scala`

```Console
bin/spark-shell  --master  spark://localhost:7077  --deploy-mode client --conf spark.rss.client.reassign.blockRetryMaxTimes=3 --conf spark.rss.writer.buffer.spill.size=30 --conf spark.rss.client.reassign.enabled=true  --conf spark.shuffle.manager=org.apache.spark.shuffle.RssShuffleManager --conf spark.rss.coordinator.quorum=localhost:19999  --conf spark.rss.storage.type=LOCALFILE --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.rss.test.mode.enable=true --conf spark.rss.client.type=GRPC_NETTY --conf spark.sql.shuffle.partitions=1  -i test.scala
```

- test.scala
```scala
val data = sc.parallelize(Seq(("A", 1), ("B", 2), ("C", 3), ("A", 4), ("B", 5), ("A", 6), ("A", 7),("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7), ("A", 7)));
val result = data.reduceByKey(_ + _);
result.collect().foreach(println);
System.exit(0);
```

<img width="410" alt="image" src="https://github.com/user-attachments/assets/7c72fa3e-cfb5-4361-9875-a82b6aeeedfb">
