### PR TITLE
[#1628] test(client): Fix double release ShuffleIndexResult cause exception to pass flaky test 

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
@@ -20,12 +20,16 @@ package org.apache.uniffle.common;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.netty.buffer.ManagedBuffer;
 import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
 import org.apache.uniffle.common.util.ByteBufUtils;
 
 public class ShuffleIndexResult {
+  private static final Logger LOG = LoggerFactory.getLogger(ShuffleIndexResult.class);
+
   private final ManagedBuffer buffer;
   private long dataFileLen;
   private String dataFileName;
@@ -74,7 +78,15 @@ public class ShuffleIndexResult {
 
   public void release() {
     if (this.buffer != null) {
-      this.buffer.release();
+      try {
+        this.buffer.release();
+      } catch (Throwable e) {
+        LOG.warn(
+            "Failed to release shuffle index result with length {} of {}. "
+                + "Maybe it has been released by others.",
+            dataFileLen,
+            dataFileName);
+      }
     }
   }
 

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.common;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.Unpooled;
+import io.netty.util.IllegalReferenceCountException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public class ShuffleIndexResult {
     if (this.buffer != null) {
       try {
         this.buffer.release();
-      } catch (Throwable e) {
+      } catch (IllegalReferenceCountException e) {
         LOG.warn(
             "Failed to release shuffle index result with length {} of {}. "
                 + "Maybe it has been released by others.",

--- a/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
+++ b/common/src/main/java/org/apache/uniffle/common/ShuffleIndexResult.java
@@ -85,7 +85,8 @@ public class ShuffleIndexResult {
             "Failed to release shuffle index result with length {} of {}. "
                 + "Maybe it has been released by others.",
             dataFileLen,
-            dataFileName);
+            dataFileName,
+            e);
       }
     }
   }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

- Pass the flaky test
- Avoid memory leak after double release the `ShuffleIndexResult`

Fix: #1628

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Flaky test can be fixed.
