### PR TITLE
[#2130] fix(server): Potential huge partition limit invalid when flushing is slow

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/HugePartitionUtils.java
+++ b/server/src/main/java/org/apache/uniffle/server/HugePartitionUtils.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.exception.ExceedHugePartitionHardLimitException;
+import org.apache.uniffle.server.buffer.ShuffleBuffer;
 import org.apache.uniffle.server.buffer.ShuffleBufferManager;
 
 /** Huge partition utils. */
@@ -130,11 +131,9 @@ public class HugePartitionUtils {
       int partitionId,
       long usedPartitionDataSize) {
     if (usedPartitionDataSize > shuffleBufferManager.getHugePartitionSizeThreshold()) {
-      long memoryUsed =
-          shuffleBufferManager
-              .getShuffleBufferEntry(appId, shuffleId, partitionId)
-              .getValue()
-              .getSize();
+      ShuffleBuffer buffer =
+          shuffleBufferManager.getShuffleBufferEntry(appId, shuffleId, partitionId).getValue();
+      long memoryUsed = buffer.getInFlushSize() + buffer.getSize();
       if (memoryUsed > shuffleBufferManager.getHugePartitionMemoryLimitSize()) {
         LOG.warn(
             "AppId: {}, shuffleId: {}, partitionId: {}, memory used: {}, "

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -93,7 +93,7 @@ import static org.apache.uniffle.server.ShuffleServerMetrics.REQUIRE_BUFFER_COUN
 public class ShuffleTaskManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleTaskManager.class);
-  private final ShuffleFlushManager shuffleFlushManager;
+  private ShuffleFlushManager shuffleFlushManager;
   private final ScheduledExecutorService scheduledExecutorService;
   private final ScheduledExecutorService expiredAppCleanupExecutorService;
   private final ScheduledExecutorService leakShuffleDataCheckExecutorService;
@@ -1032,5 +1032,11 @@ public class ShuffleTaskManager {
   @VisibleForTesting
   protected void setStorageManager(StorageManager storageManager) {
     this.storageManager = storageManager;
+  }
+
+  // only for tests
+  @VisibleForTesting
+  protected void setShuffleFlushManager(ShuffleFlushManager flushManager) {
+    this.shuffleFlushManager = flushManager;
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/AbstractShuffleBuffer.java
@@ -19,6 +19,7 @@ package org.apache.uniffle.server.buffer;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import com.google.common.collect.Lists;
@@ -40,6 +41,8 @@ public abstract class AbstractShuffleBuffer implements ShuffleBuffer {
   protected static final Logger LOG = LoggerFactory.getLogger(AbstractShuffleBuffer.class);
 
   protected long size;
+
+  protected AtomicLong inFlushSize = new AtomicLong();
 
   public AbstractShuffleBuffer() {
     this.size = 0;
@@ -177,5 +180,10 @@ public abstract class AbstractShuffleBuffer implements ShuffleBuffer {
         break;
       }
     }
+  }
+
+  @Override
+  public long getInFlushSize() {
+    return inFlushSize.get();
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -52,6 +52,8 @@ public interface ShuffleBuffer {
 
   long getSize();
 
+  long getInFlushSize();
+
   /** Only for test */
   List<ShufflePartitionedBlock> getBlocks();
 

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferManager.java
@@ -757,4 +757,9 @@ public class ShuffleBufferManager {
   public void setUsedMemory(long usedMemory) {
     this.usedMemory.set(usedMemory);
   }
+
+  @VisibleForTesting
+  public void setBufferFlushThreshold(long bufferFlushThreshold) {
+    this.bufferFlushThreshold = bufferFlushThreshold;
+  }
 }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -92,9 +92,11 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
         () -> {
           this.clearInFlushBuffer(event.getEventId());
           spBlocks.forEach(spb -> spb.getData().release());
+          inFlushSize.addAndGet(-event.getSize());
         });
     inFlushBlockMap.put(eventId, inFlushedQueueBlocks);
     blocks.clear();
+    inFlushSize.addAndGet(size);
     size = 0;
     return event;
   }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -92,10 +92,12 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
         () -> {
           this.clearInFlushBuffer(event.getEventId());
           spBlocks.forEach(spb -> spb.getData().release());
+          inFlushSize.addAndGet(-event.getSize());
         });
     inFlushBlockMap.put(eventId, blocksMap);
     blocksMap = newConcurrentSkipListMap();
     blockCount = 0;
+    inFlushSize.addAndGet(size);
     size = 0;
     return event;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix potential huge partition limit invalid when flushing is slow

### Why are the changes needed?

Fix: #2130

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests
