### PR TITLE
[#2119] fix(server): Duplicate blockId causes shuffle Server network to be full.

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -17,8 +17,8 @@
 
 package org.apache.uniffle.server.buffer;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -53,7 +53,7 @@ public interface ShuffleBuffer {
   long getSize();
 
   /** Only for test */
-  List<ShufflePartitionedBlock> getBlocks();
+  Set<ShufflePartitionedBlock> getBlocks();
 
   int getBlockCount();
 
@@ -62,5 +62,5 @@ public interface ShuffleBuffer {
   void clearInFlushBuffer(long eventId);
 
   @VisibleForTesting
-  Map<Long, List<ShufflePartitionedBlock>> getInFlushBlockMap();
+  Map<Long, Set<ShufflePartitionedBlock>> getInFlushBlockMap();
 }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -17,11 +17,12 @@
 
 package org.apache.uniffle.server.buffer;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Supplier;
@@ -101,8 +102,8 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   }
 
   @Override
-  public List<ShufflePartitionedBlock> getBlocks() {
-    return new LinkedList<>(blocksMap.values());
+  public Set<ShufflePartitionedBlock> getBlocks() {
+    return new LinkedHashSet<>(blocksMap.values());
   }
 
   @Override
@@ -139,9 +140,10 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   }
 
   @Override
-  public Map<Long, List<ShufflePartitionedBlock>> getInFlushBlockMap() {
+  public Map<Long, Set<ShufflePartitionedBlock>> getInFlushBlockMap() {
     return inFlushBlockMap.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue().values())));
+        .collect(
+            Collectors.toMap(Map.Entry::getKey, e -> new LinkedHashSet<>(e.getValue().values())));
   }
 
   @Override

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleTaskManagerTest.java
@@ -634,12 +634,12 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     shuffleTaskManager.refreshAppId("clearTest1");
     shuffleTaskManager.refreshAppId("clearTest2");
     assertEquals(2, shuffleTaskManager.getAppIds().size());
-    ShufflePartitionedData partitionedData0 = createPartitionedData(1, 1, 35);
 
     // keep refresh status of application "clearTest1"
     int retry = 0;
     while (retry < 10) {
       Thread.sleep(1000);
+      ShufflePartitionedData partitionedData0 = createPartitionedData(1, 1, 35);
       shuffleTaskManager.cacheShuffleData("clearTest1", shuffleId, false, partitionedData0);
       shuffleTaskManager.updateCachedBlockIds(
           "clearTest1", shuffleId, partitionedData0.getBlockList());
@@ -650,7 +650,7 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     // application "clearTest2" was removed according to rss.server.app.expired.withoutHeartbeat
     assertEquals(Sets.newHashSet("clearTest1"), shuffleTaskManager.getAppIds());
     assertEquals(
-        1, shuffleTaskManager.getCachedBlockIds("clearTest1", shuffleId).getLongCardinality());
+        10, shuffleTaskManager.getCachedBlockIds("clearTest1", shuffleId).getLongCardinality());
 
     // register again
     shuffleTaskManager.registerShuffle(
@@ -1008,12 +1008,11 @@ public class ShuffleTaskManagerTest extends HadoopTestBase {
     shuffleTaskManager.refreshAppId(appId);
     assertEquals(1, shuffleTaskManager.getAppIds().size());
 
-    ShufflePartitionedData shuffleData = createPartitionedData(1, 1, 48);
-
     // make sure shuffle data flush to disk
     int retry = 0;
     while (retry < 5) {
       Thread.sleep(1000);
+      ShufflePartitionedData shuffleData = createPartitionedData(1, 1, 48);
       shuffleTaskManager.cacheShuffleData(appId, shuffleId, false, shuffleData);
       shuffleTaskManager.updateCachedBlockIds(appId, shuffleId, shuffleData.getBlockList());
       shuffleTaskManager.refreshAppId(appId);

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.server.buffer;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -207,7 +208,8 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     // First read from the cached data
     ShuffleDataResult sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 16);
     byte[] expectedData = getExpectedData(spd1, spd2);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 0, 2);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 0, 2);
     assertArrayEquals(expectedData, sdr.getData());
 
     // Second read after flushed
