### PR TITLE
[MINOR] improve(common/server/coordinator): Display the port in use port

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/web/JettyServer.java
@@ -167,7 +167,7 @@ public class JettyServer {
     try {
       server.start();
     } catch (BindException e) {
-      ExitUtils.terminate(1, "Fail to start jetty http server", e, LOG);
+      ExitUtils.terminate(1, "Fail to start jetty http server, port is " + httpPort, e, LOG);
     }
     LOG.info("Jetty http server started, listening on port {}", httpPort);
   }

--- a/common/src/test/java/org/apache/uniffle/common/web/JettyServerTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/web/JettyServerTest.java
@@ -86,7 +86,7 @@ public class JettyServerTest {
     try {
       jettyServer2.start();
     } catch (Exception e) {
-      assertEquals(expectMessage, e.getMessage());
+      assertTrue(e.getMessage().startsWith(expectMessage));
       assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
 

--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/CoordinatorServerTest.java
@@ -23,6 +23,7 @@ import org.apache.uniffle.common.util.ExitUtils;
 import org.apache.uniffle.common.util.ExitUtils.ExitException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoordinatorServerTest {
 
@@ -43,7 +44,7 @@ public class CoordinatorServerTest {
     try {
       cs2.start();
     } catch (Exception e) {
-      assertEquals(expectMessage, e.getMessage());
+      assertTrue(e.getMessage().startsWith(expectMessage));
       assertEquals(expectStatus, ((ExitException) e).getStatus());
     } finally {
       // Always call stopServer after new CoordinatorServer to shut down ExecutorService

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerTest.java
@@ -38,6 +38,7 @@ import org.apache.uniffle.storage.util.StorageType;
 import static org.apache.uniffle.server.ShuffleServerConf.SERVER_DECOMMISSION_CHECK_INTERVAL;
 import static org.apache.uniffle.server.ShuffleServerConf.SERVER_DECOMMISSION_SHUTDOWN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerTest {
@@ -56,7 +57,7 @@ public class ShuffleServerTest {
     try {
       ss2.start();
     } catch (Exception e) {
-      assertEquals(expectMessage, e.getMessage());
+      assertTrue(e.getMessage().startsWith(expectMessage));
       assertEquals(expectStatus, ((ExitException) e).getStatus());
     }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Display the port while in use

### Why are the changes needed?

Help to find the in use port and its process.

### Does this PR introduce _any_ user-facing change?

```
16:29:02.179 [main] ERROR org.apache.uniffle.common.web.JettyServer - Terminating with exit status 1: Fail to start jetty http server, port is 9528
java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method) ~[?:1.8.0_251]
	at sun.nio.ch.Net.bind(Net.java:433) ~[?:1.8.0_251]
	at sun.nio.ch.Net.bind(Net.java:425) ~[?:1.8.0_251]
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223) ~[?:1.8.0_251]
```

### How was this patch tested?

UTs.