### PR TITLE
[#2317] feat(server): Introduce server flush benchmark

### DIFF
--- a/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleServerMetrics.java
@@ -267,6 +267,7 @@ public class ShuffleServerMetrics {
 
   private static MetricsManager metricsManager;
   private static boolean isRegister = false;
+  @VisibleForTesting public static Supplier<Void> callbackBenchmark;
 
   public static synchronized void register(
       CollectorRegistry collectorRegistry, String tags, ShuffleServerConf serverConf) {
@@ -326,6 +327,9 @@ public class ShuffleServerMetrics {
         counterRemoteStorageSuccessWrite.labels(tags, storageHost).inc();
       }
     }
+    if (callbackBenchmark != null) {
+      callbackBenchmark.get();
+    }
   }
 
   public static void incStorageFailedCounter(String storageHost) {
@@ -337,6 +341,9 @@ public class ShuffleServerMetrics {
         counterRemoteStorageTotalWrite.labels(tags, storageHost).inc();
         counterRemoteStorageFailedWrite.labels(tags, storageHost).inc();
       }
+    }
+    if (callbackBenchmark != null) {
+      callbackBenchmark.get();
     }
   }
 

--- a/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
+++ b/server/src/main/java/org/apache/uniffle/server/ShuffleTaskInfo.java
@@ -37,6 +37,7 @@ import org.apache.uniffle.common.config.RssClientConf;
 import org.apache.uniffle.common.util.Constants;
 import org.apache.uniffle.common.util.JavaUtils;
 import org.apache.uniffle.common.util.UnitConverter;
+import org.apache.uniffle.proto.RssProtos;
 import org.apache.uniffle.server.block.ShuffleBlockIdManager;
 import org.apache.uniffle.server.block.ShuffleBlockIdManagerFactory;
 
