### PR TITLE
[#2308] improvement(server): More detailed and clear logs on reading failure for FileSegmentManagedBuffer

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/buffer/FileSegmentManagedBuffer.java
@@ -75,7 +75,10 @@ public class FileSegmentManagedBuffer extends ManagedBuffer {
       return buf;
     } catch (IOException e) {
       String fileName = file.getAbsolutePath();
-      String errorMessage = String.format("Errors on reading localfile data with offset[%s] length[%s] from [%s]. ", offset, length, fileName);
+      String errorMessage =
+          String.format(
+              "Errors on reading localfile data with offset[%s] length[%s] from [%s]. ",
+              offset, length, fileName);
       try {
         if (channel != null) {
           long size = channel.size();


### PR DESCRIPTION

### What changes were proposed in this pull request?

More detailed and clear logs on reading failure for FileSegmentManagedBuffer

### Why are the changes needed?

for #2308 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't
