### PR TITLE
[#2292] fix(server): Potential hang when HadoopShuffleWriteHandler initialization failure in PooledHadoopShuffleWriteHandler

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHadoopShuffleWriteHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PooledHadoopShuffleWriteHandler.java
@@ -112,7 +112,8 @@ public class PooledHadoopShuffleWriteHandler implements ShuffleWriteHandler {
     if (queue.isEmpty() && initializedHandlerCnt < maxConcurrency) {
       synchronized (this) {
         if (initializedHandlerCnt < maxConcurrency) {
-          queue.add(createWriterFunc.apply(initializedHandlerCnt++));
+          queue.add(createWriterFunc.apply(initializedHandlerCnt));
+          initializedHandlerCnt += 1;
         }
       }
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Correct the initialization flag to fix potential hang in PooledHadoopShuffleWriteHandler

### Why are the changes needed?


fix: #2292

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?

Unit tests
