### PR TITLE
[MINOR] improvement(server): Perf for single Local storage

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -204,6 +204,12 @@ public class LocalStorageManager extends SingleStorageManager {
 
   @Override
   public Storage selectStorage(ShuffleDataFlushEvent event) {
+    if (localStorages.size() == 1) {
+      if (event.getUnderStorage() == null) {
+        event.setUnderStorage(localStorages.get(0));
+      }
+      return localStorages.get(0);
+    }
     String appId = event.getAppId();
     int shuffleId = event.getShuffleId();
     int partitionId = event.getStartPartition();
@@ -254,6 +260,9 @@ public class LocalStorageManager extends SingleStorageManager {
 
   @Override
   public Storage selectStorage(ShuffleDataReadEvent event) {
+    if (localStorages.size() == 1) {
+      return localStorages.get(0);
+    }
     String appId = event.getAppId();
     int shuffleId = event.getShuffleId();
     int partitionId = event.getStartPartition();

--- a/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/ShuffleFlushManagerTest.java
@@ -607,7 +607,8 @@ public class ShuffleFlushManagerTest extends HadoopTestBase {
 
     ShuffleDataReadEvent shuffle1ReadEvent = new ShuffleDataReadEvent(appId2, 1, 0, 0);
     ShuffleDataReadEvent shuffle11ReadEvent = new ShuffleDataReadEvent(appId2, 11, 0, 0);
-    assertNull(storageManager.selectStorage(shuffle1ReadEvent));
+    // As there are only one storage, it should select the only storage anyway
+    assertNotNull(storageManager.selectStorage(shuffle1ReadEvent));
     assertNotNull(storageManager.selectStorage(shuffle11ReadEvent));
 
     storageManager.removeResources(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Do not select storage when there is only one storage, this can reduce the memory cost of `LocalStorageManager#sortedPartitionsOfStorageMap`.

### Why are the changes needed?

Perf for single Local storage

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.