### PR TITLE
[MINOR] improve(server): Log more before server remove resource

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/PartitionInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/PartitionInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common;
+
+public class PartitionInfo {
+  private int id;
+  private int shuffleId;
+  private long size;
+  private long blockCount;
+
+  public long getSize() {
+    return size;
+  }
+
+  public long getBlockCount() {
+    return blockCount;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public void update(int id, int shuffleId, long size, long blockCount) {
+    this.id = id;
+    this.shuffleId = shuffleId;
+    this.size = size;
+    this.blockCount = blockCount;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[id=%s, shuffleId=%s, size=%s, blockCount=%s]", id, shuffleId, size, blockCount);
+  }
+
+  public boolean isCurrentPartition(int shuffleId, int partitionId) {
+    return this.shuffleId == shuffleId && this.id == partitionId;
+  }
+
+  public void setBlockCount(long blockCount) {
+    this.blockCount = blockCount;
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -714,6 +714,11 @@ public class ShuffleServerConf extends RssBaseConf {
           .stringType()
           .defaultValue(null)
           .withDescription("The jars path for class loader when merge");
+  public static final ConfigOption<Boolean> SERVER_LOG_APP_DETAIL_WHILE_REMOVE_ENABLED =
+      ConfigOptions.key("rss.server.log.app.detail.while.remove.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to enable app detail log");
 
   public ShuffleServerConf() {}
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Log more before server remove resource

### Why are the changes needed?

Clearly and easily to view the job partitons blocks info, help to find the biggest partition.

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

```
[2024-09-20 23:31:36.211] [clearResourceThread] [INFO] ShuffleTaskManager - Remove app info: appId: app-20240920233127-0046_1726846285810 shuffleId: 0 contains partition/block: 3/19
The maxSizePartitionInfo: [id=1, shuffleId=0, size=624, blockCount=16]
```

```
[2024-09-21 11:06:40.011] [clearResourceThread] [INFO] ShuffleTaskManager - Remove app info: appId: application_1703049085550_21177982_1726887839406 
 shuffleId: 0 contains partition/block: 1/193
 shuffleId: 2 contains partition/block: 1/4
The maxSizePartitionInfo: [id=0, shuffleId=0, size=707108250, blockCount=193]

[2024-09-21 11:06:39.979] [clearResourceThread] [INFO] ShuffleTaskManager - Remove app info: appId: application_1703049085550_21177982_1726887839406
 shuffleId: 0 contains partition/block: 1/51
 shuffleId: 1 contains partition/block: 1/8
The maxSizePartitionInfo: [id=0, shuffleId=0, size=162936203, blockCount=51]
```
