### PR TITLE
[MINOR] feat(server): Introduce metrics related bitmaps(committedBlockIds/cachedBlockIds/partitionToBlockIds)

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -166,6 +166,10 @@ public class ShuffleServerMetrics {
   public static final String BUFFER_COUNT_IN_BUFFER_POOL = "buffer_count_in_buffer_pool";
   public static final String SHUFFLE_COUNT_IN_BUFFER_POOL = "shuffle_count_in_buffer_pool";
 
+  public static final String COMMITTED_BLOCK_COUNT = "committed_block_count";
+  public static final String REPORTED_BLOCK_COUNT = "reported_block_count";
+  public static final String CACHED_BLOCK_COUNT = "cached_block_count";
+
   public static Counter.Child counterTotalAppNum;
   public static Counter.Child counterTotalAppWithHugePartitionNum;
   public static Counter.Child counterTotalPartitionNum;

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -88,6 +88,8 @@ import org.apache.uniffle.storage.util.ShuffleStorageUtils;
 
 import static org.apache.uniffle.server.ShuffleServerConf.CLIENT_MAX_CONCURRENCY_LIMITATION_OF_ONE_PARTITION;
 import static org.apache.uniffle.server.ShuffleServerConf.SERVER_MAX_CONCURRENCY_OF_ONE_PARTITION;
+import static org.apache.uniffle.server.ShuffleServerMetrics.CACHED_BLOCK_COUNT;
+import static org.apache.uniffle.server.ShuffleServerMetrics.REPORTED_BLOCK_COUNT;
 import static org.apache.uniffle.server.ShuffleServerMetrics.REQUIRE_BUFFER_COUNT;
 
 public class ShuffleTaskManager {
@@ -243,6 +245,26 @@ public class ShuffleTaskManager {
     topNShuffleDataSizeOfAppCalcTask.start();
 
     ShuffleServerMetrics.addLabeledGauge(REQUIRE_BUFFER_COUNT, requireBufferIds::size);
+    ShuffleServerMetrics.addLabeledCacheGauge(
+        REPORTED_BLOCK_COUNT,
+        () ->
+            partitionsToBlockIds.values().stream()
+                .flatMap(innerMap -> innerMap.values().stream())
+                .flatMapToLong(
+                    arr ->
+                        java.util.Arrays.stream(arr)
+                            .mapToLong(Roaring64NavigableMap::getLongCardinality))
+                .sum(),
+        2 * 60 * 1000L /* 2 minutes */);
+    ShuffleServerMetrics.addLabeledCacheGauge(
+        CACHED_BLOCK_COUNT,
+        () ->
+            shuffleTaskInfos.values().stream()
+                .map(ShuffleTaskInfo::getCachedBlockIds)
+                .flatMap(map -> map.values().stream())
+                .mapToLong(Roaring64NavigableMap::getLongCardinality)
+                .sum(),
+        2 * 60 * 1000L /* 2 minutes */);
   }
 
   public ReentrantReadWriteLock.WriteLock getAppWriteLock(String appId) {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Introduce metrics related bitmaps.

### Why are the changes needed?

Insight the block bitmap related count.

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

- committed_block_count
- reported_block_count
- cached_block_count

### How was this patch tested?

Locally.

<img width="2512" alt="image" src="https://github.com/user-attachments/assets/c57706db-a13f-44f5-93fd-235825122f5d">

