### PR TITLE
[#2103] fix(server): Potential bytebuf offset race condition when flushing and getting data

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/ByteBufUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/ByteBufUtils.java
@@ -80,7 +80,8 @@ public class ByteBufUtils {
     return from.retain().readSlice(length);
   }
 
-  public static final byte[] readBytes(ByteBuf buf) {
+  public static final byte[] readBytes(ByteBuf byteBuf) {
+    ByteBuf buf = byteBuf.duplicate();
     byte[] bytes = new byte[buf.readableBytes()];
     buf.readBytes(bytes);
     buf.resetReaderIndex();

--- a/common/src/main/java/org/apache/uniffle/common/util/ByteBufUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/ByteBufUtils.java
@@ -84,7 +84,6 @@ public class ByteBufUtils {
     ByteBuf buf = byteBuf.duplicate();
     byte[] bytes = new byte[buf.readableBytes()];
     buf.readBytes(bytes);
-    buf.resetReaderIndex();
     return bytes;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When flush block and getInMemoryShuffleData occur together, may cause data reading errors. Because there may be two threads reading data at the same time, and the readIndex of ByteBuf will be inconsistent. So we should use duplicated when read bytes from ByteBuf.

### Why are the changes needed?

Fix: #2103 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

unit test.