### PR TITLE
[#2241] feat(server): Introduce option to mark server unhealthy once any storage corrupted

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerConf.java
@@ -267,6 +267,13 @@ public class ShuffleServerConf extends RssBaseConf {
           .defaultValue(2 * 1024L * 1024L)
           .withDescription("The index file size hint");
 
+  public static final ConfigOption<Boolean> SERVER_UNHEALTHY_ONCE_STORAGE_CORRUPTION =
+      ConfigOptions.key("rss.server.health.markUnhealthyOnceStorageCorruption")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "Mark server unhealthy once any storage corrupted. Default value is false");
+
   public static final ConfigOption<Double> HEALTH_STORAGE_MAX_USAGE_PERCENTAGE =
       ConfigOptions.key("rss.server.health.max.storage.usage.percentage")
           .doubleType()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce option to mark server unhealthy once any storage corrupted.

### Why are the changes needed?

For: #2241
This feature is to reduce the impact while the local directories are corrupted.

### Does this PR introduce _any_ user-facing change?

Yes. 

`rss.server.health.markUnhealthyOnceStorageCorruption` is introduced, the default value is false that will not activate this feature by default.


### How was this patch tested?

Existing unit tests.
