### PR TITLE
[Bug] In the Spark3 getMapSizesByExecutorId can lead to loss of data.

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -799,6 +799,11 @@ public class RssShuffleManager extends RssShuffleManagerBase {
                         SparkEnv.get().mapOutputTracker(), shuffleId, startPartition, endPartition);
       }
     } catch (Exception e) {
+      // If here is a MetadataFetchFailedException abnormalities, packaging needs to be a new
+      // exception, prevent Stage retry, loss of data.
+      if (e instanceof MetadataFetchFailedException) {
+        throw new RssException("Unable to obtained map statuses data.");
+      }
       throw new RssException(e);
     }
     while (mapStatusIter.hasNext()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the Spark3 getMapSizesByExecutorId can lead to loss of data.

### Why are the changes needed?

#2296 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT.
