### PR TITLE
[#2105] fix(server): Fix memory leak caused by duplicate blocks when using ShuffleBufferWithSkipList.

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -62,9 +62,13 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
 
     synchronized (this) {
       for (ShufflePartitionedBlock block : data.getBlockList()) {
-        blocksMap.put(block.getBlockId(), block);
-        blockCount++;
-        size += block.getSize();
+        if (!blocksMap.containsKey(block.getBlockId())) {
+          blocksMap.put(block.getBlockId(), block);
+          blockCount++;
+          size += block.getSize();
+        } else {
+          block.getData().release();
+        }
       }
       this.size += size;
     }

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -62,6 +62,8 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
 
     synchronized (this) {
       for (ShufflePartitionedBlock block : data.getBlockList()) {
+        // If sendShuffleData retried, we may receive duplicate block. The duplicate
+        // block would gc without release. Here we must release the duplicated block.
         if (!blocksMap.containsKey(block.getBlockId())) {
           blocksMap.put(block.getBlockId(), block);
           blockCount++;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release duplicate block.  #2016 solve this problem in client side. I think sendShuffeData may be retried, duplicated block still be reproduce.

### Why are the changes needed?

Fix: #2105

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

test in cluster.