### PR TITLE
[#2181]improvement(server): Replace ShuffleBlockInfo with ShufflePartitionedBlock in netty

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Message.java
@@ -151,7 +151,7 @@ public abstract class Message implements Encodable {
       case RPC_RESPONSE:
         return RpcResponse.decode(in, false);
       case SEND_SHUFFLE_DATA_REQUEST:
-        return SendShuffleDataRequest.decode(in);
+        return SendShuffleDataRequestV1.decode(in);
       case GET_LOCAL_SHUFFLE_DATA_REQUEST:
         return GetLocalShuffleDataRequest.decode(in);
       case GET_LOCAL_SHUFFLE_DATA_RESPONSE:

--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequestV1.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/SendShuffleDataRequestV1.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.common.netty.protocol;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.util.ByteBufUtils;
+
+public class SendShuffleDataRequestV1 extends RequestMessage {
+  private String appId;
+  private int shuffleId;
+
+  private int stageAttemptNumber;
+  private long requireId;
+  private Map<Integer, List<ShufflePartitionedBlock>> partitionToBlocks;
+  private long timestamp;
+  private int decodedLength;
+
+  public SendShuffleDataRequestV1(long requestId) {
+    super(requestId);
+  }
+
+  @Override
+  public Type type() {
+    return Type.SEND_SHUFFLE_DATA_REQUEST;
+  }
+
+  @Override
+  public int encodedLength() {
+    return -1;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {}
+
+  public void decodeShuffleData(ByteBuf byteBuf) {
+    final int startIndex = byteBuf.readerIndex();
+    this.appId = ByteBufUtils.readLengthAndString(byteBuf);
+    this.shuffleId = byteBuf.readInt();
+    this.requireId = byteBuf.readLong();
+    this.partitionToBlocks = decodePartitionData(byteBuf);
+    this.timestamp = byteBuf.readLong();
+    int endIndex = byteBuf.readerIndex();
+    decodedLength += endIndex - startIndex;
+  }
+
+  public int getDecodedLength() {
+    return decodedLength;
+  }
+
+  private Map<Integer, List<ShufflePartitionedBlock>> decodePartitionData(ByteBuf byteBuf) {
+    Map<Integer, List<ShufflePartitionedBlock>> partitionToBlocks = Maps.newHashMap();
+    int lengthOfPartitionData = byteBuf.readInt();
+    for (int i = 0; i < lengthOfPartitionData; i++) {
+      int partitionId = byteBuf.readInt();
+      int lengthOfShuffleBlocks = byteBuf.readInt();
+      List<ShufflePartitionedBlock> shufflePartitionedBlocks = Lists.newArrayList();
+      for (int j = 0; j < lengthOfShuffleBlocks; j++) {
+        try {
+          shufflePartitionedBlocks.add(Decoders.decodeShufflePartitionedBlockV1(byteBuf));
+        } catch (Throwable t) {
+          shufflePartitionedBlocks.forEach(sbi -> sbi.getData().release());
+          if (!partitionToBlocks.isEmpty()) {
+            partitionToBlocks.forEach(
+                (integer, shuffleBlockInfos) -> {
+                  shuffleBlockInfos.forEach(sbi -> sbi.getData().release());
+                });
+          }
+          throw t;
+        }
+      }
+      partitionToBlocks.put(partitionId, shufflePartitionedBlocks);
+    }
+    return partitionToBlocks;
+  }
+
+  public static SendShuffleDataRequestV1 decode(ByteBuf byteBuf) {
+    int startIndex = byteBuf.readerIndex();
+    long requestId = byteBuf.readLong();
+    SendShuffleDataRequestV1 req = new SendShuffleDataRequestV1(requestId);
+    req.decodeShuffleData(byteBuf);
+    int endIndex = byteBuf.readerIndex();
+    req.setDecodedLength(endIndex - startIndex);
+
+    return req;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public long getRequireId() {
+    return requireId;
+  }
+
+  public void setRequireId(long requireId) {
+    this.requireId = requireId;
+  }
+
+  public Map<Integer, List<ShufflePartitionedBlock>> getPartitionToBlocks() {
+    return partitionToBlocks;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public int getStageAttemptNumber() {
+    return stageAttemptNumber;
+  }
+
+  @Override
+  public String getOperationType() {
+    return "sendShuffleDataV1";
+  }
+
+  public void setDecodedLength(int decodedLength) {
+    this.decodedLength = decodedLength;
+  }
+}

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTest.java
@@ -30,6 +30,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import org.apache.uniffle.common.BufferSegment;
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShufflePartitionedBlock;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.netty.buffer.ManagedBuffer;
 import org.apache.uniffle.common.netty.buffer.NettyManagedBuffer;
@@ -103,17 +104,17 @@ public class NettyProtocolTest {
     ByteBuf byteBuf = Unpooled.buffer(sendShuffleDataRequest.encodedLength());
     sendShuffleDataRequest.encode(byteBuf);
     assertEquals(byteBuf.readableBytes(), encodeLength);
-    SendShuffleDataRequest sendShuffleDataRequest1 = sendShuffleDataRequest.decode(byteBuf);
+    SendShuffleDataRequestV1 sendShuffleDataRequest1 = SendShuffleDataRequestV1.decode(byteBuf);
     assertTrue(
-        NettyProtocolTestUtils.compareSendShuffleDataRequest(
+        NettyProtocolTestUtils.compareSendShuffleDataRequestV1(
             sendShuffleDataRequest, sendShuffleDataRequest1));
-    assertEquals(encodeLength, sendShuffleDataRequest1.encodedLength());
+    assertEquals(encodeLength, sendShuffleDataRequest1.getDecodedLength());
     byteBuf.release();
-    for (ShuffleBlockInfo shuffleBlockInfo :
+    for (ShufflePartitionedBlock shuffleBlockInfo :
         sendShuffleDataRequest1.getPartitionToBlocks().get(1)) {
       shuffleBlockInfo.getData().release();
     }
-    for (ShuffleBlockInfo shuffleBlockInfo :
+    for (ShufflePartitionedBlock shuffleBlockInfo :
         sendShuffleDataRequest1.getPartitionToBlocks().get(2)) {
       shuffleBlockInfo.getData().release();
     }

--- a/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
+++ b/common/src/test/java/org/apache/uniffle/common/netty/protocol/NettyProtocolTestUtils.java
@@ -22,21 +22,28 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.uniffle.common.ShuffleBlockInfo;
+import org.apache.uniffle.common.ShufflePartitionedBlock;
 
 public class NettyProtocolTestUtils {
 
   private static boolean compareShuffleBlockInfo(
       ShuffleBlockInfo blockInfo1, ShuffleBlockInfo blockInfo2) {
-    return blockInfo1.getPartitionId() == blockInfo2.getPartitionId()
-        && blockInfo1.getBlockId() == blockInfo2.getBlockId()
+    return blockInfo1.getBlockId() == blockInfo2.getBlockId()
         && blockInfo1.getLength() == blockInfo2.getLength()
-        && blockInfo1.getShuffleId() == blockInfo2.getShuffleId()
         && blockInfo1.getCrc() == blockInfo2.getCrc()
         && blockInfo1.getTaskAttemptId() == blockInfo2.getTaskAttemptId()
         && blockInfo1.getUncompressLength() == blockInfo2.getUncompressLength()
-        && blockInfo1.getFreeMemory() == blockInfo2.getFreeMemory()
-        && blockInfo1.getData().equals(blockInfo2.getData())
-        && blockInfo1.getShuffleServerInfos().equals(blockInfo2.getShuffleServerInfos());
+        && blockInfo1.getData().equals(blockInfo2.getData());
+  }
+
+  private static boolean compareShuffleBlockInfoV1(
+      ShuffleBlockInfo blockInfo1, ShufflePartitionedBlock blockInfo2) {
+    return blockInfo1.getBlockId() == blockInfo2.getBlockId()
+        && blockInfo1.getLength() == blockInfo2.getDataLength()
+        && blockInfo1.getCrc() == blockInfo2.getCrc()
+        && blockInfo1.getTaskAttemptId() == blockInfo2.getTaskAttemptId()
+        && blockInfo1.getUncompressLength() == blockInfo2.getUncompressLength()
+        && blockInfo1.getData().equals(blockInfo2.getData());
   }
 
   private static boolean compareBlockList(
@@ -52,6 +59,19 @@ public class NettyProtocolTestUtils {
     return true;
   }
 
+  private static boolean compareBlockListV1(
+      List<ShuffleBlockInfo> list1, List<ShufflePartitionedBlock> list2) {
+    if (list1 == null || list2 == null || list1.size() != list2.size()) {
+      return false;
+    }
+    for (int i = 0; i < list1.size(); i++) {
+      if (!compareShuffleBlockInfoV1(list1.get(i), list2.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private static boolean comparePartitionToBlockList(
       Map<Integer, List<ShuffleBlockInfo>> m1, Map<Integer, List<ShuffleBlockInfo>> m2) {
     if (m1 == null || m2 == null || m1.size() != m2.size()) {
@@ -61,6 +81,21 @@ public class NettyProtocolTestUtils {
     while (iter1.hasNext()) {
       Map.Entry<Integer, List<ShuffleBlockInfo>> entry1 = iter1.next();
       if (!compareBlockList(entry1.getValue(), m2.get(entry1.getKey()))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean comparePartitionToBlockListV1(
+      Map<Integer, List<ShuffleBlockInfo>> m1, Map<Integer, List<ShufflePartitionedBlock>> m2) {
+    if (m1 == null || m2 == null || m1.size() != m2.size()) {
+      return false;
+    }
+    Iterator<Map.Entry<Integer, List<ShuffleBlockInfo>>> iter1 = m1.entrySet().iterator();
+    while (iter1.hasNext()) {
+      Map.Entry<Integer, List<ShuffleBlockInfo>> entry1 = iter1.next();
+      if (!compareBlockListV1(entry1.getValue(), m2.get(entry1.getKey()))) {
         return false;
       }
     }
@@ -85,5 +120,22 @@ public class NettyProtocolTestUtils {
       return false;
     }
     return comparePartitionToBlockList(req1.getPartitionToBlocks(), req2.getPartitionToBlocks());
+  }
+
+  public static boolean compareSendShuffleDataRequestV1(
+      SendShuffleDataRequest req1, SendShuffleDataRequestV1 req2) {
+    if (req1 == null || req2 == null) {
+      return false;
+    }
+    boolean isEqual =
+        req1.getRequestId() == req2.getRequestId()
+            && req1.getShuffleId() == req2.getShuffleId()
+            && req1.getRequireId() == req2.getRequireId()
+            && req1.getTimestamp() == req2.getTimestamp()
+            && req1.getAppId().equals(req2.getAppId());
+    if (!isEqual) {
+      return false;
+    }
+    return comparePartitionToBlockListV1(req1.getPartitionToBlocks(), req2.getPartitionToBlocks());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

On the server side of the netty mode, when the server receives the sendShuffleData message, it decodes it into an unnecessary ShuffleBlockInfo and then converts it to ShufflePartitionedBlock in handleSendShuffleDataRequest. 

### Why are the changes needed?

Fix: #2181 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Locally