### PR TITLE
[MINOR] improvement(server): LOG the exception call stack while unregisterShuffle

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerGrpcService.java
@@ -169,6 +169,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         }
       } catch (Exception e) {
         status = StatusCode.INTERNAL_ERROR;
+        LOG.error("App {} exception while unregisterShuffleByAppId", appId, e);
       }
 
       auditContext.withStatusCode(status);
@@ -212,6 +213,7 @@ public class ShuffleServerGrpcService extends ShuffleServerImplBase {
         }
       } catch (Exception e) {
         status = StatusCode.INTERNAL_ERROR;
+        LOG.error("App {} exception while unregisterShuffle", appId, e);
       }
 
       auditContext.withStatusCode(status);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

LOG the exception call stack while unregisterShuffle

### Why are the changes needed?

Easy to find the error call stack.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.
