### PR TITLE
[MINOR] chore: Fix the issue of license loss.

### DIFF
--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -211,6 +211,10 @@
                   <pattern>picocli</pattern>
                   <shadedPattern>${rss.shade.packageName}.picocli</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF/license</pattern>
+                  <shadedPattern>META-INF/license-tmp</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>
@@ -301,6 +305,22 @@
                           to="lib${rss.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib"
                           type="glob"></mapper>
                 </move>
+                <!-- Since it may be compiled on case-insensitive operating system, it may be executed multiple times.
+                 Here the license directory, licenses directory, and LICENSE file are processed with aliases. -->
+                <move failonerror="false" quiet="true"
+                      todir="${project.build.directory}/unpacked/META-INF/license-tmps">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/license-tmp">
+                    <include name="LICENSE*.txt"/>
+                  </fileset>
+                </move>
+                <delete failonerror="false" quiet="true"
+                        dir="${project.build.directory}/unpacked/META-INF/license-tmp"/>
+                <move failonerror="false" quiet="true"
+                      file="${project.build.directory}/unpacked/META-INF/license-tmps"
+                      tofile="${project.build.directory}/unpacked/META-INF/licenses"/>
+                <move failonerror="false" quiet="true"
+                      file="${project.build.directory}/unpacked/META-INF/LICENSE-binary"
+                      tofile="${project.build.directory}/unpacked/META-INF/LICENSE"/>
                 <!-- Delete our NettyUtils to avoid errors like NoSuchMethodError, let Spark use its own NettyUtils -->
                 <!-- See https://github.com/apache/incubator-uniffle/pull/1565 for more details -->
                 <delete dir="${project.build.directory}/unpacked/org/apache/spark/network"/>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -211,6 +211,10 @@
                   <pattern>picocli</pattern>
                   <shadedPattern>${rss.shade.packageName}.picocli</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF/license</pattern>
+                  <shadedPattern>META-INF/license-tmp</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>
@@ -301,6 +305,22 @@
                           to="lib${rss.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib"
                           type="glob"></mapper>
                 </move>
+                <!-- Since it may be compiled on case-insensitive operating system, it may be executed multiple times.
+                 Here the license directory, licenses directory, and LICENSE file are processed with aliases. -->
+                <move failonerror="false" quiet="true"
+                      todir="${project.build.directory}/unpacked/META-INF/license-tmps">
+                  <fileset dir="${project.build.directory}/unpacked/META-INF/license-tmp">
+                    <include name="LICENSE*.txt"/>
+                  </fileset>
+                </move>
+                <delete failonerror="false" quiet="true"
+                        dir="${project.build.directory}/unpacked/META-INF/license-tmp"/>
+                <move failonerror="false" quiet="true"
+                      file="${project.build.directory}/unpacked/META-INF/license-tmps"
+                      tofile="${project.build.directory}/unpacked/META-INF/licenses"/>
+                <move failonerror="false" quiet="true"
+                      file="${project.build.directory}/unpacked/META-INF/LICENSE-binary"
+                      tofile="${project.build.directory}/unpacked/META-INF/LICENSE"/>
                 <echo message="repackaging netty jar"></echo>
                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                      basedir="${project.build.directory}/unpacked"/>

--- a/release/publish_maven_artifacts.sh
+++ b/release/publish_maven_artifacts.sh
@@ -52,7 +52,7 @@ copy_license_files() {
   cp -f "${PROJECT_DIR}/NOTICE-binary" \
   "${PROJECT_DIR}/client-spark/spark2-shaded/src/main/resources/META-INF/NOTICE"
   cp -f "${PROJECT_DIR}/LICENSE-binary" \
-  "${PROJECT_DIR}/client-spark/spark2-shaded/src/main/resources/META-INF/LICENSE"
+  "${PROJECT_DIR}/client-spark/spark2-shaded/src/main/resources/META-INF/LICENSE-binary"
   rm -rf "${PROJECT_DIR}/client-spark/spark2-shaded/src/main/resources/META-INF/licenses"
   cp -rf "${PROJECT_DIR}/licenses-binary" \
   "${PROJECT_DIR}/client-spark/spark2-shaded/src/main/resources/META-INF/licenses"
@@ -61,7 +61,7 @@ copy_license_files() {
   cp -f "${PROJECT_DIR}/NOTICE-binary" \
     "${PROJECT_DIR}/client-spark/spark3-shaded/src/main/resources/META-INF/NOTICE"
   cp -f "${PROJECT_DIR}/LICENSE-binary" \
-    "${PROJECT_DIR}/client-spark/spark3-shaded/src/main/resources/META-INF/LICENSE"
+    "${PROJECT_DIR}/client-spark/spark3-shaded/src/main/resources/META-INF/LICENSE-binary"
   rm -rf "${PROJECT_DIR}/client-spark/spark3-shaded/src/main/resources/META-INF/licenses"
   cp -rf "${PROJECT_DIR}/licenses-binary" \
     "${PROJECT_DIR}/client-spark/spark3-shaded/src/main/resources/META-INF/licenses"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue of license loss

### Why are the changes needed?

LICENSE file is missing but license directory which is from  grpc-netty-shaded-1.61.1.jar exists.

And when published maven artifacts, I can not close.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

test in dev and cluster 
