### PR TITLE
[MINOR] feat(server): Introduce in flush block count metrics in buffer pool

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -160,6 +160,8 @@ public class ShuffleServerMetrics {
 
   public static final String REQUIRE_BUFFER_COUNT = "require_buffer_count";
 
+  public static final String IN_FLUSH_BLOCK_COUNT_IN_BUFFER_POOL
+      = "in_flush_block_count_in_buffer_pool";
   public static final String BLOCK_COUNT_IN_BUFFER_POOL = "block_count_in_buffer_pool";
   public static final String BUFFER_COUNT_IN_BUFFER_POOL = "buffer_count_in_buffer_pool";
   public static final String SHUFFLE_COUNT_IN_BUFFER_POOL = "shuffle_count_in_buffer_pool";

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBuffer.java
@@ -59,6 +59,8 @@ public interface ShuffleBuffer {
 
   int getBlockCount();
 
+  long getInFlushBlockCount();
+
   long release();
 
   void clearInFlushBuffer(long eventId);

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -120,6 +120,11 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
   }
 
   @Override
+  public long getInFlushBlockCount() {
+    return inFlushBlockMap.values().stream().mapToLong(Set::size).sum();
+  }
+
+  @Override
   public synchronized long release() {
     Throwable lastException = null;
     int failedToReleaseSize = 0;

--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithSkipList.java
@@ -121,6 +121,11 @@ public class ShuffleBufferWithSkipList extends AbstractShuffleBuffer {
   }
 
   @Override
+  public long getInFlushBlockCount() {
+    return inFlushBlockMap.values().stream().mapToLong(Map::size).sum();
+  }
+
+  @Override
   public synchronized long release() {
     Throwable lastException = null;
     int failedToReleaseSize = 0;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Introduce in flush block count metrics in buffer pool

### Why are the changes needed?

Insight all blocks in server include buffer pool and in flush blocks.

### Does this PR introduce _any_ user-facing change?

- New metrics named `in_flush_block_count_in_buffer_pool`

### How was this patch tested?

Test locally.
