### PR TITLE
[#2197] Support reg app conf to server and avoid update committed/cached blockIds bitmap

### DIFF
--- a/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -722,7 +722,8 @@ public class SortWriteBufferManagerTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.MergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext,
+        Map<String, String> properties) {}
 
     @Override
     public boolean sendCommit(

--- a/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/core/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -508,7 +508,8 @@ public class FetcherTest {
         ShuffleDataDistributionType distributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.MergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext,
+        Map<String, String> properties) {}
 
     @Override
     public boolean sendCommit(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -899,11 +899,6 @@ public class RssShuffleManager extends RssShuffleManagerBase {
         this.sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX));
   }
 
-  @VisibleForTesting
-  public SparkConf getSparkConf() {
-    return sparkConf;
-  }
-
   private synchronized void startHeartbeat() {
     shuffleWriteClient.registerApplicationInfo(id.get(), heartbeatTimeout, user);
     if (!heartbeatStarted) {

--- a/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
+++ b/client-tez/src/test/java/org/apache/tez/runtime/library/common/sort/buffer/WriteBufferManagerTest.java
@@ -716,7 +716,8 @@ public class WriteBufferManagerTest {
         ShuffleDataDistributionType dataDistributionType,
         int maxConcurrencyPerPartitionToWrite,
         int stageAttemptNumber,
-        RssProtos.MergeContext mergeContext) {}
+        RssProtos.MergeContext mergeContext,
+        Map<String, String> properties) {}
 
     @Override
     public boolean sendCommit(

--- a/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/org/apache/uniffle/client/api/ShuffleWriteClient.java
@@ -73,7 +73,53 @@ public interface ShuffleWriteClient {
         dataDistributionType,
         maxConcurrencyPerPartitionToWrite,
         0,
-        null);
+        null,
+        Collections.emptyMap());
+  }
+
+  default void registerShuffle(
+      ShuffleServerInfo shuffleServerInfo,
+      String appId,
+      int shuffleId,
+      List<PartitionRange> partitionRanges,
+      RemoteStorageInfo remoteStorage,
+      ShuffleDataDistributionType dataDistributionType,
+      int maxConcurrencyPerPartitionToWrite,
+      Map<String, String> properties) {
+    registerShuffle(
+        shuffleServerInfo,
+        appId,
+        shuffleId,
+        partitionRanges,
+        remoteStorage,
+        dataDistributionType,
+        maxConcurrencyPerPartitionToWrite,
+        0,
+        null,
+        properties);
+  }
+
+  default void registerShuffle(
+      ShuffleServerInfo shuffleServerInfo,
+      String appId,
+      int shuffleId,
+      List<PartitionRange> partitionRanges,
+      RemoteStorageInfo remoteStorage,
+      ShuffleDataDistributionType dataDistributionType,
+      int maxConcurrencyPerPartitionToWrite,
+      int stageAttemptNumber,
+      MergeContext mergeContext) {
+    registerShuffle(
+        shuffleServerInfo,
+        appId,
+        shuffleId,
+        partitionRanges,
+        remoteStorage,
+        dataDistributionType,
+        maxConcurrencyPerPartitionToWrite,
+        stageAttemptNumber,
+        mergeContext,
+        Collections.emptyMap());
   }
 
   void registerShuffle(
@@ -85,7 +131,8 @@ public interface ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      MergeContext mergeContext);
+      MergeContext mergeContext,
+      Map<String, String> properties);
 
   boolean sendCommit(
       Set<ShuffleServerInfo> shuffleServerInfoSet, String appId, int shuffleId, int numMaps);

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleWriteClientImpl.java
@@ -565,7 +565,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      MergeContext mergeContext) {
+      MergeContext mergeContext,
+      Map<String, String> properties) {
     String user = null;
     try {
       user = UserGroupInformation.getCurrentUser().getShortUserName();
@@ -583,7 +584,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             dataDistributionType,
             maxConcurrencyPerPartitionToWrite,
             stageAttemptNumber,
-            mergeContext);
+            mergeContext,
+            properties);
     RssRegisterShuffleResponse response =
         getShuffleServerClient(shuffleServerInfo).registerShuffle(request);
 

