### PR TITLE
[FOLLOWUP][#2105] Fix memory leak caused by duplicate blocks when using ShuffleBufferWithLinkedList

### DIFF
--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
@@ -583,6 +583,19 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertArrayEquals(expectedData, sdr.getData());
   }
 
+  @Test
+  public void appendRepeatBlockTest() {
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithLinkedList();
+    ShufflePartitionedData block = createData(10);
+    shuffleBuffer.append(block);
+    // ShufflePartitionedBlock has constant 32 bytes overhead
+    assertEquals(42, shuffleBuffer.getSize());
+
+    shuffleBuffer.append(block);
+    // The repeat block should not append to shuffleBuffer
+    assertEquals(42, shuffleBuffer.getSize());
+  }
+
   private byte[] getExpectedData(ShufflePartitionedData... spds) {
     int size = 0;
     for (ShufflePartitionedData spd : spds) {

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipListTest.java
@@ -197,6 +197,19 @@ public class ShuffleBufferWithSkipListTest extends BufferTestBase {
     assertEquals(3, result.getBufferSegments().size());
   }
 
+  @Test
+  public void appendRepeatBlockTest() {
+    ShuffleBuffer shuffleBuffer = new ShuffleBufferWithSkipList();
+    ShufflePartitionedData block = createData(10);
+    shuffleBuffer.append(block);
+    // ShufflePartitionedBlock has constant 32 bytes overhead
+    assertEquals(42, shuffleBuffer.getSize());
+
+    shuffleBuffer.append(block);
+    // The repeat block should not append to shuffleBuffer
+    assertEquals(42, shuffleBuffer.getSize());
+  }
+
   @Override
   protected AtomicInteger getAtomSequenceNo() {
     return atomSequenceNo;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix memory leak issue after the data structure of `blocks` changed from `list` to `set`.

### Why are the changes needed?

Fix: #2105

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.