### PR TITLE
[#2117] feat(server): Introduce bufferPool related metrics(block/buffer/shuffle count)

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/metrics/MetricsManager.java
+++ b/common/src/main/java/org/apache/uniffle/common/metrics/MetricsManager.java
@@ -85,6 +85,11 @@ public class MetricsManager {
   }
 
   public <T extends Number> void addLabeledGauge(String name, Supplier<T> supplier) {
+    addLabeledCacheGauge(name, supplier, 0);
+  }
+
+  public <T extends Number> void addLabeledCacheGauge(
+      String name, Supplier<T> supplier, long updateInterval) {
     supplierGaugeMap.computeIfAbsent(
         name,
         metricName ->
@@ -93,7 +98,8 @@ public class MetricsManager {
                     "Gauge " + name,
                     supplier,
                     this.defaultLabelNames,
-                    this.defaultLabelValues)
+                    this.defaultLabelValues,
+                    updateInterval)
                 .register(collectorRegistry));
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -159,6 +159,10 @@ public class ShuffleServerMetrics {
 
   public static final String REQUIRE_BUFFER_COUNT = "require_buffer_count";
 
+  public static final String BLOCK_COUNT_IN_BUFFER_POOL = "block_count_in_buffer_pool";
+  public static final String BUFFER_COUNT_IN_BUFFER_POOL = "buffer_count_in_buffer_pool";
+  public static final String SHUFFLE_COUNT_IN_BUFFER_POOL = "shuffle_count_in_buffer_pool";
+
   public static Counter.Child counterTotalAppNum;
   public static Counter.Child counterTotalAppWithHugePartitionNum;
   public static Counter.Child counterTotalPartitionNum;
@@ -517,5 +521,13 @@ public class ShuffleServerMetrics {
 
   public static <T extends Number> void addLabeledGauge(String name, Supplier<T> supplier) {
     metricsManager.addLabeledGauge(name, supplier);
+  }
+
+  public static <T extends Number> void addLabeledCacheGauge(
+      String name, Supplier<T> supplier, long updateInterval) {
+    if (!isRegister) {
+      return;
+    }
+    metricsManager.addLabeledCacheGauge(name, supplier, updateInterval);
   }
 }

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerMetricsTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerMetricsTest.java
@@ -55,6 +55,7 @@ public class ShuffleServerMetricsTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
+    ShuffleServerMetrics.clear();
     ShuffleServerConf ssc = new ShuffleServerConf();
     ssc.set(ShuffleServerConf.JETTY_HTTP_PORT, 12345);
     ssc.set(ShuffleServerConf.JETTY_CORE_POOL_SIZE, 128);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Introduce block count in buffer pool metrics.

### Why are the changes needed?

Fix: #2117

### Does this PR introduce _any_ user-facing change?

Yes. `block_count_in_buffer_pool` metrics introduced.

- "block_count_in_buffer_pool"
- "buffer_count_in_buffer_pool"
- "shuffle_count_in_buffer_pool"

### How was this patch tested?

By dashboard server metrics popup page.
