### PR TITLE
[#2133][FOLLOWUP] improvement(server): Support output the shuffle data size and block count before purge app

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/PartitionInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/PartitionInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.uniffle.common;
 
+import org.apache.uniffle.common.util.UnitConverter;
+
 public class PartitionInfo {
   private int id;
   private int shuffleId;
@@ -49,7 +51,8 @@ public class PartitionInfo {
   @Override
   public String toString() {
     return String.format(
-        "[id=%s, shuffleId=%s, size=%s, blockCount=%s]", id, shuffleId, size, blockCount);
+        "[id=%s, shuffleId=%s, size=%s, blockCount=%s]",
+        id, shuffleId, UnitConverter.formatSize(size), blockCount);
   }
 
   public boolean isCurrentPartition(int shuffleId, int partitionId) {

--- a/common/src/main/java/org/apache/uniffle/common/util/ByteUnit.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/ByteUnit.java
@@ -83,5 +83,9 @@ public enum ByteUnit {
     return convertTo(d, PiB);
   }
 
+  public long getMultiplier() {
+    return multiplier;
+  }
+
   private final long multiplier;
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -89,4 +89,6 @@ public final class Constants {
   // We are accessing this configuration through RssConf, the spark prefix is stripped, hence, this
   // field.
   public static final String DRIVER_HOST = "driver.host";
+
+  public static final String DATE_PATTERN = "yyyy-MM-dd HH:mm:ss";
 }

--- a/common/src/main/java/org/apache/uniffle/common/util/UnitConverter.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/UnitConverter.java
@@ -148,4 +148,26 @@ public final class UnitConverter {
       throw new NumberFormatException(timeError + "\n" + e.getMessage());
     }
   }
+
+  /**
+   * Returns a human-readable version of bytes 10GiB 2048KiB etc.
+   *
+   * @param bytes the number of bytes
+   * @return human-readable version
+   */
+  public static String formatSize(long bytes) {
+    if (bytes < ByteUnit.KiB.getMultiplier()) {
+      return bytes + "B";
+    } else if (bytes < ByteUnit.MiB.getMultiplier()) {
+      return String.format("%.2fKiB", bytes / (double) ByteUnit.KiB.getMultiplier());
+    } else if (bytes < ByteUnit.GiB.getMultiplier()) {
+      return String.format("%.2fMiB", bytes / (double) ByteUnit.MiB.getMultiplier());
+    } else if (bytes < ByteUnit.TiB.getMultiplier()) {
+      return String.format("%.2fGiB", bytes / (double) ByteUnit.GiB.getMultiplier());
+    } else if (bytes < ByteUnit.PiB.getMultiplier()) {
+      return String.format("%.2fTiB", bytes / (double) ByteUnit.TiB.getMultiplier());
+    } else {
+      return String.format("%.2fPiB", bytes / (double) ByteUnit.PiB.getMultiplier());
+    }
+  }
 }

--- a/common/src/test/java/org/apache/uniffle/common/util/UnitConverterTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/UnitConverterTest.java
@@ -20,6 +20,7 @@ package org.apache.uniffle.common.util;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -114,5 +115,15 @@ public class UnitConverterTest {
     } else {
       assertEquals(expected, UnitConverter.timeStringAs(value, unit));
     }
+  }
+
+  @Test
+  public void testFormatSize() {
+    assertEquals("500B", UnitConverter.formatSize(500), "Should display in bytes");
+    assertEquals("1.90KiB", UnitConverter.formatSize(1946), "Should display in KiB");
+    assertEquals("11.77MiB", UnitConverter.formatSize(12345678), "Should display in MiB");
+    assertEquals("11.50GiB", UnitConverter.formatSize(12345678901L), "Should display in GiB");
+    assertEquals("1.00TiB", UnitConverter.formatSize(1099511627776L), "Should display in TiB");
+    assertEquals("9.77PiB", UnitConverter.formatSize(10995116277760000L), "Should display in PiB");
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDetailInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDetailInfo.java
@@ -28,12 +28,14 @@ public class ShuffleDetailInfo {
   private int id;
   private AtomicLong dataSize;
   private AtomicLong blockCount;
+  private AtomicLong partitionCount;
   private long startTime;
 
   public ShuffleDetailInfo(int id, long startTime) {
     this.id = id;
     this.dataSize = new AtomicLong();
     this.blockCount = new AtomicLong();
+    this.partitionCount = new AtomicLong();
     this.startTime = startTime;
   }
 
@@ -61,13 +63,18 @@ public class ShuffleDetailInfo {
     blockCount.addAndGet(count);
   }
 
+  public void incrPartitionCount() {
+    partitionCount.addAndGet(1);
+  }
+
   @Override
   public String toString() {
     return String.format(
-        "ShuffleDetail [id=%s, dataSize=%s, blockCount=%s, startTime=%s]",
+        "ShuffleDetail [%d: partitionCount=%s, blockCount=%s, size=%s, startTime=%s]",
         id,
-        UnitConverter.formatSize(dataSize.get()),
+        partitionCount,
         blockCount,
+        UnitConverter.formatSize(dataSize.get()),
         DateFormatUtils.format(startTime, Constants.DATE_PATTERN));
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleDetailInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleDetailInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.common.util.UnitConverter;
+
+public class ShuffleDetailInfo {
+  private int id;
+  private AtomicLong dataSize;
+  private AtomicLong blockCount;
+  private long startTime;
+
+  public ShuffleDetailInfo(int id, long startTime) {
+    this.id = id;
+    this.dataSize = new AtomicLong();
+    this.blockCount = new AtomicLong();
+    this.startTime = startTime;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getBlockCount() {
+    return blockCount.get();
+  }
+
+  public long getDataSize() {
+    return dataSize.get();
+  }
+
+  public void incrDataSize(long size) {
+    dataSize.addAndGet(size);
+  }
+
+  public void incrBlockCount(long count) {
+    blockCount.addAndGet(count);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ShuffleDetail [id=%s, dataSize=%s, blockCount=%s, startTime=%s]",
+        id,
+        UnitConverter.formatSize(dataSize.get()),
+        blockCount,
+        DateFormatUtils.format(startTime, Constants.DATE_PATTERN));
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.uniffle.common.PartitionInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.util.JavaUtils;
+import org.apache.uniffle.common.util.UnitConverter;
 
 /**
  * ShuffleTaskInfo contains the information of submitting the shuffle, the information of the cache
@@ -67,7 +68,10 @@ public class ShuffleTaskInfo {
 
   private final AtomicReference<ShuffleSpecification> specification;
 
+  /** shuffleId -> partitionId -> block counter */
   private final Map<Integer, Map<Integer, AtomicLong>> partitionBlockCounters;
+  /** shuffleId -> shuffleDetailInfo */
+  private final Map<Integer, ShuffleDetailInfo> shuffleDetailInfos;
 
   private final Map<Integer, Integer> latestStageAttemptNumbers;
 
@@ -84,6 +88,7 @@ public class ShuffleTaskInfo {
     this.specification = new AtomicReference<>();
     this.partitionBlockCounters = JavaUtils.newConcurrentMap();
     this.latestStageAttemptNumbers = JavaUtils.newConcurrentMap();
+    this.shuffleDetailInfos = JavaUtils.newConcurrentMap();
   }
 
   public Long getCurrentTimes() {
@@ -129,6 +134,10 @@ public class ShuffleTaskInfo {
   public long addPartitionDataSize(int shuffleId, int partitionId, long delta) {
     totalDataSize.addAndGet(delta);
     inMemoryDataSize.addAndGet(delta);
+    shuffleDetailInfos
+        .computeIfAbsent(
+            shuffleId, key -> new ShuffleDetailInfo(shuffleId, System.currentTimeMillis()))
+        .incrDataSize(delta);
     partitionDataSizes.computeIfAbsent(shuffleId, key -> JavaUtils.newConcurrentMap());
     Map<Integer, Long> partitions = partitionDataSizes.get(shuffleId);
     partitions.putIfAbsent(partitionId, 0L);
@@ -235,6 +244,10 @@ public class ShuffleTaskInfo {
     if (maxSizePartitionInfo.isCurrentPartition(shuffleId, partitionId)) {
       maxSizePartitionInfo.setBlockCount(blockCount);
     }
+    shuffleDetailInfos
+        .computeIfAbsent(
+            shuffleId, key -> new ShuffleDetailInfo(shuffleId, System.currentTimeMillis()))
+        .incrBlockCount(delta);
   }
 
   public long getBlockNumber(int shuffleId, int partitionId) {
@@ -261,6 +274,10 @@ public class ShuffleTaskInfo {
     return maxSizePartitionInfo;
   }
 
+  public ShuffleDetailInfo getShuffleDetailInfo(int shuffleId) {
+    return shuffleDetailInfos.get(shuffleId);
+  }
+
   @Override
   public String toString() {
     return "ShuffleTaskInfo{"
@@ -268,17 +285,17 @@ public class ShuffleTaskInfo {
         + appId
         + '\''
         + ", totalDataSize="
-        + totalDataSize
+        + UnitConverter.formatSize(totalDataSize.get())
         + ", inMemoryDataSize="
-        + inMemoryDataSize
+        + UnitConverter.formatSize(inMemoryDataSize.get())
         + ", onLocalFileDataSize="
-        + onLocalFileDataSize
+        + UnitConverter.formatSize(onLocalFileDataSize.get())
         + ", onHadoopDataSize="
-        + onHadoopDataSize
-        + ", partitionDataSizes="
-        + partitionDataSizes
+        + UnitConverter.formatSize(onHadoopDataSize.get())
         + ", maxSizePartitionInfo="
         + maxSizePartitionInfo
+        + ", shuffleDetailInfo="
+        + shuffleDetailInfos
         + '}';
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -72,6 +72,7 @@ import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RssUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
+import org.apache.uniffle.common.util.UnitConverter;
 import org.apache.uniffle.server.buffer.PreAllocatedBufferInfo;
 import org.apache.uniffle.server.buffer.ShuffleBuffer;
 import org.apache.uniffle.server.buffer.ShuffleBufferManager;
@@ -866,13 +867,6 @@ public class ShuffleTaskManager {
       StringBuilder partitionInfoSummary = new StringBuilder();
       partitionInfoSummary.append("appId: ").append(appId).append("\n");
       for (int shuffleId : shuffleTaskInfo.getShuffleIds()) {
-        Roaring64NavigableMap[] bitmaps = partitionsToBlockIds.get(appId).get(shuffleId);
-        long shuffleBlockCount = 0L;
-        if (bitmaps != null) {
-          for (Roaring64NavigableMap bitmap : bitmaps) {
-            shuffleBlockCount += bitmap.getLongCardinality();
-          }
-        }
         if (conf.getBoolean(ShuffleServerConf.SERVER_LOG_APP_DETAIL_WHILE_REMOVE_ENABLED)) {
           for (int partitionId : shuffleTaskInfo.getPartitionIds(shuffleId)) {
             long partitionSize = shuffleTaskInfo.getPartitionDataSize(shuffleId, partitionId);
@@ -883,21 +877,11 @@ public class ShuffleTaskManager {
                 shuffleId,
                 partitionId,
                 partitionBlockCount,
-                partitionSize);
+                UnitConverter.formatSize(partitionSize));
           }
         }
-        partitionInfoSummary
-            .append(" shuffleId: ")
-            .append(shuffleId)
-            .append(" contains partition/block: ")
-            .append(shuffleTaskInfo.getPartitionIds(shuffleId).size())
-            .append("/")
-            .append(shuffleBlockCount)
-            .append("\n");
       }
-      partitionInfoSummary
-          .append("The maxSizePartitionInfo: ")
-          .append(shuffleTaskInfo.getMaxSizePartitionInfo());
+      partitionInfoSummary.append("The app task info: ").append(shuffleTaskInfo);
       LOG.info("Removing app summary info: {}", partitionInfoSummary);
 
       partitionsToBlockIds.remove(appId);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Output the shuffle data size and block count before purge app

### Why are the changes needed?

Clearly and easily to view the shuffle blocks info.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Run locally.

```
[2024-10-15 11:25:31.438] [clearResourceThread] [INFO] ShuffleTaskManager - Removing app summary info: appId: app-20241015112429-0069_1728962668484
The app task info: ShuffleTaskInfo{appId='app-20241015112429-0069_1728962668484', totalDataSize=741B, inMemoryDataSize=0B, onLocalFileDataSize=741B, onHadoopDataSize=0B, maxSizePartitionInfo=[id=1, shuffleId=0, size=663B, blockCount=17], shuffleDetailInfo={0=ShuffleDetail [id=0, dataSize=741B, blockCount=19, startTime=2024-10-15 11:24:36]}}

```
