### PR TITLE
[MINOR]improvement(client/server): (RemoteMerger) Refactor to use mergeContext collect the arguments related

### DIFF
--- a/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/core/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -80,7 +80,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.RetryUtils;
 import org.apache.uniffle.hadoop.shim.HadoopShimImpl;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.apache.hadoop.mapreduce.RssMRConfig.RSS_REMOTE_MERGE_CLASS_LOADER;
@@ -287,7 +287,7 @@ public class RssMRAppMaster extends MRAppMaster {
                                       .get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE),
                                   0,
                                   remoteMergeEnable
-                                      ? PMergeContext.newBuilder()
+                                      ? MergeContext.newBuilder()
                                           .setKeyClass(conf.getMapOutputKeyClass().getName())
                                           .setValueClass(conf.getMapOutputValueClass().getName())
                                           .setComparatorClass(

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -62,6 +62,7 @@ import org.apache.uniffle.common.serializer.SerializerFactory;
 import org.apache.uniffle.common.serializer.SerializerInstance;
 import org.apache.uniffle.common.serializer.SerializerUtils;
 import org.apache.uniffle.common.util.JavaUtils;
+import org.apache.uniffle.proto.RssProtos;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -722,11 +723,7 @@ public class SortWriteBufferManagerTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        String keyClassName,
-        String valueClassName,
-        String comparatorClassName,
-        int mergedBlockSize,
-        String mergeClassLoader) {}
+        RssProtos.PMergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -723,7 +723,7 @@ public class SortWriteBufferManagerTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.PMergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -77,6 +77,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.hadoop.shim.HadoopShimImpl;
+import org.apache.uniffle.proto.RssProtos;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -507,11 +508,7 @@ public class FetcherTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        String keyClassName,
-        String valueClassName,
-        String comparatorClassName,
-        int mergedBlockSize,
-        String mergeClassLoader) {}
+        RssProtos.PMergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -508,7 +508,7 @@ public class FetcherTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.PMergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1028,10 +1028,6 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
                   ShuffleDataDistributionType.NORMAL,
                   maxConcurrencyPerPartitionToWrite,
                   stageAttemptNumber,
-                  null,
-                  null,
-                  null,
-                  -1,
                   null);
             });
     LOG.info(

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -66,6 +66,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.RetryUtils;
+import org.apache.uniffle.proto.RssProtos;
 
 import static org.apache.uniffle.common.config.RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE;
 
@@ -305,13 +306,19 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
                                           RssTezConfig.toRssConf(conf)
                                               .get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE),
                                           0,
-                                          keyClassName,
-                                          valueClassName,
-                                          comparatorClassName,
-                                          conf.getInt(
-                                              RssTezConfig.RSS_MERGED_BLOCK_SZIE,
-                                              RssTezConfig.RSS_MERGED_BLOCK_SZIE_DEFAULT),
-                                          conf.get(RssTezConfig.RSS_REMOTE_MERGE_CLASS_LOADER)));
+                                          RssProtos.PMergeContext.newBuilder()
+                                              .setKeyClass(keyClassName)
+                                              .setValueClass(valueClassName)
+                                              .setComparatorClass(comparatorClassName)
+                                              .setMergedBlockSize(
+                                                  conf.getInt(
+                                                      RssTezConfig.RSS_MERGED_BLOCK_SZIE,
+                                                      RssTezConfig.RSS_MERGED_BLOCK_SZIE_DEFAULT))
+                                              .setMergeClassLoader(
+                                                  conf.get(
+                                                      RssTezConfig.RSS_REMOTE_MERGE_CLASS_LOADER,
+                                                      ""))
+                                              .build()));
                           LOG.info(
                               "Finish register shuffle with "
                                   + (System.currentTimeMillis() - start)

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -306,7 +306,7 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
                                           RssTezConfig.toRssConf(conf)
                                               .get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE),
                                           0,
-                                          RssProtos.PMergeContext.newBuilder()
+                                          RssProtos.MergeContext.newBuilder()
                                               .setKeyClass(keyClassName)
                                               .setValueClass(valueClassName)
                                               .setComparatorClass(comparatorClassName)

