### PR TITLE
[MINOR] fix: fix log content of MultiReplicaClientReadHandler#readShuffleData

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
@@ -83,7 +83,8 @@ public class MultiReplicaClientReadHandler extends AbstractClientReadHandler {
                 readHandlerIndex + 1,
                 handlers.size(),
                 shuffleServerInfos.get(readHandlerIndex).getId(),
-                shuffleServerInfos.get(readHandlerIndex + 1).getId());
+                shuffleServerInfos.get(readHandlerIndex + 1).getId(),
+                e);
           } else {
             LOG.warn(
                 "Finished read from {}/{} [{}], but haven't finished read all the blocks.",

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/MultiReplicaClientReadHandler.java
@@ -76,10 +76,22 @@ public class MultiReplicaClientReadHandler extends AbstractClientReadHandler {
           RssUtils.checkProcessedBlockIds(blockIdBitmap, processedBlockIds);
           return result;
         } catch (RssException e) {
-          LOG.warn(
-              "Finished read from [{}], but haven't finished read all the blocks.",
-              shuffleServerInfos.get(readHandlerIndex).getId(),
-              e);
+          // If this is not the last server, then read next.
+          if (readHandlerIndex < handlers.size() - 1) {
+            LOG.info(
+                "Finished read from {}/{} [{}], haven't finished read all the blocks. Will read from next server {}",
+                readHandlerIndex + 1,
+                handlers.size(),
+                shuffleServerInfos.get(readHandlerIndex).getId(),
+                shuffleServerInfos.get(readHandlerIndex + 1).getId());
+          } else {
+            LOG.warn(
+                "Finished read from {}/{} [{}], but haven't finished read all the blocks.",
+                readHandlerIndex + 1,
+                handlers.size(),
+                shuffleServerInfos.get(readHandlerIndex).getId(),
+                e);
+          }
         }
         readHandlerIndex++;
       }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

fix log content of MultiReplicaClientReadHandler#readShuffleData to different content for last server and others.

### Why are the changes needed?

The existing log can make user stress, as we have multi replica or servers to handle shuffle data read, so we should warn to user until we cannot get all blocks from last server.

### Does this PR introduce _any_ user-facing change?

Yes, the read task log will be more friendly.

### How was this patch tested?

Test locally.