### PR TITLE
[MINOR] Enlarge the app/server table height in the application page

### DIFF
--- a/dashboard/src/main/webapp/src/mock/nodelistpage.js
+++ b/dashboard/src/main/webapp/src/mock/nodelistpage.js
@@ -150,7 +150,137 @@ Mock.mock(/\/server\/nodes\?status=active/, 'get', function (options) {
         nettyPort: 29997,
         jettyPort: 29998,
         totalMemory: 42949672960
-      }
+      },
+      {
+        id: '192.168.1.6-29999-29997',
+        ip: '192.168.1.6',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.7-29999-29997',
+        ip: '192.168.1.7',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.8-29999-29997',
+        ip: '192.168.1.8',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.9-29999-29997',
+        ip: '192.168.1.9',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
+      {
+        id: '192.168.1.10-29999-29997',
+        ip: '192.168.1.10',
+        grpcPort: 29999,
+        usedMemory: 0,
+        preAllocatedMemory: 0,
+        availableMemory: 42949672960,
+        eventNumInFlush: 0,
+        registrationTime: 1722057271192,
+        timestamp: 1722404451189,
+        tags: ['GRPC_NETTY', 'ss_v5'],
+        status: 'ACTIVE',
+        storageInfo: {
+          '/dev/sdd1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          },
+          '/dev/sdc1': {
+            type: 'HDD',
+            status: 'NORMAL'
+          }
+        },
+        nettyPort: 29997,
+        jettyPort: 29998,
+        totalMemory: 42949672960
+      },
     ],
     errMsg: 'success'
   }

--- a/dashboard/src/main/webapp/src/mock/shuffleserverpage.js
+++ b/dashboard/src/main/webapp/src/mock/shuffleserverpage.js
@@ -21,7 +21,7 @@ Mock.mock(/\/server\/nodes\/summary/, 'get', function (options) {
   return {
     code: 0,
     data: {
-      ACTIVE: 5,
+      ACTIVE: 10,
       DECOMMISSIONED: 1,
       DECOMMISSIONING: 1,
       EXCLUDED: 19,

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -58,7 +58,7 @@
     <div>
       <el-table
         :data="pageData.appInfoData"
-        height="250"
+        height="650"
         style="width: 100%"
         :default-sort="sortApp"
         @sort-change="sortAppChangeEvent"

--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -58,7 +58,7 @@
     <div>
       <el-table
         :data="pageData.appInfoData"
-        height="650"
+        height="700"
         style="width: 100%"
         :default-sort="sortApp"
         @sort-change="sortAppChangeEvent"

--- a/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
+++ b/dashboard/src/main/webapp/src/pages/serverstatus/NodeListPage.vue
@@ -19,7 +19,7 @@
   <div>
     <el-table
       :data="listPageData.tableData"
-      height="550"
+      height="800"
       style="width: 100%"
       :default-sort="sortColumn"
       @sort-change="sortChangeEvent"


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Enlarge the app table and server table height in the application page

### Why are the changes needed?

The existing height is too too small that we can only view 2 application info.

<img width="2349" alt="image" src="https://github.com/user-attachments/assets/0d60ab13-0ac3-4e3f-bc8f-95a139ad1a1f">

<img width="662" alt="image" src="https://github.com/user-attachments/assets/f5a62958-d0e6-48f9-b072-5069d8e6a879">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested local. 

<img width="1565" alt="image" src="https://github.com/user-attachments/assets/e99575fc-5623-4df6-8b41-0f38f44b8239">

<img width="2401" alt="image" src="https://github.com/user-attachments/assets/d30ba5dd-45dc-4f67-b50f-27912d9cbd3c">