--- a/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
+++ b/client-tez/src/main/java/org/apache/tez/dag/app/TezRemoteShuffleManager.java
@@ -306,19 +306,23 @@ public class TezRemoteShuffleManager implements ServicePluginLifecycle {
                                           RssTezConfig.toRssConf(conf)
                                               .get(MAX_CONCURRENCY_PER_PARTITION_TO_WRITE),
                                           0,
-                                          RssProtos.MergeContext.newBuilder()
-                                              .setKeyClass(keyClassName)
-                                              .setValueClass(valueClassName)
-                                              .setComparatorClass(comparatorClassName)
-                                              .setMergedBlockSize(
-                                                  conf.getInt(
-                                                      RssTezConfig.RSS_MERGED_BLOCK_SZIE,
-                                                      RssTezConfig.RSS_MERGED_BLOCK_SZIE_DEFAULT))
-                                              .setMergeClassLoader(
-                                                  conf.get(
-                                                      RssTezConfig.RSS_REMOTE_MERGE_CLASS_LOADER,
-                                                      ""))
-                                              .build()));
+                                          StringUtils.isBlank(keyClassName)
+                                              ? null
+                                              : RssProtos.MergeContext.newBuilder()
+                                                  .setKeyClass(keyClassName)
+                                                  .setValueClass(valueClassName)
+                                                  .setComparatorClass(comparatorClassName)
+                                                  .setMergedBlockSize(
+                                                      conf.getInt(
+                                                          RssTezConfig.RSS_MERGED_BLOCK_SZIE,
+                                                          RssTezConfig
+                                                              .RSS_MERGED_BLOCK_SZIE_DEFAULT))
+                                                  .setMergeClassLoader(
+                                                      conf.get(
+                                                          RssTezConfig
+                                                              .RSS_REMOTE_MERGE_CLASS_LOADER,
+                                                          ""))
+                                                  .build()));
                           LOG.info(
                               "Finish register shuffle with "
                                   + (System.currentTimeMillis() - start)

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -78,6 +78,7 @@ import org.apache.uniffle.common.serializer.SerializerFactory;
 import org.apache.uniffle.common.serializer.SerializerInstance;
 import org.apache.uniffle.common.serializer.SerializerUtils;
 import org.apache.uniffle.common.util.JavaUtils;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -719,11 +720,7 @@ public class WriteBufferManagerTest {
         ShuffleDataDistributionType dataDistributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        String keyClassName,
-        String valueClassName,
-        String comparatorClassName,
-        int mergedBlockSize,
-        String mergeClassLoader) {}
+        RssProtos.PMergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -720,7 +720,7 @@ public class WriteBufferManagerTest {
         ShuffleDataDistributionType dataDistributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.PMergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext) {}
 
     @Override
     public boolean sendCommit(

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -33,6 +33,7 @@ import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.proto.RssProtos.PMergeContext;
 
 public interface ShuffleWriteClient {
 
@@ -72,10 +73,6 @@ public interface ShuffleWriteClient {
         dataDistributionType,
         maxConcurrencyPerPartitionToWrite,
         0,
-        null,
-        null,
-        null,
-        -1,
         null);
   }
 
@@ -88,11 +85,7 @@ public interface ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      String keyClassName,
-      String valueClassName,
-      String comparatorClassName,
-      int mergedBlockSize,
-      String mergeClassLoader);
+      PMergeContext mergeContext);
 
   boolean sendCommit(
       Set<ShuffleServerInfo> shuffleServerInfoSet, String appId, int shuffleId, int numMaps);

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -33,7 +33,7 @@ import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 
 public interface ShuffleWriteClient {
 
@@ -85,7 +85,7 @@ public interface ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      PMergeContext mergeContext);
+      MergeContext mergeContext);
 
   boolean sendCommit(
       Set<ShuffleServerInfo> shuffleServerInfoSet, String appId, int shuffleId, int numMaps);

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -95,6 +95,7 @@ import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
+import org.apache.uniffle.proto.RssProtos.PMergeContext;
 
 public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
