### PR TITLE
[#2241][FOLLOWUP] improvement(server): Mark the underlying thread name

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
+++ b/server/src/main/java/org/apache/uniffle/server/DefaultFlushEventHandler.java
@@ -103,7 +103,8 @@ public class DefaultFlushEventHandler implements FlushEventHandler {
           }
           return null;
         };
-    CompletableFutureUtils.withTimeoutCancel(supplier, flushMaxWaitTimeoutSec * 1000);
+    CompletableFutureUtils.withTimeoutCancel(
+        supplier, flushMaxWaitTimeoutSec * 1000, "event-flushing");
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Mark the underlying thread name for flushing events

### Why are the changes needed?

The follow up pr for #2241

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

needn't
