### PR TITLE
[MINOR] feat(operator): Add support for PodManagementPolicy

### DIFF
--- a/deploy/kubernetes/operator/api/uniffle/v1alpha1/remoteshuffleservice_types.go
+++ b/deploy/kubernetes/operator/api/uniffle/v1alpha1/remoteshuffleservice_types.go
@@ -18,6 +18,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,6 +151,11 @@ type ShuffleServerConfig struct {
 
 	// UpgradeStrategy defines upgrade strategy of shuffle servers.
 	UpgradeStrategy *ShuffleServerUpgradeStrategy `json:"upgradeStrategy"`
+
+	// PodManagementPolicy defines the policy used to manage shuffle servers' pods,
+	// options are OrderedReady and Parallel, default is OrderedReady.
+	// +optional
+	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 
 	// volumeClaimTemplates is a list of claims that pods are allowed to reference.
 	// The StatefulSet controller is responsible for mapping network identities to

--- a/deploy/kubernetes/operator/config/crd/bases/uniffle.apache.org_remoteshuffleservices.yaml
+++ b/deploy/kubernetes/operator/config/crd/bases/uniffle.apache.org_remoteshuffleservices.yaml
@@ -6812,6 +6812,11 @@ spec:
                     description: Parameters holds the optional parameters used by
                       coordinators or shuffle servers.
                     type: object
+                  podManagementPolicy:
+                    description: PodManagementPolicy defines the policy used to manage
+                      shuffle servers' pods, options are OrderedReady and Parallel,
+                      default is OrderedReady.
+                    type: string
                   ports:
                     description: Ports represents ports used by coordinators or shuffle
                       servers.

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver.go
@@ -162,6 +162,7 @@ func GenerateSts(kubeClient kubernetes.Interface, rss *unifflev1alpha1.RemoteShu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: defaultLabels,
 			},
+			PodManagementPolicy: rss.Spec.ShuffleServer.PodManagementPolicy,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{

--- a/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
+++ b/deploy/kubernetes/operator/pkg/controller/sync/shuffleserver/shuffleserver_test.go
@@ -245,6 +245,12 @@ func withCustomVolumeClaimTemplates(volumeClaimTemplates []corev1.PersistentVolu
 	return rss
 }
 
+func withPodManagementPolicy(policy appsv1.PodManagementPolicyType) *uniffleapi.RemoteShuffleService {
+	rss := utils.BuildRSSWithDefaultValue()
+	rss.Spec.ShuffleServer.PodManagementPolicy = policy
+	return rss
+}
+
 func buildRssWithHPA() *uniffleapi.RemoteShuffleService {
 	rss := utils.BuildRSSWithDefaultValue()
 	rss.Spec.ShuffleServer.Autoscaler.Enable = true
@@ -561,6 +567,26 @@ func TestGenerateSts(t *testing.T) {
 					}
 				} else {
 					return false, fmt.Errorf("generated deploy should include annotations: %v", testAnnotations)
+				}
+				return true, nil
+			},
+		},
+		{
+			name: "set OrderedReady pod management policy",
+			rss:  withPodManagementPolicy(appsv1.OrderedReadyPodManagement),
+			IsValidSts: func(sts *appsv1.StatefulSet, rss *uniffleapi.RemoteShuffleService) (bool, error) {
+				if sts.Spec.PodManagementPolicy != appsv1.OrderedReadyPodManagement {
+					return false, fmt.Errorf("expected OrderedReady pod management policy, got: %v", sts.Spec.PodManagementPolicy)
+				}
+				return true, nil
+			},
+		},
+		{
+			name: "set Parallel pod management policy",
+			rss:  withPodManagementPolicy(appsv1.ParallelPodManagement),
+			IsValidSts: func(sts *appsv1.StatefulSet, rss *uniffleapi.RemoteShuffleService) (bool, error) {
+				if sts.Spec.PodManagementPolicy != appsv1.ParallelPodManagement {
+					return false, fmt.Errorf("expected Parallel pod management policy, got: %v", sts.Spec.PodManagementPolicy)
 				}
 				return true, nil
 			},


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add optional PodManagementPolicy field under shuffleServer

### Why are the changes needed?
To support cases where users deploy the shuffle service as a short-lived service that is deployed and deleted frequently, allowing users to set PodManagementPolicy to `Parallel` makes deployment time shorter

### Does this PR introduce _any_ user-facing change?
Introduce 1 new optional field in CRD:
PodManagementPolicy

### How was this patch tested?
 UT + Manually
