### PR TITLE
[#2205] feature(dashboard) Display version and gitCommitId in one column

### DIFF
--- a/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
+++ b/dashboard/src/main/webapp/src/pages/ApplicationPage.vue
@@ -79,16 +79,13 @@
           :formatter="dateFormatter"
           sortable
         />
-        <el-table-column
-          prop="version"
-          label="Version"
-          min-width="180"
-        />
-        <el-table-column
-          prop="gitCommitId"
-          label="GitCommitId"
-          min-width="180"
-        />
+        <el-table-column label="Version" min-width="180">
+          <template v-slot="{ row }">
+            <div class="version">
+              {{ row.version }}_{{ row.gitCommitId }}
+            </div>
+          </template>
+        </el-table-column>
       </el-table>
     </div>
   </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Display version and gitCommitId in one column

### Why are the changes needed?

Fix: #2205 

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
Locally

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/93ff9a00-b4ec-4b75-b725-726600639e31">