--- a/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
+++ b/client/src/test/java/org/apache/uniffle/client/record/reader/MockedShuffleWriteClient.java
@@ -64,7 +64,8 @@ public class MockedShuffleWriteClient implements ShuffleWriteClient {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      RssProtos.MergeContext mergeContext) {}
+      RssProtos.MergeContext mergeContext,
+      Map<String, String> properties) {}
 
   @Override
   public boolean sendCommit(

--- a/common/src/main/java/org/apache/uniffle/common/util/Constants.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/Constants.java
@@ -91,4 +91,6 @@ public final class Constants {
   public static final String DRIVER_HOST = "driver.host";
 
   public static final String DATE_PATTERN = "yyyy-MM-dd HH:mm:ss";
+
+  public static final String SPARK_RSS_CONFIG_PREFIX = "spark.";
 }

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -198,7 +198,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      MergeContext mergeContext) {
+      MergeContext mergeContext,
+      Map<String, String> properties) {
     ShuffleRegisterRequest.Builder reqBuilder = ShuffleRegisterRequest.newBuilder();
     reqBuilder
         .setAppId(appId)
@@ -207,7 +208,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         .setShuffleDataDistribution(RssProtos.DataDistribution.valueOf(dataDistributionType.name()))
         .setMaxConcurrencyPerPartitionToWrite(maxConcurrencyPerPartitionToWrite)
         .addAllPartitionRanges(toShufflePartitionRanges(partitionRanges))
-        .setStageAttemptNumber(stageAttemptNumber);
+        .setStageAttemptNumber(stageAttemptNumber)
+        .putAllProperties(properties);
     if (mergeContext != null) {
       reqBuilder.setMergeContext(mergeContext);
     }
@@ -484,7 +486,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
             request.getDataDistributionType(),
             request.getMaxConcurrencyPerPartitionToWrite(),
             request.getStageAttemptNumber(),
-            request.getMergeContext());
+            request.getMergeContext(),
+            request.getProperties());
 
     RssRegisterShuffleResponse response;
     RssProtos.StatusCode statusCode = rpcResponse.getStatus();

--- a/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/request/RssRegisterShuffleRequest.java
@@ -17,8 +17,11 @@
 
 package org.apache.uniffle.client.request;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.uniffle.common.PartitionRange;
