### PR TITLE
[#2148] improvement(server): Rename ShuffleBufferWithLinkedList to DefaultShuffleBuffer

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -1322,6 +1322,12 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
           ShuffleServerMetrics.gaugeReadLocalIndexFileBufferSize.inc(assumedFileSize);
           GetLocalShuffleIndexResponse.Builder builder =
               GetLocalShuffleIndexResponse.newBuilder().setStatus(status.toProto()).setRetMsg(msg);
+          builder.setIndexData(UnsafeByteOperations.unsafeWrap(data));
+          builder.setDataFileLen(shuffleIndexResult.getDataFileLen());
+          builder.addAllStorageIds(
+                  Arrays.stream(shuffleIndexResult.getStorageIds())
+                          .boxed()
+                          .collect(Collectors.toList()));
           long readTime = System.currentTimeMillis() - start;
           shuffleServer
               .getGrpcMetrics()
@@ -1331,13 +1337,6 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
               readTime,
               data.remaining(),
               requestInfo);
-
-          builder.setIndexData(UnsafeByteOperations.unsafeWrap(data));
-          builder.setDataFileLen(shuffleIndexResult.getDataFileLen());
-          builder.addAllStorageIds(
-              Arrays.stream(shuffleIndexResult.getStorageIds())
-                  .boxed()
-                  .collect(Collectors.toList()));
           auditContext.withReturnValue("len=" + shuffleIndexResult.getDataFileLen());
           reply = builder.build();
         } catch (FileNotFoundException indexFileNotFoundException) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename ShuffleBufferWithLinkedList to DefaultShuffleBuffer

### Why are the changes needed?

Fix: #2148

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
