### PR TITLE
[MINOR] improvement(server,coordinator): Support config grpc queue size

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -181,6 +181,11 @@ public class RssBaseConf extends RssConf {
           .intType()
           .defaultValue(1000)
           .withDescription("Thread number for grpc to process request");
+  public static final ConfigOption<Integer> RPC_EXECUTOR_QUEUE_SIZE =
+      ConfigOptions.key("rss.rpc.executor.queue.size")
+          .intType()
+          .defaultValue(Integer.MAX_VALUE)
+          .withDescription("Thread pool waiting queue size");
 
   public static final ConfigOption<Boolean> RSS_JVM_METRICS_VERBOSE_ENABLE =
       ConfigOptions.key("rss.jvm.metrics.verbose.enable")

--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -73,13 +73,14 @@ public class GrpcServer implements ServerInterface {
     this.grpcMetrics = grpcMetrics;
 
     int rpcExecutorSize = conf.getInteger(RssBaseConf.RPC_EXECUTOR_SIZE);
+    int queueSize = conf.getInteger(RssBaseConf.RPC_EXECUTOR_QUEUE_SIZE);
     pool =
         new GrpcThreadPoolExecutor(
             rpcExecutorSize,
             rpcExecutorSize * 2,
             10,
             TimeUnit.MINUTES,
-            Queues.newLinkedBlockingQueue(Integer.MAX_VALUE),
+            Queues.newLinkedBlockingQueue(queueSize),
             ThreadUtils.getThreadFactory("Grpc"),
             grpcMetrics);
     ThreadPoolManager.registerThreadPool("Grpc", rpcExecutorSize, rpcExecutorSize * 2, 10, pool);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support config grpc thread pool waiting queue size

### Why are the changes needed?

Without this, the server could be rush full of rpc call and cost all memory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
