### PR TITLE
[#2251] fix(server): fix wrong disk used space while config multiply dirs in one mount point

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/storage/StorageInfo.java
+++ b/common/src/main/java/org/apache/uniffle/common/storage/StorageInfo.java
@@ -96,6 +96,10 @@ public class StorageInfo {
     return type;
   }
 
+  public long getUsedBytes() {
+    return usedBytes;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/server/src/main/java/org/apache/uniffle/server/Checker.java
+++ b/server/src/main/java/org/apache/uniffle/server/Checker.java
@@ -17,9 +17,12 @@
 
 package org.apache.uniffle.server;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public abstract class Checker {
 
   Checker(ShuffleServerConf conf) {}
 
-  abstract boolean checkIsHealthy();
+  @VisibleForTesting
+  public abstract boolean checkIsHealthy();
 }

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -431,8 +431,6 @@ public class LocalStorageManager extends SingleStorageManager {
     Map<String, StorageInfo> result = Maps.newHashMap();
     for (LocalStorage storage : localStorages) {
       String mountPoint = storage.getMountPoint();
-      long capacity = storage.getCapacity();
-      long wroteBytes = storage.getServiceUsedBytes();
       StorageStatus status = StorageStatus.NORMAL;
       if (storage.isCorrupted()) {
         status = StorageStatus.UNHEALTHY;
@@ -444,10 +442,12 @@ public class LocalStorageManager extends SingleStorageManager {
         media = StorageMedia.UNKNOWN;
       }
       StorageInfo existingMountPoint = result.get(mountPoint);
+      long wroteBytes = storage.getServiceUsedBytes();
       // if there is already a storage on the mount point, we should sum up the used bytes.
       if (existingMountPoint != null) {
         wroteBytes += existingMountPoint.getUsedBytes();
       }
+      long capacity = storage.getCapacity();
       StorageInfo info = new StorageInfo(mountPoint, media, capacity, wroteBytes, status);
       result.put(mountPoint, info);
     }

--- a/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/LocalStorageManager.java
@@ -443,6 +443,11 @@ public class LocalStorageManager extends SingleStorageManager {
       if (media == null) {
         media = StorageMedia.UNKNOWN;
       }
+      StorageInfo existingMountPoint = result.get(mountPoint);
+      // if there is already a storage on the mount point, we should sum up the used bytes.
+      if (existingMountPoint != null) {
+        wroteBytes += existingMountPoint.getUsedBytes();
+      }
       StorageInfo info = new StorageInfo(mountPoint, media, capacity, wroteBytes, status);
       result.put(mountPoint, info);
     }

--- a/server/src/test/java/org/apache/uniffle/server/HealthyMockChecker.java
+++ b/server/src/test/java/org/apache/uniffle/server/HealthyMockChecker.java
@@ -25,7 +25,7 @@ public class HealthyMockChecker extends Checker {
   }
 
   @Override
-  boolean checkIsHealthy() {
+  public boolean checkIsHealthy() {
     return true;
   }
 }

--- a/server/src/test/java/org/apache/uniffle/server/UnHealthyMockChecker.java
+++ b/server/src/test/java/org/apache/uniffle/server/UnHealthyMockChecker.java
@@ -25,7 +25,7 @@ public class UnHealthyMockChecker extends Checker {
   }
 
   @Override
-  boolean checkIsHealthy() {
+  public boolean checkIsHealthy() {
     return false;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix wrong disk used space while config multiply dirs in one mount point

Fix: [#2251](https://github.com/apache/incubator-uniffle/issues/2251)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No need.