### PR TITLE
[#2219] feat(server) add new bitmap strategy

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -720,6 +720,12 @@ public class ShuffleServerConf extends RssBaseConf {
           .defaultValue(false)
           .withDescription("Whether to enable app detail log");
 
+  public static final ConfigOption<Boolean> SERVER_BITMAP_NEW_STRATEGY_ENABLED =
+      ConfigOptions.key("rss.server.bitmap.new.strategy")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to enable new strategy of bitmap.");
+
   public ShuffleServerConf() {}
 
   public ShuffleServerConf(String fileName) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Supports one bitmap per partition.
Add a new config `   rss.server.bitmap.new.strategy`to decide whether to enable the function.

### Why are the changes needed?

Fix: #2219 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested locally.