@@ -564,11 +565,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      String keyClassName,
-      String valueClassName,
-      String comparatorClassName,
-      int mergedBlockSize,
-      String mergeClassLoader) {
+      PMergeContext mergeContext) {
     String user = null;
     try {
       user = UserGroupInformation.getCurrentUser().getShortUserName();
@@ -586,11 +583,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             dataDistributionType,
             maxConcurrencyPerPartitionToWrite,
             stageAttemptNumber,
-            keyClassName,
-            valueClassName,
-            comparatorClassName,
-            mergedBlockSize,
-            mergeClassLoader);
+            mergeContext);
     RssRegisterShuffleResponse response =
         getShuffleServerClient(shuffleServerInfo).registerShuffle(request);
 

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -95,7 +95,7 @@ import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.ThreadUtils;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 
 public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
@@ -565,7 +565,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      PMergeContext mergeContext) {
+      MergeContext mergeContext) {
     String user = null;
     try {
       user = UserGroupInformation.getCurrentUser().getShortUserName();

--- a/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
+++ b/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
@@ -34,6 +34,7 @@ import org.apache.uniffle.common.ShuffleAssignmentsInfo;
 import org.apache.uniffle.common.ShuffleBlockInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.ShuffleServerInfo;
+import org.apache.uniffle.proto.RssProtos;
 
 public class MockedShuffleWriteClient implements ShuffleWriteClient {
 
@@ -63,11 +64,7 @@ public class MockedShuffleWriteClient implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      String keyClassName,
-      String valueClassName,
-      String comparatorClassName,
-      int mergedBlockSize,
-      String mergeClassLoader) {}
+      RssProtos.PMergeContext mergeContext) {}
 
   @Override
   public boolean sendCommit(

--- a/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
+++ b/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
@@ -64,7 +64,7 @@ public class MockedShuffleWriteClient implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      RssProtos.PMergeContext mergeContext) {}
+      RssProtos.MergeContext mergeContext) {}
 
   @Override
   public boolean sendCommit(

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
@@ -64,6 +64,7 @@ import org.apache.uniffle.common.serializer.SerializerUtils;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -171,11 +172,13 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // task 0 attempt 0 generate three blocks
@@ -334,11 +337,13 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // task 0 attempt 0 generate three blocks
@@ -505,11 +510,13 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // this shuffle have three partition, which is hash by key index mode 3
@@ -711,11 +718,13 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // this shuffle have three partition, which is hash by key index mode 3

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
@@ -172,7 +172,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -337,7 +337,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -510,7 +510,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -718,7 +718,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
         ShuffleDataDistributionType.NORMAL,
         0,
         -1,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
@@ -177,7 +177,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -342,7 +342,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -516,7 +516,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())
@@ -725,7 +725,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClass.getName())
             .setValueClass(valueClass.getName())
             .setComparatorClass(comparator.getClass().getName())

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
@@ -64,6 +64,7 @@ import org.apache.uniffle.common.serializer.SerializerUtils;
 import org.apache.uniffle.common.util.BlockIdLayout;
 import org.apache.uniffle.common.util.ChecksumUtils;
 import org.apache.uniffle.coordinator.CoordinatorConf;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.storage.util.StorageType;
 
@@ -176,11 +177,13 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // task 0 attempt 0 generate three blocks
@@ -339,11 +342,13 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
 
     // 3 report shuffle result
@@ -511,11 +516,13 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // this shuffle have three partition, which is hash by key index mode 3
@@ -718,11 +725,13 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
         ShuffleDataDistributionType.NORMAL,
         -1,
         0,
-        keyClass.getName(),
-        valueClass.getName(),
-        comparator.getClass().getName(),
-        -1,
-        null);
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClass.getName())
+            .setValueClass(valueClass.getName())
+            .setComparatorClass(comparator.getClass().getName())
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 3 report shuffle result
     // this shuffle have three partition, which is hash by key index mode 3

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -95,6 +95,7 @@ import org.apache.uniffle.proto.RssProtos.GetShuffleResultForMultiPartRequest;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultForMultiPartResponse;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultRequest;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultResponse;
+import org.apache.uniffle.proto.RssProtos.PMergeContext;
 import org.apache.uniffle.proto.RssProtos.PartitionToBlockIds;
 import org.apache.uniffle.proto.RssProtos.RemoteStorage;
 import org.apache.uniffle.proto.RssProtos.RemoteStorageConfItem;
