### PR TITLE
[MINOR] docs: Fix the license format of remote_merge_guide.md

### DIFF
--- a/docs/remote_merge_guide.md
+++ b/docs/remote_merge_guide.md
@@ -4,20 +4,20 @@ displayTitle: Uniffle Remote Merge Guide
 title: Uniffle Remote Merge Guide
 description: Uniffle Remote Merge Guide
 license: |
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ---
 # remote merge guide
 


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#123] feat(server,coordinator): support xxx"
     - "[#123] feat(common): support xxx"
     - "[MINOR] improvement(script): fix style"
     - "[MINOR] improvement(ci): add some examples and notice"
     - "[#233] fix: check null before access result in xxx"
     - "[#233][FOLLOWUP] improvement(dashboard): display something xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix the license format of remote_merge_guide.md

### Why are the changes needed?

If we open https://github.com/apache/incubator-uniffle/blob/master/docs/remote_merge_guide.md, we can see the following warning.
```
Error in user YAML: (<unknown>): could not find expected ':' while scanning a simple key at line 6 column 1
```
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unnecessary
