### PR TITLE
[#2145] feat(server): The server-side supports choosing Netty's ByteBufAllocator.

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/TransportFrameDecoder.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/TransportFrameDecoder.java
@@ -59,6 +59,16 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
   private long totalSize = 0;
   private long nextFrameSize = UNKNOWN_FRAME_SIZE;
 
+  private final boolean pooled;
+
+  public TransportFrameDecoder() {
+    this(true);
+  }
+
+  public TransportFrameDecoder(boolean pooled) {
+    this.pooled = pooled;
+  }
+
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object data) {
     ByteBuf in = (ByteBuf) data;
@@ -72,7 +82,7 @@ public class TransportFrameDecoder extends ChannelInboundHandlerAdapter implemen
       }
       Message msg = null;
       try {
-        msg = Message.decode(curType, frame);
+        msg = Message.decode(curType, frame, pooled);
       } finally {
         if (shouldRelease(msg)) {
           frame.release();

--- a/common/src/main/java/org/apache/uniffle/common/netty/client/TransportClientFactory.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/client/TransportClientFactory.java
@@ -115,7 +115,11 @@ public class TransportClientFactory implements Closeable {
 
   public TransportClient createClient(String remoteHost, int remotePort, int partitionId)
       throws IOException, InterruptedException {
-    return createClient(remoteHost, remotePort, partitionId, new TransportFrameDecoder());
+    return createClient(
+        remoteHost,
+        remotePort,
+        partitionId,
+        new TransportFrameDecoder(conf.isPooledAllocatorEnabled()));
   }
 
   public TransportClient createClient(

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Decoders.java
@@ -39,7 +39,7 @@ public class Decoders {
     return new ShuffleServerInfo(id, host, grpcPort, nettyPort);
   }
 
-  public static ShuffleBlockInfo decodeShuffleBlockInfo(ByteBuf byteBuf) {
+  public static ShuffleBlockInfo decodeShuffleBlockInfo(ByteBuf byteBuf, boolean pooled) {
     int partId = byteBuf.readInt();
     long blockId = byteBuf.readLong();
     int length = byteBuf.readInt();
@@ -47,7 +47,10 @@ public class Decoders {
     long crc = byteBuf.readLong();
     long taskAttemptId = byteBuf.readLong();
     int dataLength = byteBuf.readInt();
-    ByteBuf data = NettyUtils.getSharedUnpooledByteBufAllocator(true).directBuffer(dataLength);
+    ByteBuf data =
+        pooled
+            ? NettyUtils.getSharedPooledByteBufAllocator(true, false, 0).directBuffer(dataLength)
+            : NettyUtils.getSharedUnpooledByteBufAllocator(true).directBuffer(dataLength);
     data.writeBytes(byteBuf, dataLength);
     int lengthOfShuffleServers = byteBuf.readInt();
     List<ShuffleServerInfo> serverInfos = Lists.newArrayList();

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.common.netty.protocol;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 
 import org.apache.uniffle.common.exception.RssException;
@@ -140,12 +141,17 @@ public abstract class Message implements Encodable {
     }
   }
 
+  @VisibleForTesting
   public static Message decode(Type msgType, ByteBuf in) {
+    return decode(msgType, in, true);
+  }
+
+  public static Message decode(Type msgType, ByteBuf in, boolean pooled) {
     switch (msgType) {
       case RPC_RESPONSE:
         return RpcResponse.decode(in, false);
       case SEND_SHUFFLE_DATA_REQUEST:
-        return SendShuffleDataRequest.decode(in);
+        return SendShuffleDataRequest.decode(in, pooled);
       case GET_LOCAL_SHUFFLE_DATA_REQUEST:
         return GetLocalShuffleDataRequest.decode(in);
       case GET_LOCAL_SHUFFLE_DATA_RESPONSE:

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequest.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequest.java
@@ -95,7 +95,8 @@ public class SendShuffleDataRequest extends RequestMessage {
     buf.writeLong(timestamp);
   }
 
-  private static Map<Integer, List<ShuffleBlockInfo>> decodePartitionData(ByteBuf byteBuf) {
+  private static Map<Integer, List<ShuffleBlockInfo>> decodePartitionData(
+      ByteBuf byteBuf, boolean pooled) {
     Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
     int lengthOfPartitionData = byteBuf.readInt();
     for (int i = 0; i < lengthOfPartitionData; i++) {
@@ -103,19 +104,19 @@ public class SendShuffleDataRequest extends RequestMessage {
       int lengthOfShuffleBlocks = byteBuf.readInt();
       List<ShuffleBlockInfo> shuffleBlockInfoList = Lists.newArrayList();
       for (int j = 0; j < lengthOfShuffleBlocks; j++) {
-        shuffleBlockInfoList.add(Decoders.decodeShuffleBlockInfo(byteBuf));
+        shuffleBlockInfoList.add(Decoders.decodeShuffleBlockInfo(byteBuf, pooled));
       }
       partitionToBlocks.put(partitionId, shuffleBlockInfoList);
     }
     return partitionToBlocks;
   }
 
-  public static SendShuffleDataRequest decode(ByteBuf byteBuf) {
+  public static SendShuffleDataRequest decode(ByteBuf byteBuf, boolean pooled) {
     long requestId = byteBuf.readLong();
     String appId = ByteBufUtils.readLengthAndString(byteBuf);
     int shuffleId = byteBuf.readInt();
     long requireId = byteBuf.readLong();
-    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = decodePartitionData(byteBuf);
+    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = decodePartitionData(byteBuf, pooled);
     long timestamp = byteBuf.readLong();
     return new SendShuffleDataRequest(
         requestId, appId, shuffleId, requireId, partitionToBlocks, timestamp);

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
@@ -102,7 +102,7 @@ public class NettyProtocolTest {
     ByteBuf byteBuf = Unpooled.buffer(sendShuffleDataRequest.encodedLength());
     sendShuffleDataRequest.encode(byteBuf);
     assertEquals(byteBuf.readableBytes(), encodeLength);
-    SendShuffleDataRequest sendShuffleDataRequest1 = sendShuffleDataRequest.decode(byteBuf);
+    SendShuffleDataRequest sendShuffleDataRequest1 = sendShuffleDataRequest.decode(byteBuf, true);
     assertTrue(
         NettyProtocolTestUtils.compareSendShuffleDataRequest(
             sendShuffleDataRequest, sendShuffleDataRequest1));

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -600,6 +600,13 @@ public class ShuffleServerConf extends RssBaseConf {
                   + "network_bandwidth = 10Gbps, buffer size should be ~ 1.25MB."
                   + "Default is 0, OS will dynamically adjust the buf size.");
 
+  public static final ConfigOption<Boolean> NETTY_SERVER_POOLED_ALLOCATOR_ENABLED =
+      ConfigOptions.key("rss.server.netty.pooled.allocator.enabled")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription(
+              "If true, we will use PooledByteBufAllocator to allocate byte buffers within Netty, otherwise we'll use UnpooledByteBufAllocator.");
+
   public static final ConfigOption<Integer> TOP_N_APP_SHUFFLE_DATA_SIZE_NUMBER =
       ConfigOptions.key("rss.server.topN.appShuffleDataSize.number")
           .intType()


### PR DESCRIPTION
### What changes were proposed in this pull request?

The server-side supports choosing Netty's ByteBufAllocator.

### Why are the changes needed?

Fix: #2145 

### Does this PR introduce _any_ user-facing change?

Introduce rss.server.netty.pooled.allocator.enabled to choose allocator.

### How was this patch tested?

test in cluster.