@@ -198,11 +199,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      String keyClassName,
-      String valueClassName,
-      String comparatorClassName,
-      int mergedBlockSize,
-      String mergeClassLoader) {
+      PMergeContext mergeContext) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)
@@ -212,16 +209,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         .setMaxConcurrencyPerPartitionToWrite(maxConcurrencyPerPartitionToWrite)
         .addAllPartitionRanges(toShufflePartitionRanges(partitionRanges))
         .setStageAttemptNumber(stageAttemptNumber);
-    if (StringUtils.isNotBlank(keyClassName)) {
-      reqBuilder.setKeyClass(keyClassName);
-      reqBuilder.setValueClass(valueClassName);
-      if (StringUtils.isNotBlank(comparatorClassName)) {
-        reqBuilder.setComparatorClass(comparatorClassName);
-      }
-      reqBuilder.setMergedBlockSize(mergedBlockSize);
-      if (StringUtils.isNotBlank(mergeClassLoader)) {
-        reqBuilder.setMergeClassLoader(mergeClassLoader);
-      }
+    if (mergeContext != null && StringUtils.isNotBlank(mergeContext.getKeyClass())) {
+      reqBuilder.setMergeContext(mergeContext);
     }
     RemoteStorage.Builder rsBuilder = RemoteStorage.newBuilder();
     rsBuilder.setPath(remoteStorageInfo.getPath());
@@ -496,11 +485,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             request.getDataDistributionType(),
             request.getMaxConcurrencyPerPartitionToWrite(),
             request.getStageAttemptNumber(),
-            request.getKeyClassName(),
-            request.getValueClassName(),
-            request.getComparatorClassName(),
-            request.getMergedBlockSize(),
-            request.getMergeClassLoader());
+            request.getMergeContext());
 
     RssRegisterShuffleResponse response;
     RssProtos.StatusCode statusCode = rpcResponse.getStatus();

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
 import io.netty.buffer.Unpooled;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +208,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         .setMaxConcurrencyPerPartitionToWrite(maxConcurrencyPerPartitionToWrite)
         .addAllPartitionRanges(toShufflePartitionRanges(partitionRanges))
         .setStageAttemptNumber(stageAttemptNumber);