@@ -39,7 +42,9 @@ public class RssRegisterShuffleRequest {
   private int stageAttemptNumber;
 
   private final MergeContext mergeContext;
+  private Map<String, String> properties;
 
+  @VisibleForTesting
   public RssRegisterShuffleRequest(
       String appId,
       int shuffleId,
@@ -57,7 +62,8 @@ public class RssRegisterShuffleRequest {
         dataDistributionType,
         maxConcurrencyPerPartitionToWrite,
         0,
-        null);
+        null,
+        Collections.emptyMap());
   }
 
   public RssRegisterShuffleRequest(
@@ -69,7 +75,8 @@ public class RssRegisterShuffleRequest {
       ShuffleDataDistributionType dataDistributionType,
       int maxConcurrencyPerPartitionToWrite,
       int stageAttemptNumber,
-      MergeContext mergeContext) {
+      MergeContext mergeContext,
+      Map<String, String> properties) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionRanges = partitionRanges;
@@ -79,8 +86,10 @@ public class RssRegisterShuffleRequest {
     this.maxConcurrencyPerPartitionToWrite = maxConcurrencyPerPartitionToWrite;
     this.stageAttemptNumber = stageAttemptNumber;
     this.mergeContext = mergeContext;
+    this.properties = properties;
   }
 
+  @VisibleForTesting
   public RssRegisterShuffleRequest(
       String appId,
       int shuffleId,
@@ -97,7 +106,8 @@ public class RssRegisterShuffleRequest {
         dataDistributionType,
         RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE.defaultValue(),
         0,
-        null);
+        null,
+        Collections.emptyMap());
   }
 
   public RssRegisterShuffleRequest(
@@ -111,7 +121,8 @@ public class RssRegisterShuffleRequest {
         ShuffleDataDistributionType.NORMAL,
         RssClientConf.MAX_CONCURRENCY_PER_PARTITION_TO_WRITE.defaultValue(),
         0,
-        null);
+        null,
+        Collections.emptyMap());
   }
 
   public String getAppId() {
@@ -148,5 +159,9 @@ public class RssRegisterShuffleRequest {
 
   public MergeContext getMergeContext() {
     return mergeContext;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
   }
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -197,6 +197,7 @@ message ShuffleRegisterRequest {
   int32 maxConcurrencyPerPartitionToWrite = 7;
   int32 stageAttemptNumber = 8;
   MergeContext mergeContext = 9;
+  map<string, string> properties = 10;
 }
 
 enum DataDistribution {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -194,11 +194,14 @@ public class ShuffleFlushManager {
         throw new EventRetryException();
       }
       long endTime = System.currentTimeMillis();
-
-      // update some metrics for shuffle task
-      updateCommittedBlockIds(event.getAppId(), event.getShuffleId(), event.getShuffleBlocks());
       ShuffleTaskInfo shuffleTaskInfo =
           shuffleServer.getShuffleTaskManager().getShuffleTaskInfo(event.getAppId());
+      if (shuffleTaskInfo == null || !shuffleTaskInfo.isClientStorageTypeWithMemory()) {
+        // With memory storage type should never need cachedBlockIds,
+        // since client do not need call finish shuffle rpc
+        // update some metrics for shuffle task
+        updateCommittedBlockIds(event.getAppId(), event.getShuffleId(), event.getShuffleBlocks());
+      }
       if (isStorageAuditLogEnabled) {
         AUDIT_LOGGER.info(
             String.format(

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleFlushManager.java
@@ -103,9 +103,7 @@ public class ShuffleFlushManager {
                 .mapToLong(bitmap -> bitmap.getLongCardinality())
                 .sum(),
         2 * 60 * 1000L /* 2 minutes */);
-    this.storageTypeWithMemory =
-        StorageType.withMemory(
-            StorageType.valueOf(shuffleServerConf.get(ShuffleServerConf.RSS_STORAGE_TYPE).name()));
+    this.storageTypeWithMemory = StorageType.withMemory(StorageType.valueOf(storageType));
   }
 
   public void addToFlushQueue(ShuffleDataFlushEvent event) {

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -719,8 +719,8 @@ public class ShuffleServerConf extends RssBaseConf {
           .booleanType()
           .defaultValue(false)
           .withDescription("Whether to enable app detail log");
-  public static final ConfigOption<Boolean> SERVER_WITH_MEMORY_STORAGE_TYPE_OPTIMIZE_ENABLED =
-      ConfigOptions.key("rss.server.with.memory.storage.type.opt.enabled")
+  public static final ConfigOption<Boolean> SERVER_STORAGE_BITMAP_MEMORY_OPTIMIZE_ENABLED =
+      ConfigOptions.key("rss.server.storage.bitmapMemoryOptimizeEnabled")
           .booleanType()
           .defaultValue(true)
           .withDescription("Whether to enable with memory storage type optimize");

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -719,6 +719,11 @@ public class ShuffleServerConf extends RssBaseConf {
           .booleanType()
           .defaultValue(false)
           .withDescription("Whether to enable app detail log");
+  public static final ConfigOption<Boolean> SERVER_WITH_MEMORY_STORAGE_TYPE_OPTIMIZE_ENABLED =
+      ConfigOptions.key("rss.server.with.memory.storage.type.opt.enabled")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription("Whether to enable with memory storage type optimize");
 
   public ShuffleServerConf() {}
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -719,11 +719,6 @@ public class ShuffleServerConf extends RssBaseConf {
           .booleanType()
           .defaultValue(false)
           .withDescription("Whether to enable app detail log");
-  public static final ConfigOption<Boolean> SERVER_STORAGE_BITMAP_MEMORY_OPTIMIZE_ENABLED =
-      ConfigOptions.key("rss.server.storage.bitmapMemoryOptimizeEnabled")
-          .booleanType()
-          .defaultValue(true)
-          .withDescription("Whether to enable with memory storage type optimize");
 
   public ShuffleServerConf() {}
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -322,7 +322,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                   new RemoteStorageInfo(remoteStoragePath, remoteStorageConf),
                   user,
                   shuffleDataDistributionType,
-                  maxConcurrencyPerPartitionToWrite);
+                  maxConcurrencyPerPartitionToWrite,
+                  req.getPropertiesMap());
       if (StatusCode.SUCCESS == result
           && shuffleServer.isRemoteMergeEnable()
           && req.hasMergeContext()) {
@@ -338,7 +339,8 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
                     new RemoteStorageInfo(remoteStoragePath, remoteStorageConf),
                     user,
                     shuffleDataDistributionType,
-                    maxConcurrencyPerPartitionToWrite);
+                    maxConcurrencyPerPartitionToWrite,
+                    req.getPropertiesMap());
         if (result == StatusCode.SUCCESS) {
           result =
               shuffleServer

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -98,6 +98,7 @@ import org.apache.uniffle.server.merge.MergeStatus;
 import org.apache.uniffle.storage.common.Storage;
 import org.apache.uniffle.storage.common.StorageReadMetrics;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;
+import org.apache.uniffle.storage.util.StorageType;
 
 import static org.apache.uniffle.server.merge.ShuffleMergeManager.MERGE_APP_SUFFIX;
 
@@ -578,6 +579,15 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       String appId = req.getAppId();
       int shuffleId = req.getShuffleId();
       auditContext.withAppId(appId).withShuffleId(shuffleId);
+      org.apache.uniffle.common.StorageType storageType =
+          shuffleServer.getShuffleServerConf().get(ShuffleServerConf.RSS_STORAGE_TYPE);
+      boolean storageTypeWithMemory =
+          StorageType.withMemory(StorageType.valueOf(storageType.name()));
+      if (storageTypeWithMemory) {
+        LOG.warn(
+            "finishShuffle should not be called while server-side configured StorageType to {}",
+            storageType);
+      }
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
         auditContext.withStatusCode(status);
@@ -635,6 +645,15 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
       String appId = req.getAppId();
       int shuffleId = req.getShuffleId();
       auditContext.withAppId(appId).withShuffleId(shuffleId);
+      org.apache.uniffle.common.StorageType storageType =
+          shuffleServer.getShuffleServerConf().get(ShuffleServerConf.RSS_STORAGE_TYPE);
+      boolean storageTypeWithMemory =
+          StorageType.withMemory(StorageType.valueOf(storageType.name()));
+      if (storageTypeWithMemory) {
+        LOG.warn(
+            "finishShuffle should not be called while server-side configured StorageType to {}",
+            storageType);
+      }
       StatusCode status = verifyRequest(appId);
       if (status != StatusCode.SUCCESS) {
         auditContext.withStatusCode(status);

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -334,7 +334,7 @@ public class ShuffleTaskInfo {
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     this.properties = filteredProperties;
     LOGGER.info("{} set properties to {}", appId, properties);
-    if (serverConf.getBoolean(ShuffleServerConf.SERVER_WITH_MEMORY_STORAGE_TYPE_OPTIMIZE_ENABLED)) {
+    if (serverConf.getBoolean(ShuffleServerConf.SERVER_STORAGE_BITMAP_MEMORY_OPTIMIZE_ENABLED)) {
       String storageType = properties.get(RssClientConf.RSS_STORAGE_TYPE.key());
       if (StringUtils.isEmpty(storageType)) {
         storageType =

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -26,18 +26,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.PartitionInfo;
 import org.apache.uniffle.common.ShuffleDataDistributionType;
-import org.apache.uniffle.common.config.RssClientConf;
-import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.UnitConverter;
-import org.apache.uniffle.storage.util.StorageType;
 
 /**
  * ShuffleTaskInfo contains the information of submitting the shuffle, the information of the cache
@@ -82,7 +78,6 @@ public class ShuffleTaskInfo {
 
   private final Map<Integer, Integer> latestStageAttemptNumbers;
   private Map<String, String> properties;
-  private boolean clientStorageTypeWithMemory = false;
 
   public ShuffleTaskInfo(String appId) {
     this.appId = appId;
@@ -302,10 +297,6 @@ public class ShuffleTaskInfo {
     return partitionDataSizes.values().stream().mapToLong(Map::size).sum();
   }
 
-  public boolean isClientStorageTypeWithMemory() {
-    return clientStorageTypeWithMemory;
-  }
-
   @Override
   public String toString() {
     return "ShuffleTaskInfo{"
@@ -327,24 +318,12 @@ public class ShuffleTaskInfo {
         + '}';
   }
 
-  public void setProperties(Map<String, String> properties, ShuffleServerConf serverConf) {
+  public void setProperties(Map<String, String> properties) {
     Map<String, String> filteredProperties =
         properties.entrySet().stream()
             .filter(entry -> entry.getKey().contains(".rss."))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     this.properties = filteredProperties;
     LOGGER.info("{} set properties to {}", appId, properties);
-    if (serverConf.getBoolean(ShuffleServerConf.SERVER_STORAGE_BITMAP_MEMORY_OPTIMIZE_ENABLED)) {
-      String storageType = properties.get(RssClientConf.RSS_STORAGE_TYPE.key());
-      if (StringUtils.isEmpty(storageType)) {
-        storageType =
-            properties.get(
-                Constants.SPARK_RSS_CONFIG_PREFIX + RssClientConf.RSS_STORAGE_TYPE.key());
-      }
-      if (StringUtils.isNotEmpty(storageType)) {
-        clientStorageTypeWithMemory = StorageType.withMemory(StorageType.valueOf(storageType));
-        LOGGER.info("{} set clientStorageTypeWithMemory to {}", appId, clientStorageTypeWithMemory);
-      }
-    }
   }
 }

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskManager.java
@@ -149,9 +149,12 @@ public class ShuffleTaskManager {
     this.shuffleBufferManager = shuffleBufferManager;
     this.storageManager = storageManager;
     this.shuffleMergeManager = shuffleMergeManager;
+    org.apache.uniffle.common.StorageType storageType =
+        conf.get(ShuffleServerConf.RSS_STORAGE_TYPE);
     this.storageTypeWithMemory =
-        StorageType.withMemory(
-            StorageType.valueOf(conf.get(ShuffleServerConf.RSS_STORAGE_TYPE).name()));
+        storageType == null
+            ? false
+            : StorageType.withMemory(StorageType.valueOf(storageType.name()));
     this.appExpiredWithoutHB = conf.getLong(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT);
     this.commitCheckIntervalMax = conf.getLong(ShuffleServerConf.SERVER_COMMIT_CHECK_INTERVAL_MAX);
     this.preAllocationExpired = conf.getLong(ShuffleServerConf.SERVER_PRE_ALLOCATION_EXPIRED);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support reg app conf to server.

### Why are the changes needed?

Fix #2197

Avoid update committed/cached blockIds bitmap while storage type is with memory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally