### PR TITLE
[#2279] improvement(spark): Trigger the upstream rewrite when the read stage fails 

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -200,7 +200,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
                 // Clear the metadata of the completed task, after the upstream ShuffleId is
                 // cleared, the write Stage can be triggered again.
                 shuffleManager.unregisterAllMapOutput(shuffleId);
-                status.setClearedMapTrackerBlock(true);
+                status.clearedMapTrackerBlock(true);
                 LOG.info(
                     "Clear shuffle result in shuffleId:{}, stageId:{} in the write failure phase.",
                     shuffleId,
@@ -592,7 +592,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
           });
     }
 
-    public void setClearedMapTrackerBlock(boolean isCleared) {
+    public void clearedMapTrackerBlock(boolean isCleared) {
       withWriteLock(
           () -> {
             this.isClearedMapTrackerBlock = isCleared;

--- a/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
+++ b/integration-test/spark-common/src/test/java/org/apache/uniffle/test/RSSStageResubmitTest.java
@@ -79,7 +79,7 @@ public class RSSStageResubmitTest extends SparkTaskFailureIntegrationTestBase {
     super.updateSparkConfCustomer(sparkConf);
     sparkConf.set(
         RssSparkConfig.SPARK_RSS_CONFIG_PREFIX
-            + RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_WRITE_FAILURE_ENABLED,
+            + RssSparkConfig.RSS_RESUBMIT_STAGE_WITH_FETCH_FAILURE_ENABLED,
         "true");
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the current Reader fails to obtain Shuffle data, it does not trigger the upstream Stage to rewrite the data. If a Shuffle Server fails, it does not trigger Stage retry.

### Why are the changes needed?

Fix: https://github.com/apache/incubator-uniffle/issues/2279

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

UT.