-    if (mergeContext != null && StringUtils.isNotBlank(mergeContext.getKeyClass())) {
+    if (mergeContext != null) {
       reqBuilder.setMergeContext(mergeContext);
     }
     RemoteStorage.Builder rsBuilder = RemoteStorage.newBuilder();

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -95,7 +95,7 @@ import org.apache.uniffle.proto.RssProtos.GetShuffleResultForMultiPartRequest;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultForMultiPartResponse;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultRequest;
 import org.apache.uniffle.proto.RssProtos.GetShuffleResultResponse;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 import org.apache.uniffle.proto.RssProtos.PartitionToBlockIds;
 import org.apache.uniffle.proto.RssProtos.RemoteStorage;
 import org.apache.uniffle.proto.RssProtos.RemoteStorageConfItem;
@@ -199,7 +199,7 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      PMergeContext mergeContext) {
+      MergeContext mergeContext) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -25,6 +25,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.config.RssClientConf;
+import org.apache.uniffle.proto.RssProtos.PMergeContext;
 
 public class RssRegisterShuffleRequest {
 
@@ -36,11 +37,8 @@ public class RssRegisterShuffleRequest {
   private ShuffleDataDistributionType dataDistributionType;
   private int maxConcurrencyPerPartitionToWrite;
   private int stageAttemptNumber;
-  private String keyClassName;
-  private String valueClassName;
-  private String comparatorClassName;
-  private int mergedBlockSize;
-  private String mergeClassLoader;
+
+  private final PMergeContext mergeContext;
 
   public RssRegisterShuffleRequest(
       String appId,
@@ -59,10 +57,6 @@ public class RssRegisterShuffleRequest {
         dataDistributionType,
         maxConcurrencyPerPartitionToWrite,
         0,
-        null,
-        null,
-        null,
-        -1,
         null);
   }
 
@@ -75,11 +69,7 @@ public class RssRegisterShuffleRequest {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      String keyClassName,
-      String valueClassName,
-      String comparatorClassName,
-      int mergedBlockSize,
-      String mergeClassLoader) {
+      PMergeContext mergeContext) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionRanges = partitionRanges;
@@ -88,11 +78,7 @@ public class RssRegisterShuffleRequest {
     this.dataDistributionType = dataDistributionType;
     this.maxConcurrencyPerPartitionToWrite = maxConcurrencyPerPartitionToWrite;
     this.stageAttemptNumber = stageAttemptNumber;
-    this.keyClassName = keyClassName;
-    this.valueClassName = valueClassName;
-    this.comparatorClassName = comparatorClassName;
-    this.mergedBlockSize = mergedBlockSize;
-    this.mergeClassLoader = mergeClassLoader;
+    this.mergeContext = mergeContext;
   }
 
   public RssRegisterShuffleRequest(
@@ -111,10 +97,6 @@ public class RssRegisterShuffleRequest {
         dataDistributionType,
         RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE.defaultValue(),
         0,
-        null,
-        null,
-        null,
-        -1,
         null);
   }
 
@@ -129,10 +111,6 @@ public class RssRegisterShuffleRequest {
         ShuffleDataDistributionType.NORMAL,
         RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE.defaultValue(),
         0,
-        null,
-        null,
-        null,
-        -1,
         null);
   }
 
@@ -168,23 +146,7 @@ public class RssRegisterShuffleRequest {
     return stageAttemptNumber;
   }
 
-  public String getKeyClassName() {
-    return keyClassName;
-  }
-
-  public String getValueClassName() {
-    return valueClassName;
-  }
-
-  public String getComparatorClassName() {
-    return comparatorClassName;
-  }
-
-  public int getMergedBlockSize() {
-    return mergedBlockSize;
-  }
-
-  public String getMergeClassLoader() {
-    return mergeClassLoader;
+  public PMergeContext getMergeContext() {
+    return mergeContext;
   }
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -25,7 +25,7 @@ import org.apache.uniffle.common.PartitionRange;
 import org.apache.uniffle.common.RemoteStorageInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
 import org.apache.uniffle.common.config.RssClientConf;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 
 public class RssRegisterShuffleRequest {
 
@@ -38,7 +38,7 @@ public class RssRegisterShuffleRequest {
   private int maxConcurrencyPerPartitionToWrite;
   private int stageAttemptNumber;
 
-  private final PMergeContext mergeContext;
+  private final MergeContext mergeContext;
 
   public RssRegisterShuffleRequest(
       String appId,
@@ -69,7 +69,7 @@ public class RssRegisterShuffleRequest {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      PMergeContext mergeContext) {
+      MergeContext mergeContext) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionRanges = partitionRanges;
@@ -146,7 +146,7 @@ public class RssRegisterShuffleRequest {
     return stageAttemptNumber;
   }
 
-  public PMergeContext getMergeContext() {
+  public MergeContext getMergeContext() {
     return mergeContext;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -179,7 +179,7 @@ message ShufflePartitionRange {
   int32 end = 2;
 }
 
-message PMergeContext {
+message MergeContext {
   string keyClass = 1;
   string valueClass = 2;
   string comparatorClass = 3;
@@ -196,7 +196,7 @@ message ShuffleRegisterRequest {
   DataDistribution shuffleDataDistribution = 6;
   int32 maxConcurrencyPerPartitionToWrite = 7;
   int32 stageAttemptNumber = 8;
-  PMergeContext mergeContext = 9;
+  MergeContext mergeContext = 9;
 }
 
 enum DataDistribution {

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -179,6 +179,14 @@ message ShufflePartitionRange {
   int32 end = 2;
 }
 
+message PMergeContext {
+  string keyClass = 1;
+  string valueClass = 2;
+  string comparatorClass = 3;
+  int32 mergedBlockSize = 4;
+  string mergeClassLoader = 5;
+}
+
 message ShuffleRegisterRequest {
   string appId = 1;
   int32 shuffleId = 2;
@@ -188,11 +196,7 @@ message ShuffleRegisterRequest {
   DataDistribution shuffleDataDistribution = 6;
   int32 maxConcurrencyPerPartitionToWrite = 7;
   int32 stageAttemptNumber = 8;
-  string keyClass = 9;
-  string valueClass = 10;
-  string comparatorClass = 11;
-  int32 mergedBlockSize = 12;
-  string mergeClassLoader = 13;
+  PMergeContext mergeContext = 9;
 }
 
 enum DataDistribution {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -325,7 +325,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   maxConcurrencyPerPartitionToWrite);
       if (StatusCode.SUCCESS == result
           && shuffleServer.isRemoteMergeEnable()
-          && StringUtils.isNotBlank(req.getKeyClass())) {
+          && req.hasMergeContext()) {
         // The merged block is in a different domain from the original block,
         // so you need to register a new app for holding the merged block.
         result =
@@ -343,14 +343,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
           result =
               shuffleServer
                   .getShuffleMergeManager()
-                  .registerShuffle(
-                      appId,
-                      shuffleId,
-                      req.getKeyClass(),
-                      req.getValueClass(),
-                      req.getComparatorClass(),
-                      req.getMergedBlockSize(),
-                      req.getMergeClassLoader());
+                  .registerShuffle(appId, shuffleId, req.getMergeContext());
         }
       }
       auditContext.withStatusCode(result);

--- a/server/src/main/java/org/apache/uniffle/server/merge/ShuffleMergeManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/merge/ShuffleMergeManager.java
@@ -44,7 +44,7 @@ import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.merger.Segment;
 import org.apache.uniffle.common.rpc.StatusCode;
 import org.apache.uniffle.common.util.JavaUtils;
-import org.apache.uniffle.proto.RssProtos.PMergeContext;
+import org.apache.uniffle.proto.RssProtos.MergeContext;
 import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 
@@ -147,7 +147,7 @@ public class ShuffleMergeManager {
     return cachedClassLoader.getOrDefault(label, cachedClassLoader.get(""));
   }
 
-  public StatusCode registerShuffle(String appId, int shuffleId, PMergeContext mergeContext) {
+  public StatusCode registerShuffle(String appId, int shuffleId, MergeContext mergeContext) {
     try {
       ClassLoader classLoader = getClassLoader(mergeContext.getMergeClassLoader());
       Class kClass = ClassUtils.getClass(classLoader, mergeContext.getKeyClass());

--- a/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.uniffle.common.serializer.PartialInputStream;
 import org.apache.uniffle.common.serializer.SerializerUtils;
 import org.apache.uniffle.common.serializer.writable.WritableSerializer;
 import org.apache.uniffle.common.util.BlockIdLayout;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.server.ShuffleServer;
 import org.apache.uniffle.server.ShuffleServerConf;
 import org.apache.uniffle.server.ShuffleServerMetrics;
@@ -129,7 +130,15 @@ public class ShuffleMergeManagerTest {
         new RemoteStorageInfo(""),
         USER);
     mergeManager.registerShuffle(
-        APP_ID, SHUFFLE_ID, keyClassName, valueClassName, comparatorClassName, -1, "");
+        APP_ID,
+        SHUFFLE_ID,
+        RssProtos.PMergeContext.newBuilder()
+            .setKeyClass(keyClassName)
+            .setValueClass(valueClassName)
+            .setComparatorClass(comparatorClassName)
+            .setMergedBlockSize(-1)
+            .setMergeClassLoader("")
+            .build());
 
     // 4 report blocks
     // 4.1 send shuffle data

--- a/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/merge/ShuffleMergeManagerTest.java
@@ -132,7 +132,7 @@ public class ShuffleMergeManagerTest {
     mergeManager.registerShuffle(
         APP_ID,
         SHUFFLE_ID,
-        RssProtos.PMergeContext.newBuilder()
+        RssProtos.MergeContext.newBuilder()
             .setKeyClass(keyClassName)
             .setValueClass(valueClassName)
             .setComparatorClass(comparatorClassName)


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Refactor to use mergeContext collect the arguments related to remote merger

### Why are the changes needed?

- Make code clean and friendly to other developer who do not attention to `Remote Merger`.
- Without api change while extends the `mergeContext`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need, just refactor.
