### PR TITLE
MINOR] test: Fix ConcurrentModifiedException while use TestAppender

### DIFF
--- a/common/src/test/java/org/apache/uniffle/common/log/TestLoggerExtension.java
+++ b/common/src/test/java/org/apache/uniffle/common/log/TestLoggerExtension.java
@@ -134,7 +134,7 @@ public class TestLoggerExtension implements BeforeEachCallback, AfterEachCallbac
     }
 
     @Override
-    public void append(LogEvent event) {
+    public synchronized void append(LogEvent event) {
       events.add(event);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix ConcurrentModifiedException while use TestAppender

### Why are the changes needed?

```
[ERROR] testNewAppWhileCheckLeak{ExtensionContext}  Time elapsed: 0.3 s  <<< ERROR!
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:911)
    at java.util.ArrayList$Itr.next(ArrayList.java:861)
    at org.apache.uniffle.common.log.TestLoggerExtension$TestAppender.wasLogged(TestLoggerExtension.java:106)
    at org.apache.uniffle.common.log.TestLoggerExtension.wasLogged(TestLoggerExtension.java:73)
    at org.apache.uniffle.server.storage.LocalStorageManagerTest.testNewAppWhileCheckLeak(LocalStorageManagerTest.java:399)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.