### PR TITLE
[#2282] improvement(spark3): Invoke with object self in DelegationRssShuffleManager

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -247,6 +247,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
                       TaskContext.class,
                       ShuffleReadMetricsReporter.class)
                   .invoke(
+                      delegate,
                       handle,
                       startMapIndex,
                       endMapIndex,
@@ -285,6 +286,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
                       TaskContext.class,
                       ShuffleReadMetricsReporter.class)
                   .invoke(
+                      delegate,
                       handle,
                       startMapIndex,
                       endMapIndex,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the bug of none object self when invoking the reflection method.

### Why are the changes needed?

Fix: #2282

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests
