### PR TITLE
[#2259] fix(server) dataLength of ShuffleBufferWithLinkedList not be cleared after toFlushEvent

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
+++ b/server/src/main/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedList.java
@@ -120,6 +120,7 @@ public class ShuffleBufferWithLinkedList extends AbstractShuffleBuffer {
     blocks = new LinkedHashSet<>();
     inFlushSize.addAndGet(encodedLength);
     encodedLength = 0;
+    dataLength = 0;
     return event;
   }
 

--- a/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
+++ b/server/src/test/java/org/apache/uniffle/server/buffer/ShuffleBufferWithLinkedListTest.java
@@ -79,6 +79,11 @@ public class ShuffleBufferWithLinkedListTest extends BufferTestBase {
     assertEquals(42, shuffleBuffer.getEncodedLength());
     event = shuffleBuffer.toFlushEvent("appId", 0, 0, 1, null);
     assertEquals(42, event.getEncodedLength());
+    assertEquals(10, event.getDataLength());
+    shuffleBuffer.append(createData(10));
+    event = shuffleBuffer.toFlushEvent("appId", 0, 0, 1, null);
+    assertEquals(42, event.getEncodedLength());
+    assertEquals(10, event.getDataLength());
     assertEquals(0, shuffleBuffer.getEncodedLength());
     assertEquals(0, shuffleBuffer.getBlocks().size());
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The private variable dataLength of ShuffleBufferWithLinkedList will be cleared after toFlushEvent.

### Why are the changes needed?
The private variable dataLength of ShuffleBufferWithLinkedList not be cleared after toFlushEvent.

Fix: #2259 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Tested by UT.