@@ -217,7 +219,10 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     sdr = shuffleBuffer.getShuffleData(lastBlockId, 16);
     expectedData = getExpectedData(spd3);
     compareBufferSegment(
-        shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()), sdr.getBufferSegments(), 2, 1);
+        new LinkedList<>(shuffleBuffer.getInFlushBlockMap().get(event1.getEventId())),
+        sdr.getBufferSegments(),
+        2,
+        1);
     assertArrayEquals(expectedData, sdr.getData());
 
     assertEquals(0, event1.getShuffleBlocks().get(0).getTaskAttemptId());
@@ -225,11 +230,20 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertEquals(2, event1.getShuffleBlocks().get(2).getTaskAttemptId());
 
     assertEquals(
-        1, shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()).get(0).getTaskAttemptId());
+        1,
+        new LinkedList<>(shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()))
+            .get(0)
+            .getTaskAttemptId());
     assertEquals(
-        0, shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()).get(1).getTaskAttemptId());
+        0,
+        new LinkedList<>(shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()))
+            .get(1)
+            .getTaskAttemptId());
     assertEquals(
-        2, shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()).get(2).getTaskAttemptId());
+        2,
+        new LinkedList<>(shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()))
+            .get(2)
+            .getTaskAttemptId());
   }
 
   @Test
@@ -242,7 +256,8 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     shuffleBuffer.append(spd2);
     byte[] expectedData = getExpectedData(spd1, spd2);
     ShuffleDataResult sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 40);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 0, 2);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 0, 2);
     assertArrayEquals(expectedData, sdr.getData());
 
     // case2: cached data only, blockId = -1, readBufferSize = buffer size
@@ -253,7 +268,8 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     shuffleBuffer.append(spd2);
     expectedData = getExpectedData(spd1, spd2);
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 40);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 0, 2);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 0, 2);
     assertArrayEquals(expectedData, sdr.getData());
 
     // case3-1: cached data only, blockId = -1, readBufferSize < buffer size
@@ -264,7 +280,8 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     shuffleBuffer.append(spd2);
     expectedData = getExpectedData(spd1, spd2);
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 40);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 0, 2);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 0, 2);
     assertArrayEquals(expectedData, sdr.getData());
 
     // case3-2: cached data only, blockId = -1, readBufferSize < buffer size
@@ -277,14 +294,16 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     shuffleBuffer.append(spd3);
     expectedData = getExpectedData(spd1, spd2);
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 25);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 0, 2);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 0, 2);
     assertArrayEquals(expectedData, sdr.getData());
 
     // case4: cached data only, blockId != -1 && exist, readBufferSize < buffer size
     long lastBlockId = spd2.getBlockList()[0].getBlockId();
     sdr = shuffleBuffer.getShuffleData(lastBlockId, 25);
     expectedData = getExpectedData(spd3);
-    compareBufferSegment(shuffleBuffer.getBlocks(), sdr.getBufferSegments(), 2, 1);
+    compareBufferSegment(
+        new LinkedList<>(shuffleBuffer.getBlocks()), sdr.getBufferSegments(), 2, 1);
     assertArrayEquals(expectedData, sdr.getData());
 
     // case5: flush data only, blockId = -1, readBufferSize < buffer size
@@ -297,7 +316,10 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertEquals(0, shuffleBuffer.getBlocks().size());
     sdr = shuffleBuffer.getShuffleData(Constants.INVALID_BLOCK_ID, 20);
     compareBufferSegment(
-        shuffleBuffer.getInFlushBlockMap().get(event1.getEventId()), sdr.getBufferSegments(), 0, 2);
+        new LinkedList<>(shuffleBuffer.getInFlushBlockMap().get(event1.getEventId())),
+        sdr.getBufferSegments(),
+        0,
+        2);
     expectedData = getExpectedData(spd1, spd2);
     assertArrayEquals(expectedData, sdr.getData());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

Fixed block duplication bug.

(Please clarify why the changes are needed. For instance,

Fix: #2119 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT.