@@ -99,6 +100,13 @@ public class ShuffleTaskInfo {
     this.partitionBlockCounters = JavaUtils.newConcurrentMap();
     this.latestStageAttemptNumbers = JavaUtils.newConcurrentMap();
     this.shuffleDetailInfos = JavaUtils.newConcurrentMap();
+    ShuffleDataDistributionType shuffleDataDistributionType =
+        ShuffleDataDistributionType.valueOf(RssProtos.DataDistribution.NORMAL.name());
+    specification.set(
+        ShuffleSpecification.builder()
+            .maxConcurrencyPerPartitionToWrite(1)
+            .dataDistributionType(shuffleDataDistributionType)
+            .build());
   }
 
   public Long getCurrentTimes() {

--- a/server/src/main/java/org/apache/uniffle/server/bench/BenchHandle.java
+++ b/server/src/main/java/org/apache/uniffle/server/bench/BenchHandle.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server.bench;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+import org.apache.uniffle.common.util.Constants;
+import org.apache.uniffle.server.web.vo.BenchArgumentVO;
+
+public class BenchHandle implements AutoCloseable {
+  private final String id;
+  private final BenchArgumentVO argument;
+
+  public final List<String> log = new Vector<>();
+  private long startTime;
+  private long endTime;
+  private LinkedHashMap<String, AutoCloseable> allCloseable = new LinkedHashMap<>();
+  private BenchTrace benchTrace;
+  private long generateEventNums;
+  private long totalEventNum;
+  private AtomicLong completedEventNumCounter;
+
+  public BenchHandle(String id, BenchArgumentVO argument) {
+    this.id = id;
+    this.argument = argument;
+  }
+
+  public void startTrace() {
+    this.startTime = System.currentTimeMillis();
+    this.benchTrace = new BenchTrace();
+    benchTrace.start();
+  }
+
+  public void endTrace() {
+    endTime = System.currentTimeMillis();
+    benchTrace.end();
+  }
+
+  public BenchTrace getBenchTrace() {
+    return benchTrace;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getStartTime() {
+    return DateFormatUtils.format(startTime, Constants.DATE_PATTERN);
+  }
+
+  public String getEndTime() {
+    return DateFormatUtils.format(endTime, Constants.DATE_PATTERN);
+  }
+
+  public long getDuration() {
+    return endTime - startTime;
+  }
+
+  public List<String> getLog() {
+    return log;
+  }
+
+  public void addLog(String content) {
+    log.add(
+        DateFormatUtils.format(System.currentTimeMillis(), Constants.DATE_PATTERN)
+            + ": ["
+            + id
+            + "] "
+            + content);
+  }
+
+  public void setEndTime(long endTime) {
+    this.endTime = endTime;
+  }
+
+  public BenchArgumentVO getArgument() {
+    return argument;
+  }
+
+  public void setStartTime(long startTime) {
+    this.startTime = startTime;
+  }
+
+  public void setBenchTrace(BenchTrace benchTrace) {
+    this.benchTrace = benchTrace;
+  }
+
+  @Override
+  public void close() throws Exception {
+    ArrayList<Map.Entry<String, AutoCloseable>> entries = new ArrayList<>(allCloseable.entrySet());
+    Collections.reverse(entries);
+    for (Map.Entry<String, AutoCloseable> entry : entries) {
+      addLog("Closing " + entry.getKey());
+      entry.getValue().close();
+      addLog("Closed " + entry.getKey());
+    }
+    addLog("Closed all registered closable. Count is: " + allCloseable.size());
+    allCloseable.clear();
+  }
+
+  public <T extends AutoCloseable> T registerClosable(String description, T closeable) {
+    allCloseable.put(description, closeable);
+    addLog("register closable : " + description);
+    return closeable;
+  }
+
+  public void setGenerateEventNums(long generateEventNums) {
+    this.generateEventNums = generateEventNums;
+  }
+
+  public void setTotalEventNum(long num) {
+    this.totalEventNum = num;
+  }
+
+  public String getGenerateEventInfo() {
+    double percentage = generateEventNums * 100.0 / totalEventNum;
+    return String.format("%.2f%% (%d/%d)", percentage, generateEventNums, totalEventNum);
+  }
+
+  public long getTotalEventNum() {
+    return this.totalEventNum;
+  }
+
+  public void setCompletedEventNumsCounter(AtomicLong completedEventNumCounter) {
+    this.completedEventNumCounter = completedEventNumCounter;
+  }
+
+  public long getCompletedEventNum() {
+    return completedEventNumCounter.get();
+  }
+
+  public String getCompletedEventInfo() {
+    double percentage = completedEventNumCounter.get() * 100.0 / totalEventNum;
+    return String.format(
+        "%.2f%% (%d/%d)", percentage, completedEventNumCounter.get(), totalEventNum);
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/bench/BenchTrace.java
+++ b/server/src/main/java/org/apache/uniffle/server/bench/BenchTrace.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server.bench;
+
+import org.apache.uniffle.server.ShuffleServerMetrics;
+
+public class BenchTrace {
+  private double totalWriteTime;
+  private double totalWriteBlockSize;
+  private double totalWriteDataSize;
+  private boolean isEnd = false;
+
+  public void start() {
+    totalWriteTime = ShuffleServerMetrics.counterTotalWriteTime.get();
+    totalWriteBlockSize = ShuffleServerMetrics.counterTotalWriteBlockSize.get();
+    totalWriteDataSize = ShuffleServerMetrics.counterTotalWriteDataSize.get();
+  }
+
+  public void end() {
+    totalWriteTime = ShuffleServerMetrics.counterTotalWriteTime.get() - totalWriteTime;
+    totalWriteBlockSize =
+        ShuffleServerMetrics.counterTotalWriteBlockSize.get() - totalWriteBlockSize;
+    totalWriteDataSize = ShuffleServerMetrics.counterTotalWriteDataSize.get() - totalWriteDataSize;
+    isEnd = true;
+  }
+
+  public boolean isEnd() {
+    return isEnd;
+  }
+
+  public void setEnd(boolean end) {
+    isEnd = end;
+  }
+
+  public double getTotalWriteBlockSize() {
+    return totalWriteBlockSize;
+  }
+
+  public double getTotalWriteDataSize() {
+    return totalWriteDataSize;
+  }
+
+  public double getTotalWriteTime() {
+    return totalWriteTime;
+  }
+
+  public void setTotalWriteBlockSize(double totalWriteBlockSize) {
+    this.totalWriteBlockSize = totalWriteBlockSize;
+  }
+
+  public void setTotalWriteDataSize(double totalWriteDataSize) {
+    this.totalWriteDataSize = totalWriteDataSize;
+  }
+
+  public void setTotalWriteTime(double totalWriteTime) {
+    this.totalWriteTime = totalWriteTime;
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/bench/ShuffleServerBenchmark.java
+++ b/server/src/main/java/org/apache/uniffle/server/bench/ShuffleServerBenchmark.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server.bench;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import picocli.CommandLine;
+
+import org.apache.uniffle.common.PartitionRange;
+import org.apache.uniffle.common.RemoteStorageInfo;
+import org.apache.uniffle.common.ShuffleDataDistributionType;
+import org.apache.uniffle.common.ShufflePartitionedBlock;
+import org.apache.uniffle.common.ShufflePartitionedData;
+import org.apache.uniffle.common.util.BlockIdLayout;
+import org.apache.uniffle.common.util.ChecksumUtils;
+import org.apache.uniffle.common.util.NettyUtils;
+import org.apache.uniffle.common.util.ThreadUtils;
+import org.apache.uniffle.common.util.UnitConverter;
+import org.apache.uniffle.server.ShuffleDataFlushEvent;
+import org.apache.uniffle.server.ShuffleFlushManager;
+import org.apache.uniffle.server.ShuffleServer;
+import org.apache.uniffle.server.ShuffleServerConf;
+import org.apache.uniffle.server.ShuffleServerMetrics;
+import org.apache.uniffle.server.buffer.ShuffleBuffer;
+import org.apache.uniffle.server.buffer.ShuffleBufferType;
+import org.apache.uniffle.server.buffer.ShuffleBufferWithLinkedList;
+import org.apache.uniffle.server.buffer.ShuffleBufferWithSkipList;
+import org.apache.uniffle.server.web.vo.BenchArgumentVO;
+
+public class ShuffleServerBenchmark implements AutoCloseable {
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ShuffleServerBenchmark.class);
+  private static final AtomicLong JOB_ID_INDEX = new AtomicLong(0);
+
+  // partitionId -> ShuffleBuffer
+  private Map<Integer, ShuffleBuffer> shuffleBuffers = new ConcurrentHashMap<>();
+  //  private static final Map<Integer, Pair<byte[], Long>> datas = new HashMap<>();
+  private ByteBuf blockData = null;
+  private long blockDataCrc;
+
+  private static Map<String, BenchHandle> benchHandles = new TreeMap<>();
+
+  public ShuffleServerBenchmark() {}
+
+  public static Map<String, BenchHandle> getBenchHandle(Set<String> ids) {
+    Objects.requireNonNull(ids);
+    return benchHandles.entrySet().stream()
+        .filter(e -> ids.isEmpty() || ids.contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()));
+  }
+
+  public static boolean removeBench(String id) throws Exception {
+    BenchHandle benchHandle = benchHandles.get(id);
+    if (benchHandle != null) {
+      benchHandle.close();
+      benchHandles.remove(id);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public static boolean stopBench(String id) throws Exception {
+    BenchHandle benchHandle = benchHandles.get(id);
+    if (benchHandle != null) {
+      benchHandle.close();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * start shuffle server benchmark
+   *
+   * @param arguments the benchmark arguments
+   * @param shuffleServerConf the configuration of shuffle server
+   * @param shuffleServer the shuffle server
+   * @param async if async, the thread will return immediately, otherwise block util finish or
+   *     timeout
+   * @param timeoutMs if async, this is timeout in milliseconds, otherwise not used
+   * @return
+   * @throws Exception
+   */
+  public static String runBench(
+      BenchArgumentVO arguments,
+      ShuffleServerConf shuffleServerConf,
+      ShuffleServer shuffleServer,
+      boolean async,
+      long timeoutMs)
+      throws Exception {
+    final String appId = "ShuffleServerBenchmarkAppId" + JOB_ID_INDEX.getAndIncrement();
+    BenchHandle benchHandle = new BenchHandle(appId, arguments);
+    benchHandles.put(appId, benchHandle);
+    startAppHeartbeat(shuffleServer, appId, benchHandle);
+
+    FutureTask<Void> futureTask =
+        new FutureTask<>(
+            () -> {
+              runBenchInternal(shuffleServerConf, shuffleServer, benchHandle);
+              return null;
+            });
+    benchHandle.registerClosable("runBenchTask", () -> futureTask.cancel(true));
+
+    Thread thread = new Thread(futureTask);
+    thread.setDaemon(true);
+    thread.setName("ShuffleServerBenchmarkThread-" + appId);
+    thread.start();
+    if (async) {
+      return appId;
+    }
+    try {
+      futureTask.get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      LOG.warn("run bench timeout {} over {}s", benchHandle, timeoutMs / 1000);
+      removeBench(appId);
+    } catch (Exception e) {
+      LOG.error("Failed to run server bench {} in futureTask, will cancel it.", e);
+      removeBench(appId);
+    }
+    return appId;
+  }
+
+  private static void startAppHeartbeat(
+      ShuffleServer shuffleServer, String appId, BenchHandle benchHandle) {
+    String factoryName = "rss-heartbeat-" + appId;
+    ScheduledExecutorService heartbeatScheduledExecutorService =
+        ThreadUtils.getDaemonSingleThreadScheduledExecutor(factoryName);
+    heartbeatScheduledExecutorService.scheduleAtFixedRate(
+        () -> {
+          try {
+            shuffleServer.getShuffleTaskManager().refreshAppId(appId);
+            LOG.info("Finish send heartbeat to coordinator and servers");
+          } catch (Exception e) {
+            LOG.warn("Fail to send heartbeat to coordinator and servers", e);
+          }
+        },
+        5000 / 2,
+        5000,
+        TimeUnit.MILLISECONDS);
+    benchHandle.registerClosable(
+        "heartbeat threadPool: " + factoryName, heartbeatScheduledExecutorService::shutdown);
+  }
+
+  private static void runBenchInternal(
+      ShuffleServerConf shuffleServerConf, ShuffleServer shuffleServer, BenchHandle benchHandle)
+      throws Exception {
+    String appId = benchHandle.getId();
+    BenchArgumentVO arguments = benchHandle.getArgument();
+    final int threadNumGenerateEvent = arguments.getThreadNumGenerateEvent();
+    int blockNumThresholdInMemory = arguments.getBlockNumThresholdInMemory();
+
+    // Start a thread pool for producer to generate flush event as fast as possible
+    ExecutorService executorService =
+        ThreadUtils.getDaemonFixedThreadPool(threadNumGenerateEvent, "Bench-ThreadPool-" + appId);
+    benchHandle.registerClosable(
+        "Bench-ThreadPool-" + appId,
+        () -> {
+          executorService.shutdown();
+          Thread.sleep(5000);
+          executorService.shutdownNow();
+          while (!executorService.isShutdown()) {
+            try {
+              Thread.sleep(100);
+            } catch (InterruptedException e) {
+              LOG.warn("Shutting Bench-ThreadPool-" + appId + " was interrupted.");
+            }
+          }
+        });
+
+    final AtomicLong generatedEventNums = new AtomicLong(0);
+    final AtomicLong completedEventNums = new AtomicLong(0);
+    benchHandle.setCompletedEventNumsCounter(completedEventNums);
+    // Create a future as a barrier to wait for the bench completed
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    // register callback to get the exact test running duration
+    ShuffleServerMetrics.callbackBenchmark =
+        () -> {
+          if (completedEventNums.incrementAndGet() == benchHandle.getTotalEventNum()) {
+            future.complete(null);
+          }
+          return null;
+        };
+    if (arguments.getDumpfile() == null) {
+      int blockSize = (int) UnitConverter.byteStringAsBytes(arguments.getBlockSize());
+      int blockNumPerEvent = arguments.getBlockNumPerEvent();
+      int eventNum = arguments.getEventNum();
+      int partitionNum = arguments.getPartitionNum();
+      final int inQueueEventLimit =
+          arguments.getInQueueEventLimit() > 0
+              ? arguments.getInQueueEventLimit()
+              : blockNumThresholdInMemory / blockNumPerEvent;
+
+      System.out.printf(
+          "%s Starting write, blockSize: %s, block num: %d, event num: %d, partition num: %d, config file: %s%n",
+          LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+          UnitConverter.formatSize(blockSize),
+          blockNumPerEvent,
+          eventNum,
+          partitionNum,
+          arguments.getConfigFile());
+
+      ShuffleServerBenchmark shuffleServerBenchmark =
+          benchHandle.registerClosable("shuffleServerBenchmark", new ShuffleServerBenchmark());
+
+      final int shuffleId = 0;
+      final int taskAttemptId = 0;
+      List<PartitionRange> partitionRanges =
+          IntStream.range(0, partitionNum)
+              .mapToObj(i -> new PartitionRange(i, i))
+              .collect(Collectors.toList());
+
+      // init
+      for (int i = 0; i < partitionNum; i++) {
+        shuffleServerBenchmark.shuffleBuffers.put(
+            i,
+            shuffleServerConf.get(ShuffleServerConf.SERVER_SHUFFLE_BUFFER_TYPE)
+                    == ShuffleBufferType.SKIP_LIST
+                ? new ShuffleBufferWithSkipList()
+                : new ShuffleBufferWithLinkedList());
+      }
+
+      // Register shuffle to avoid encounter exception
+      shuffleServer
+          .getShuffleTaskManager()
+          .registerShuffle(
+              appId,
+              shuffleId,
+              0,
+              partitionRanges,
+              new RemoteStorageInfo(""),
+              "ShuffleServerBenchmarkUser",
+              ShuffleDataDistributionType.NORMAL,
+              0,
+              Collections.emptyMap());
+      benchHandle.registerClosable(
+          "registerShuffle",
+          () -> shuffleServer.getShuffleTaskManager().removeShuffleDataAsync(appId));
+      shuffleServerBenchmark.mockFixedBlockData(blockSize);
+      benchHandle.setTotalEventNum(partitionNum * eventNum);
+      String msg =
+          String.format(
+              "%s Start to generate %d(from args) events, inQueueEventLimit is %d%n",
+              LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+              benchHandle.getTotalEventNum(),
+              inQueueEventLimit);
+      System.out.printf(msg);
+      benchHandle.addLog(msg);
+      // generate common event
+      final ShuffleDataFlushEvent shuffleDataFlushEvent =
+          shuffleServerBenchmark.generateEvent(appId, shuffleId, 0, 0, blockSize, blockNumPerEvent);
+      // Start trace the bench metrics
+      benchHandle.startTrace();
+      benchHandle.registerClosable("trace", () -> benchHandle.endTrace());
+      IntStream.range(0, eventNum)
+          .forEach(
+              eventId -> {
+                IntStream.range(0, partitionNum)
+                    .forEach(
+                        partitionId -> {
+                          executorService.submit(
+                              () -> {
+                                try {
+                                  ShuffleDataFlushEvent event =
+                                      shuffleServerBenchmark.dumpShuffleDataFlushEvent(
+                                          shuffleDataFlushEvent,
+                                          shuffleId,
+                                          partitionId,
+                                          taskAttemptId,
+                                          blockNumPerEvent,
+                                          blockSize);
+                                  shuffleServer.getShuffleFlushManager().addToFlushQueue(event);
+                                  progressControl(
+                                      benchHandle, generatedEventNums, inQueueEventLimit);
+                                } catch (Throwable e) {
+                                  e.printStackTrace();
+                                }
+                              });
+                        });
+              });
+    } else {
+      // TODO(baoloongmao): Add support for dump file
+    }
+    benchHandle.addLog(
+        "generate event done, waiting flush closed." + " total:" + benchHandle.getTotalEventNum());
+    // Blocking until finish bench
+    future.get();
+    // Close bench handle, release resource, end trace
+    benchHandle.close();
+    generateBenchResult(shuffleServerConf, benchHandle);
+  }
+
+  private void mockFixedBlockData(int blockSize) {
+    byte[] data = new byte[blockSize];
+    ThreadLocalRandom.current().nextBytes(data);
+    blockDataCrc = ChecksumUtils.getCrc32(data);
+    blockData = NettyUtils.getSharedUnpooledByteBufAllocator(true).directBuffer(blockSize);
+    blockData.writeBytes(data);
+  }
+
+  private static void progressControl(
+      BenchHandle benchHandle, AtomicLong generatedEventNums, long inQueueEventLimit)
+      throws InterruptedException {
+    long progress = generatedEventNums.incrementAndGet();
+    benchHandle.setGenerateEventNums(progress);
+    long totalEventNums = benchHandle.getTotalEventNum();
+    if (progress % (totalEventNums / 5) == 0) {
+      int progressNum = (int) (progress * 50 / totalEventNums);
+      StringBuilder sb = new StringBuilder(50);
+      sb.append("\rGenerate event [");
+      String equals = StringUtils.repeat("=", progressNum);
+      String spaces = StringUtils.repeat(" ", 50 - progressNum);
+      sb.append(equals)
+          .append(spaces)
+          .append("] ")
+          .append(progress)
+          .append("/")
+          .append(totalEventNums);
+      System.out.print(sb);
+    }
+    int sleepMsExceedBlockNumThreshold =
+        benchHandle.getArgument().getSleepMsExceedBlockNumThreshold();
+    while (generatedEventNums.get() - benchHandle.getCompletedEventNum() > inQueueEventLimit
+        && sleepMsExceedBlockNumThreshold > 0) {
+      Thread.sleep(sleepMsExceedBlockNumThreshold);
+    }
+  }
+
+  private static void generateBenchResult(
+      ShuffleServerConf shuffleServerConf, BenchHandle benchHandle) {
+    BenchArgumentVO arguments = benchHandle.getArgument();
+    int blockSize = (int) UnitConverter.byteStringAsBytes(arguments.getBlockSize());
+    int blockNumPerEvent = arguments.getBlockNumPerEvent();
+    int eventNum = arguments.getEventNum();
+    int partitionNum = arguments.getPartitionNum();
+    String msg;
+    double flushWriteTotal = benchHandle.getBenchTrace().getTotalWriteTime();
+    double flushWriteMsPerEvent = flushWriteTotal / benchHandle.getTotalEventNum();
+    int flushThreadPoolSize =
+        shuffleServerConf.getInteger(ShuffleServerConf.SERVER_FLUSH_LOCALFILE_THREAD_POOL_SIZE);
+
+    System.out.println();
+    String argStr =
+        String.format(
+            "%s ShuffleServerBenchmark arguments blockSize: %s, block num: %d, event num: %d, partition num: %d, config file: %s, flushThreadPoolSize=%d%n",
+            LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+            UnitConverter.formatSize(blockSize),
+            blockNumPerEvent,
+            eventNum,
+            partitionNum,
+            arguments.getConfigFile(),
+            flushThreadPoolSize);
+
+    long expectedBlockNum = (long) eventNum * partitionNum * blockNumPerEvent;
+    double expectedDataSize = (double) eventNum * partitionNum * blockSize * blockNumPerEvent;
+
+    double actualTotalWriteBlockCount = benchHandle.getBenchTrace().getTotalWriteBlockSize();
+    double actualTotalWriteBlockDataSize = benchHandle.getBenchTrace().getTotalWriteDataSize();
+
+    if (actualTotalWriteBlockCount != expectedBlockNum) {
+      msg =
+          String.format(
+              "%s\tShuffleServerBenchmark run Fail! Block nums expect: %d actual: %f%n",
+              argStr, expectedBlockNum, actualTotalWriteBlockCount);
+      benchHandle.addLog(msg);
+      System.out.printf(msg);
+    } else if (actualTotalWriteBlockDataSize != expectedDataSize) {
+      msg =
+          String.format(
+              "%s\tShuffleServerBenchmark run Fail! Total size expect: %.2f actual: %.2f%n",
+              argStr, expectedDataSize, actualTotalWriteBlockDataSize);
+      benchHandle.addLog(msg);
+      System.out.printf(msg);
+    } else {
+      msg =
+          String.format(
+              "%s\tShuffleServerBenchmark run Success. Cost: total=%d ms, flushWriteTotal=%s ms, flushWritePerEvent=%.2f ms%n",
+              argStr, benchHandle.getDuration(), flushWriteTotal, flushWriteMsPerEvent);
+      benchHandle.addLog(msg);
+      System.out.printf(msg);
+    }
+  }
+
+  private ShuffleDataFlushEvent dumpShuffleDataFlushEvent(
+      ShuffleDataFlushEvent shuffleDataFlushEvent,
+      int shuffleId,
+      int partitionId,
+      int taskAttemptId,
+      int blockNum,
+      int blockSize) {
+    long eventId = ShuffleFlushManager.ATOMIC_EVENT_ID.getAndIncrement();
+    ShufflePartitionedBlock[] blocks =
+        generateBlocks(partitionId, taskAttemptId, blockNum, blockSize);
+    return new ShuffleDataFlushEvent(
+        eventId,
+        shuffleDataFlushEvent.getAppId(),
+        shuffleId,
+        partitionId,
+        partitionId,
+        shuffleDataFlushEvent.getEncodedLength(),
+        shuffleDataFlushEvent.getDataLength(),
+        Arrays.asList(blocks),
+        () -> shuffleDataFlushEvent.isValid(),
+        shuffleDataFlushEvent.getShuffleBuffer());
+  }
+
+  private ShufflePartitionedBlock[] generateBlocks(
+      int partition, int taskAttemptId, int blockNum, int blockSize) {
+    ShufflePartitionedBlock[] blocks = new ShufflePartitionedBlock[blockNum];
+    for (int i = 0; i < blockNum; i++) {
+      long blockId = BlockIdLayout.DEFAULT.getBlockId(i + 1, partition, taskAttemptId);
+      ByteBuf buf = Unpooled.wrappedBuffer(blockData);
+      blocks[i] =
+          new ShufflePartitionedBlock(
+              blockSize, blockSize, blockDataCrc, blockId, taskAttemptId, buf);
+    }
+    return blocks;
+  }
+
+  private ShuffleDataFlushEvent generateEvent(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      int taskAttemptId,
+      int blockSize,
+      int blockNum) {
+    ShufflePartitionedBlock[] blocks =
+        generateBlocks(partitionId, taskAttemptId, blockNum, blockSize);
+    long encodedLength =
+        Arrays.stream(blocks).mapToLong(ShufflePartitionedBlock::getEncodedLength).sum();
+    long dataLength = Arrays.stream(blocks).mapToLong(ShufflePartitionedBlock::getDataLength).sum();
+    ShufflePartitionedData shufflePartitionedData =
+        new ShufflePartitionedData(partitionId, encodedLength, dataLength, blocks);
+    ShuffleBuffer shuffleBuffer = shuffleBuffers.get(partitionId);
+    shuffleBuffer.append(shufflePartitionedData);
+    return shuffleBuffer.toFlushEvent(appId, shuffleId, partitionId, partitionId, null, null);
+  }
+
+  private static void printHelp() {
+    System.out.println("Usage: ShuffleServerBenchmark [options]");
+    System.out.println("Options:");
+    System.out.println("  -c, --conf <file>        Config file");
+    System.out.println("  -b, --blockSize <size>   Block size (e.g., 1M, 1G)");
+    System.out.println("  -n, --blockNum <num>     Number of blocks");
+    System.out.println("  -e, --eventNum <num>     Number of events");
+    System.out.println("  -p, --partitionNum <num> Number of partitions (required)");
+    System.out.println("  -h, --help               Display this help message");
+  }
+
+  public static void main(String[] args) {
+    try {
+      BenchArgumentVO arguments = new BenchArgumentVO();
+      new CommandLine(arguments).parseArgs(args);
+
+      if (arguments.isHelp()) {
+        printHelp();
+        return;
+      }
+
+      String configFile = arguments.getConfigFile();
+      ShuffleServerConf shuffleServerConf = new ShuffleServerConf(configFile);
+      shuffleServerConf.setLong(
+          ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT.key(), Long.MAX_VALUE);
+      shuffleServerConf.setLong(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL.key(), Long.MAX_VALUE);
+
+      // start shuffle server
+      ShuffleServer shuffleServer = new ShuffleServer(shuffleServerConf);
+      shuffleServer.start();
+
+      runBench(arguments, shuffleServerConf, shuffleServer, false, TimeUnit.DAYS.toMillis(1));
+      System.exit(0);
+    } catch (Exception e) {
+      System.err.printf(
+          "%s Error during test: %s%n",
+          LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (blockData != null) {
+      blockData.release();
+    }
+    if (shuffleBuffers != null) {
+      for (ShuffleBuffer shuffleBuffer : shuffleBuffers.values()) {
+        shuffleBuffer.release();
+      }
+      shuffleBuffers.clear();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
+++ b/server/src/main/java/org/apache/uniffle/server/storage/SingleStorageManager.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
+import io.netty.util.IllegalReferenceCountException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,9 @@ public abstract class SingleStorageManager implements StorageManager {
       long writeTime = System.currentTimeMillis() - startWrite;
       updateWriteMetrics(event, writeTime);
       return true;
+    } catch (IllegalReferenceCountException e) {
+      // We have no ability to retry for this exception
+      throw e;
     } catch (Exception e) {
       LOG.warn("Exception happened when write data for " + event + ", try again", e);
       ShuffleServerMetrics.counterWriteException.inc();

--- a/server/src/main/java/org/apache/uniffle/server/web/resource/ServerBenchResource.java
+++ b/server/src/main/java/org/apache/uniffle/server/web/resource/ServerBenchResource.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server.web.resource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.ServletContext;
+
+import org.apache.hbase.thirdparty.javax.ws.rs.Consumes;
+import org.apache.hbase.thirdparty.javax.ws.rs.GET;
+import org.apache.hbase.thirdparty.javax.ws.rs.POST;
+import org.apache.hbase.thirdparty.javax.ws.rs.Path;
+import org.apache.hbase.thirdparty.javax.ws.rs.QueryParam;
+import org.apache.hbase.thirdparty.javax.ws.rs.core.Context;
+import org.apache.hbase.thirdparty.javax.ws.rs.core.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.uniffle.common.web.resource.Authorization;
+import org.apache.uniffle.server.ShuffleServer;
+import org.apache.uniffle.server.bench.BenchHandle;
+import org.apache.uniffle.server.bench.ShuffleServerBenchmark;
+import org.apache.uniffle.server.web.vo.BenchArgumentVO;
+
+@Path("/bench")
+public class ServerBenchResource {
+  private static final Logger LOG = LoggerFactory.getLogger(ServerBenchResource.class);
+  @Context protected ServletContext servletContext;
+
+  @Authorization
+  @POST
+  @Path("/run")
+  @Consumes(MediaType.APPLICATION_JSON)
+  public String run(BenchArgumentVO argument) throws Exception {
+    String id =
+        ShuffleServerBenchmark.runBench(
+            argument, getShuffleServer().getShuffleServerConf(), getShuffleServer(), true, -1);
+    LOG.info("Benchmark {} is started.", id);
+    return id;
+  }
+
+  @GET
+  @Path("/get")
+  public Map<String, BenchHandle> getBenchHandles(@QueryParam("ids") Set<String> ids) {
+    if (ids == null) {
+      ids = Collections.emptySet();
+    }
+    return ShuffleServerBenchmark.getBenchHandle(ids);
+  }
+
+  @Authorization
+  @POST
+  @Path("/stop")
+  public String stop(@QueryParam("id") String id) throws Exception {
+    if (ShuffleServerBenchmark.stopBench(id)) {
+      return "OK";
+    } else {
+      return "Unknown id: " + id;
+    }
+  }
+
+  @Authorization
+  @POST
+  @Path("/remove")
+  public String remove(@QueryParam("id") String id) throws Exception {
+    if (ShuffleServerBenchmark.removeBench(id)) {
+      return "OK";
+    } else {
+      return "Unknown id: " + id;
+    }
+  }
+
+  private ShuffleServer getShuffleServer() {
+    return (ShuffleServer) servletContext.getAttribute(ShuffleServer.class.getCanonicalName());
+  }
+}

--- a/server/src/main/java/org/apache/uniffle/server/web/vo/BenchArgumentVO.java
+++ b/server/src/main/java/org/apache/uniffle/server/web/vo/BenchArgumentVO.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.uniffle.server.web.vo;
+
+import picocli.CommandLine;
+
+public class BenchArgumentVO {
+  @CommandLine.Option(
+      names = {"-c", "--conf"},
+      description = "config file",
+      defaultValue = "1k")
+  private String configFile;
+
+  @CommandLine.Option(
+      names = {"-b", "--blockSize"},
+      description = "block size",
+      required = true)
+  private String blockSize;
+
+  @CommandLine.Option(
+      names = {"-n", "--blockNum"},
+      description = "block num",
+      required = true)
+  private int blockNumPerEvent;
+
+  @CommandLine.Option(
+      names = {"-e", "--eventNum"},
+      description = "event num",
+      required = true)
+  private int eventNum;
+
+  @CommandLine.Option(
+      names = {"-p", "--partitionNum"},
+      description = "partition num",
+      required = true)
+  private int partitionNum;
+
+  @CommandLine.Option(
+      names = {"--threadNumGenerateEvent"},
+      description = "threadNumGenerateEvent",
+      defaultValue = "10")
+  private int threadNumGenerateEvent = 10;
+
+  @CommandLine.Option(
+      names = {"--generateSleep"},
+      description = "generateSleep",
+      defaultValue = "10")
+  private int sleepMsExceedBlockNumThreshold = 10;
+
+  @CommandLine.Option(
+      names = {"--blockNumThresholdInMemory"},
+      description = "sleep ${generateSleep} when block num >= ${blockNumThresholdInMemory}",
+      defaultValue = "10000000")
+  private int blockNumThresholdInMemory = 10000000;
+
+  @CommandLine.Option(
+      names = {"--inQueueEventLimit"},
+      description = "sleep ${generateSleep} when block num >= ${blockNumThresholdInMemory}",
+      defaultValue = "-1")
+  private int inQueueEventLimit = -1;
+
+  @CommandLine.Option(
+      names = {"--dumpfile"},
+      description = "flush event dump input file",
+      required = false)
+  private String dumpfile;
+
+  @CommandLine.Option(
+      names = {"-h", "--help"},
+      usageHelp = true,
+      description = "display this help message")
+  private boolean helpRequested = false;
+
+  public boolean isHelp() {
+    return helpRequested;
+  }
+
+  public String getConfigFile() {
+    return configFile;
+  }
+
+  public String getBlockSize() {
+    return blockSize;
+  }
+
+  public int getBlockNumPerEvent() {
+    return blockNumPerEvent;
+  }
+
+  public int getEventNum() {
+    return eventNum;
+  }
+
+  public int getPartitionNum() {
+    return partitionNum;
+  }
+
+  public int getThreadNumGenerateEvent() {
+    return threadNumGenerateEvent;
+  }
+
+  public int getSleepMsExceedBlockNumThreshold() {
+    return sleepMsExceedBlockNumThreshold;
+  }
+
+  public int getBlockNumThresholdInMemory() {
+    return blockNumThresholdInMemory;
+  }
+
+  public String getDumpfile() {
+    return dumpfile;
+  }
+
+  public void setInQueueEventLimit(int inQueueEventLimit) {
+    this.inQueueEventLimit = inQueueEventLimit;
+  }
+
+  public int getInQueueEventLimit() {
+    return inQueueEventLimit;
+  }
+
+  @Override
+  public String toString() {
+    return "{"
+        + "configFile='"
+        + configFile
+        + '\''
+        + ", blockSize='"
+        + blockSize
+        + '\''
+        + ", blockNumPerEvent="
+        + blockNumPerEvent
+        + ", eventNum="
+        + eventNum
+        + ", partitionNum="
+        + partitionNum
+        + ", threadNumGenerateEvent="
+        + threadNumGenerateEvent
+        + ", sleepMsExceedBlockNumThreshold="
+        + sleepMsExceedBlockNumThreshold
+        + ", blockNumThresholdInMemory="
+        + blockNumThresholdInMemory
+        + ", helpRequested="
+        + helpRequested
+        + '}';
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce server flush benchmark.

### Why are the changes needed?

Fix: #2317

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```Shell
curl http://localhost:19976/bench/run \
  -H "Content-Type: application/json" \
  -d '{
        "blockSize": "1k",
        "blockNumPerEvent": 1000,
        "eventNum": 1000,
        "partitionNum": 1000
      }'


$ curl -s http://localhost:19976/bench/get | python -m json.tool
{
    "ShuffleServerBenchmarkAppId1": {
        "argument": {
            "blockNumPerEvent": 1000,
            "blockNumThresholdInMemory": 10000000,
            "blockSize": "1k",
            "configFile": null,
            "eventNum": 1000,
            "help": false,
            "partitionNum": 1000,
            "sleepMsExceedBlockNumThreshold": 10,
            "threadNumGenerateEvent": 10
        },
        "benchTrace": {
            "end": true,
            "totalWriteBlockSize": 1000000000.0,
            "totalWriteDataSize": 1024000000000.0,
            "totalWriteTime": 9490889.0
        },
        "duration": 397233,
        "endTime": "2024-12-16 15:24:41",
        "id": "ShuffleServerBenchmarkAppId1",
        "log": [
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] register closable : heartbeat threadPool: rss-heartbeat-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] register closable : runBenchTask",
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] register closable : registerShuffle",
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] register closable : Bench-ThreadPool-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] register closable : trace",
            "2024-12-16 15:18:04: [ShuffleServerBenchmarkAppId1] 2024-12-16T15:18:04.434 Start to generate 1000000 events\n",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closing trace",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed trace",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closing Bench-ThreadPool-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed Bench-ThreadPool-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closing registerShuffle",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed registerShuffle",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closing runBenchTask",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed runBenchTask",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closing heartbeat threadPool: rss-heartbeat-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed heartbeat threadPool: rss-heartbeat-ShuffleServerBenchmarkAppId1",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] Closed all registered closable. Count is: 5",
            "2024-12-16 15:24:41: [ShuffleServerBenchmarkAppId1] 2024-12-16T15:24:41.667 ShuffleServerBenchmark arguments blockSize: 1.00KiB, block num: 1000, event num: 1000, partition num: 1000, config file: null, flushHandler=org.apache.uniffle.server.DefaultFlushEventHandler, flushThreadPoolSize=24\n\tShuffleServerBenchmark run Success. Cost: total=397233 ms, flushTotal=397233 ms, lock=0.00 ms, eventCostMs=9.49 ms\n"
        ],
        "startTime": "2024-12-16 15:18:04"
    }
}

$ curl -X POST http://localhost:19976/bench/remove?id=ShuffleServerBenchmarkAppId0
```