### PR TITLE
[Bug] Fixed the UT null pointer of RpcClientRetryTest.

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RpcClientRetryTest.java
@@ -84,6 +84,7 @@ public class RpcClientRetryTest extends ShuffleReadWriteBase {
     shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 5.0);
     shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 15.0);
     shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 600L);
+    shuffleServerConf.set(ShuffleServerConf.SINGLE_BUFFER_FLUSH_BLOCKS_NUM_THRESHOLD, 1);
     return new MockedShuffleServer(shuffleServerConf);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In unit tests for RpcClientRetryTest, compiling a long null pointer error.

### Why are the changes needed?

Fix: #2101 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.
