### PR TITLE
[#2243] improvement(server): Record the unexpected exception event flushing operation duration

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
@@ -144,7 +144,10 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
       }
 
       LOG.error(
-          "Unexpected exceptions happened when handling the flush event: {}, due to ", event, e);
+          "Unexpected exceptions happened when handling the flush event: [{}] (it cost {} ms), due to ",
+          event,
+          System.currentTimeMillis() - start,
+          e);
       // We need to release the memory when unexpected exceptions happened
       event.doCleanup();
     } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Record the unexpected exception event flushing operation duration

### Why are the changes needed?

Fix: #2243

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
