### PR TITLE
[MINOR] test: Fix flaky test about ShuffleServerMetricsTest#testStorageCounter

### DIFF
--- a/server/src/test/java/org/apache/uniffle/server/ShuffleServerMetricsTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleServerMetricsTest.java
@@ -55,6 +55,7 @@ public class ShuffleServerMetricsTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
+    ShuffleServerMetrics.clear();
     ShuffleServerConf ssc = new ShuffleServerConf();
     ssc.set(ShuffleServerConf.JETTY_HTTP_PORT, 12345);
     ssc.set(ShuffleServerConf.JETTY_CORE_POOL_SIZE, 128);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Clear metrics in case of other test update the metrics value.

### Why are the changes needed?

Fix the flaky test.

```
Error:  Tests run: 7, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.046 s <<< FAILURE! - in org.apache.uniffle.server.ShuffleServerMetricsTest
Error:  testStorageCounter  Time elapsed: 0.008 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1.0> but was: <3.0>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:86)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:81)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1010)
	at org.apache.uniffle.server.ShuffleServerMetricsTest.testStorageCounter(ShuffleServerMetricsTest.java:176)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT
