### PR TITLE
[MINOR] fix(test): Disable System exit for HadoopTestBase

### DIFF
--- a/storage/src/test/java/org/apache/uniffle/storage/HadoopTestBase.java
+++ b/storage/src/test/java/org/apache/uniffle/storage/HadoopTestBase.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.uniffle.common.util.ExitUtils;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HadoopTestBase implements Serializable {
@@ -42,6 +44,7 @@ public class HadoopTestBase implements Serializable {
 
   @BeforeAll
   public static void setUpHdfs(@TempDir File tempDir) throws Exception {
+    ExitUtils.disableSystemExit();
     conf = new Configuration();
     baseDir = tempDir;
     conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Disable System exit for HadoopTestBase

### Why are the changes needed?

Without this, we cannot find the root cause of failure test, we can only find out the test process crashed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
