### PR TITLE
[#2209] [FOLLOWUP]feat(server) Support config buffer size for HadoopShuffleWriteHandler

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
+++ b/common/src/main/java/org/apache/uniffle/common/config/RssBaseConf.java
@@ -294,17 +294,29 @@ public class RssBaseConf extends RssConf {
                   + " first combining the username and the password with a colon (uniffle:uniffle123)"
                   + ", and then by encoding the resulting string in base64 (dW5pZmZsZTp1bmlmZmxlMTIz).");
 
-  public static final ConfigOption<String> RSS_STORAGE_WRITE_DATA_BUFFER_SIZE =
-      ConfigOptions.key("rss.storage.write.dataBufferSize")
+  public static final ConfigOption<String> RSS_STORAGE_LOCALFILE_WRITE_DATA_BUFFER_SIZE =
+      ConfigOptions.key("rss.storage.localfile.write.dataBufferSize")
           .stringType()
           .defaultValue("8k")
-          .withDescription("The buffer size to cache the write data content.");
+          .withDescription("The buffer size to cache the write data content for LOCALFILE.");
 
-  public static final ConfigOption<String> RSS_STORAGE_WRITE_INDEX_BUFFER_SIZE =
-      ConfigOptions.key("rss.storage.write.indexBufferSize")
+  public static final ConfigOption<String> RSS_STORAGE_LOCALFILE_WRITE_INDEX_BUFFER_SIZE =
+      ConfigOptions.key("rss.storage.localfile.write.indexBufferSize")
           .stringType()
           .defaultValue("8k")
-          .withDescription("The buffer size to cache the write index content.");
+          .withDescription("The buffer size to cache the write index content for LOCALFILE.");
+
+  public static final ConfigOption<String> RSS_STORAGE_HDFS_WRITE_DATA_BUFFER_SIZE =
+      ConfigOptions.key("rss.storage.hdfs.write.dataBufferSize")
+          .stringType()
+          .defaultValue("8k")
+          .withDescription("The buffer size to cache the write data content for HDFS.");
+
+  public static final ConfigOption<String> RSS_STORAGE_HDFS_WRITE_INDEX_BUFFER_SIZE =
+      ConfigOptions.key("rss.storage.hdfs.write.indexBufferSize")
+          .stringType()
+          .defaultValue("8k")
+          .withDescription("The buffer size to cache the write index content for HDFS.");
 
   public boolean loadConfFromFile(String fileName, List<ConfigOption<Object>> configOptions) {
     Map<String, String> properties = RssUtils.getPropertiesFromFile(fileName);

--- a/storage/src/main/java/org/apache/uniffle/storage/common/HadoopStorage.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/common/HadoopStorage.java
@@ -83,6 +83,7 @@ public class HadoopStorage extends AbstractStorage {
       String user = request.getUser();
       if (request.getMaxFileNumber() == 1) {
         return new HadoopShuffleWriteHandler(
+            request.getRssBaseConf(),
             request.getAppId(),
             request.getShuffleId(),
             request.getStartPartition(),
@@ -93,6 +94,7 @@ public class HadoopStorage extends AbstractStorage {
             user);
       } else {
         return new PooledHadoopShuffleWriteHandler(
+            request.getRssBaseConf(),
             request.getAppId(),
             request.getShuffleId(),
             request.getStartPartition(),

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/LocalFileWriteHandler.java
@@ -61,13 +61,13 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
     this.dataBufferSize =
         (int)
             this.rssBaseConf.getSizeAsBytes(
-                RssBaseConf.RSS_STORAGE_WRITE_DATA_BUFFER_SIZE.key(),
-                RssBaseConf.RSS_STORAGE_WRITE_DATA_BUFFER_SIZE.defaultValue());
+                RssBaseConf.RSS_STORAGE_LOCALFILE_WRITE_DATA_BUFFER_SIZE.key(),
+                RssBaseConf.RSS_STORAGE_LOCALFILE_WRITE_DATA_BUFFER_SIZE.defaultValue());
     this.indexBufferSize =
         (int)
             this.rssBaseConf.getSizeAsBytes(
-                RssBaseConf.RSS_STORAGE_WRITE_INDEX_BUFFER_SIZE.key(),
-                RssBaseConf.RSS_STORAGE_WRITE_INDEX_BUFFER_SIZE.defaultValue());
+                RssBaseConf.RSS_STORAGE_LOCALFILE_WRITE_INDEX_BUFFER_SIZE.key(),
+                RssBaseConf.RSS_STORAGE_LOCALFILE_WRITE_INDEX_BUFFER_SIZE.defaultValue());
     createBasePath();
   }
 

--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHadoopShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHadoopShuffleWriteHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.storage.handler.api.ShuffleWriteHandler;
 import org.apache.uniffle.storage.util.ShuffleStorageUtils;
@@ -70,6 +71,7 @@ public class PooledHadoopShuffleWriteHandler implements ShuffleWriteHandler {
   }
 
   public PooledHadoopShuffleWriteHandler(
+      RssBaseConf rssBaseConf,
       String appId,
       int shuffleId,
       int startPartition,
@@ -90,6 +92,7 @@ public class PooledHadoopShuffleWriteHandler implements ShuffleWriteHandler {
         index -> {
           try {
             return new HadoopShuffleWriteHandler(
+                rssBaseConf,
                 appId,
                 shuffleId,
                 startPartition,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support config buffer size for HadoopShuffleWriteHandler

### Why are the changes needed?

Fix: #2209 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally test.