### PR TITLE
[#2096] fix(client): Share Netty's memory allocators in gRPC

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
@@ -72,7 +72,8 @@ public class GrpcNettyUtils {
   public static synchronized ByteBufAllocator getSharedPooledByteBufAllocator(
       int pageSize, int maxOrder, int smallCacheSize) {
     if (allocator == null) {
-      allocator = GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
+      allocator =
+          GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
     }
     return allocator;
   }

--- a/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
@@ -72,8 +72,7 @@ public class GrpcNettyUtils {
   public static synchronized ByteBufAllocator getSharedPooledByteBufAllocator(
       int pageSize, int maxOrder, int smallCacheSize) {
     if (allocator == null) {
-      allocator =
-          GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
+      allocator = createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
     }
     return allocator;
   }

--- a/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/GrpcNettyUtils.java
@@ -17,10 +17,14 @@
 
 package org.apache.uniffle.common.util;
 
+import io.grpc.netty.shaded.io.netty.buffer.ByteBufAllocator;
 import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
 import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
 
 public class GrpcNettyUtils {
+
+  private static volatile PooledByteBufAllocator allocator;
+
   public static PooledByteBufAllocator createPooledByteBufAllocator(
       boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
     return createPooledByteBufAllocator(
@@ -63,5 +67,13 @@ public class GrpcNettyUtils {
       boolean preferDirect, int numCores, int pageSize, int maxOrder, int smallCacheSize) {
     return createPooledByteBufAllocator(
         preferDirect, true, numCores, pageSize, maxOrder, smallCacheSize, -1);
+  }
+
+  public static synchronized ByteBufAllocator getSharedPooledByteBufAllocator(
+      int pageSize, int maxOrder, int smallCacheSize) {
+    if (allocator == null) {
+      allocator = GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
+    }
+    return allocator;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
@@ -37,7 +37,7 @@ public abstract class GrpcClient {
   protected boolean usePlaintext;
   protected int maxRetryAttempts;
   protected ManagedChannel channel;
-  protected static PooledByteBufAllocator allocator;
+  private static PooledByteBufAllocator allocator;
 
   protected GrpcClient(String host, int port, int maxRetryAttempts, boolean usePlaintext) {
     this(host, port, maxRetryAttempts, usePlaintext, 0, 0, 0);
@@ -77,7 +77,7 @@ public abstract class GrpcClient {
     this.channel = channel;
   }
 
-  protected static synchronized ByteBufAllocator getByteBufAllocator(
+  private static synchronized ByteBufAllocator getByteBufAllocator(
       int pageSize, int maxOrder, int smallCacheSize) {
     if (allocator == null) {
       allocator =

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
@@ -59,8 +59,7 @@ public abstract class GrpcClient {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port)
             .withOption(
-                ChannelOption.ALLOCATOR,
-                getByteBufAllocator(pageSize, maxOrder, smallCacheSize));
+                ChannelOption.ALLOCATOR, getByteBufAllocator(pageSize, maxOrder, smallCacheSize));
 
     if (usePlaintext) {
       channelBuilder.usePlaintext();
@@ -81,7 +80,8 @@ public abstract class GrpcClient {
   protected static synchronized ByteBufAllocator getByteBufAllocator(
       int pageSize, int maxOrder, int smallCacheSize) {
     if (allocator == null) {
-      allocator = GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
+      allocator =
+          GrpcNettyUtils.createPooledByteBufAllocator(true, 0, pageSize, maxOrder, smallCacheSize);
     }
     return allocator;
   }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/GrpcClient.java
@@ -21,10 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
-import io.grpc.netty.shaded.io.netty.buffer.ByteBufAllocator;
-import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
 import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
-import org.apache.uniffle.common.util.NettyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +55,8 @@ public abstract class GrpcClient {
 
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port)
-            .withOption(ChannelOption.ALLOCATOR,
+            .withOption(
+                ChannelOption.ALLOCATOR,
                 GrpcNettyUtils.getSharedPooledByteBufAllocator(pageSize, maxOrder, smallCacheSize));
 
     if (usePlaintext) {

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -144,9 +144,10 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         port,
         RssClientConf.RPC_MAX_ATTEMPTS.defaultValue(),
         RssClientConf.RPC_TIMEOUT_MS.defaultValue(),
-        RssClientConf.RPC_NETTY_PAGE_SIZE.defaultValue(),
-        RssClientConf.RPC_NETTY_MAX_ORDER.defaultValue(),
-        RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE.defaultValue());
+        true,
+        0,
+        0,
+        0);
   }
 
   public ShuffleServerGrpcClient(RssConf rssConf, String host, int port) {
@@ -159,26 +160,10 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         rssConf == null
             ? RssClientConf.RPC_TIMEOUT_MS.defaultValue()
             : rssConf.getLong(RssClientConf.RPC_TIMEOUT_MS),
-        rssConf == null
-            ? RssClientConf.RPC_NETTY_PAGE_SIZE.defaultValue()
-            : rssConf.getInteger(RssClientConf.RPC_NETTY_PAGE_SIZE),
-        rssConf == null
-            ? RssClientConf.RPC_NETTY_MAX_ORDER.defaultValue()
-            : rssConf.getInteger(RssClientConf.RPC_NETTY_MAX_ORDER),
-        rssConf == null
-            ? RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE.defaultValue()
-            : rssConf.getInteger(RssClientConf.RPC_NETTY_SMALL_CACHE_SIZE));
-  }
-
-  public ShuffleServerGrpcClient(
-      String host,
-      int port,
-      int maxRetryAttempts,
-      long rpcTimeoutMs,
-      int pageSize,
-      int maxOrder,
-      int smallCacheSize) {
-    this(host, port, maxRetryAttempts, rpcTimeoutMs, true, pageSize, maxOrder, smallCacheSize);
+        true,
+        0,
+        0,
+        0);
   }
 
   public ShuffleServerGrpcClient(

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -101,27 +101,10 @@ public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {
       int pageSize,
       int maxOrder,
       int smallCacheSize) {
-    super(host, grpcPort, maxRetryAttempts, rpcTimeoutMs, pageSize, maxOrder, smallCacheSize);
+    super(host, grpcPort, maxRetryAttempts, rpcTimeoutMs, true, pageSize, maxOrder, smallCacheSize);
     this.nettyPort = nettyPort;
     TransportContext transportContext = new TransportContext(new TransportConf(rssConf));
     this.clientFactory = new TransportClientFactory(transportContext);
-  }
-
-  @Override
-  protected ByteBufAllocator createByteBufAllocator(
-      int pageSize, int maxOrder, int smallCacheSize) {
-    LOG.info(
-        "ShuffleServerGrpcNettyClient is initialized - host:{}, gRPC port:{}, netty port:{}, maxRetryAttempts:{}, usePlaintext:{}, pageSize:{}, maxOrder:{}, smallCacheSize={}",
-        host,
-        port,
-        nettyPort,
-        maxRetryAttempts,
-        usePlaintext,
-        pageSize,
-        maxOrder,
-        smallCacheSize);
-    return GrpcNettyUtils.createPooledByteBufAllocatorWithSmallCacheOnly(
-        true, 0, pageSize, maxOrder, smallCacheSize);
   }
 
   @Override

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcNettyClient.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.grpc.netty.shaded.io.netty.buffer.ByteBufAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,6 @@ import org.apache.uniffle.common.netty.protocol.GetMemoryShuffleDataResponse;
 import org.apache.uniffle.common.netty.protocol.RpcResponse;
 import org.apache.uniffle.common.netty.protocol.SendShuffleDataRequest;
 import org.apache.uniffle.common.rpc.StatusCode;
-import org.apache.uniffle.common.util.GrpcNettyUtils;
 import org.apache.uniffle.common.util.RetryUtils;
 
 public class ShuffleServerGrpcNettyClient extends ShuffleServerGrpcClient {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use a static allocator for GrpcClient

### Why are the changes needed?

Fix: #2096

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested in real cluster.
