### PR TITLE
[MINOR] fix(spark-client) Close coordinator client in time

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManagerUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManagerUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.spark.SparkConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DelegationRssShuffleManagerUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(DelegationRssShuffleManagerUtils.class);
+
+  public static String acquireAccessId(SparkConf sparkConf) {
+    String accessId = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID.key(), "").trim();
+    if (StringUtils.isEmpty(accessId)) {
+      String providerKey = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID_PROVIDER_KEY.key(), "");
+      if (StringUtils.isNotEmpty(providerKey)) {
+        accessId = sparkConf.get(providerKey, "");
+        LOG.info("Get access id {} from provider key: {}", accessId, providerKey);
+      }
+    }
+    return accessId;
+  }
+}

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -103,15 +103,30 @@ public class RssSparkShuffleUtils {
     return instance;
   }
 
-  public static CoordinatorGrpcRetryableClient createCoordinatorClients(SparkConf sparkConf) {
+  public static CoordinatorGrpcRetryableClient createCoordinatorClientsWithoutHeartbeat(
+      SparkConf sparkConf) {
     String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
-    String coordinators = sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
+    String coordinators = getCoordinatorQuorumStr(sparkConf);
     long retryIntervalMs = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_INTERVAL_MAX);
     int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_RETRY_MAX);
-    int heartbeatThread = sparkConf.get(RssSparkConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM);
     CoordinatorClientFactory coordinatorClientFactory = CoordinatorClientFactory.getInstance();
-    return coordinatorClientFactory.createCoordinatorClient(
-        ClientType.valueOf(clientType), coordinators, retryIntervalMs, retryTimes, heartbeatThread);
+    return coordinatorClientFactory.createCoordinatorClientWithoutHeartbeat(
+        ClientType.valueOf(clientType), coordinators, retryIntervalMs, retryTimes);
+  }
+
+  public static CoordinatorGrpcRetryableClient createCoordinatorClientsForAccessCluster(
+      SparkConf sparkConf) {
+    String clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE);
+    String coordinators = getCoordinatorQuorumStr(sparkConf);
+    long retryIntervalMs = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);
+    int retryTimes = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_TIMES);
+    CoordinatorClientFactory coordinatorClientFactory = CoordinatorClientFactory.getInstance();
+    return coordinatorClientFactory.createCoordinatorClientWithoutHeartbeat(
+        ClientType.valueOf(clientType), coordinators, retryIntervalMs, retryTimes);
+  }
+
+  public static String getCoordinatorQuorumStr(SparkConf sparkConf) {
+    return sparkConf.get(RssSparkConfig.RSS_COORDINATOR_QUORUM);
   }
 
   public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -117,6 +117,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   private boolean tryAccessCluster(CoordinatorClient coordinatorClient) {
     String accessId = DelegationRssShuffleManagerUtils.acquireAccessId(sparkConf);
     if (accessId == null) {
+      LOG.warn("Access id key is null");
       return false;
     }
     long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -104,8 +104,6 @@ public class DelegationRssShuffleManager implements ShuffleManager {
               Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, true);
       sparkConf.set(RssSparkConfig.RSS_ENABLED.key(), "false");
       sparkConf.set("spark.shuffle.manager", "sort");
-      sparkConf.set("spark.shuffle.service.enabled", "true");
-      DelegationRssShuffleManagerUtils.configSparkConfForDeny(sparkConf);
       LOG.info("Use SortShuffleManager");
     } catch (Exception e) {
       throw new RssException(e.getMessage());

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -66,7 +66,7 @@ public class DelegationRssShuffleManagerTest {
     List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(new CoordinatorGrpcRetryableClient(coordinatorClients, 0, 0, 1));
     SparkConf conf = new SparkConf();
     conf.set(RssSparkConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED.key(), "false");
@@ -81,7 +81,7 @@ public class DelegationRssShuffleManagerTest {
     List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(new CoordinatorGrpcRetryableClient(coordinatorClients, 0, 0, 1));
 
     SparkConf conf = new SparkConf();
@@ -119,7 +119,7 @@ public class DelegationRssShuffleManagerTest {
     List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(new CoordinatorGrpcRetryableClient(coordinatorClients, 0, 0, 1));
 
     SparkConf conf = new SparkConf();
@@ -153,7 +153,7 @@ public class DelegationRssShuffleManagerTest {
     List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
     coordinatorClients.add(mockDeniedCoordinatorClient);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(new CoordinatorGrpcRetryableClient(coordinatorClients, 0, 0, 1));
     SparkConf conf = new SparkConf();
     conf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);
@@ -173,7 +173,7 @@ public class DelegationRssShuffleManagerTest {
     List<CoordinatorClient> secondCoordinatorClients = Lists.newArrayList();
     secondCoordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(new CoordinatorGrpcRetryableClient(secondCoordinatorClients, 0, 0, 1));
     SparkConf secondConf = new SparkConf();
     secondConf.set(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS, 3000L);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -114,16 +114,9 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   }
 
   private boolean tryAccessCluster(CoordinatorClient coordinatorClient) {
-    String accessId = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID.key(), "").trim();
-    if (StringUtils.isEmpty(accessId)) {
-      String providerKey = sparkConf.get(RssSparkConfig.RSS_ACCESS_ID_PROVIDER_KEY.key(), "");
-      if (StringUtils.isNotEmpty(accessId)) {
-        accessId = sparkConf.get(providerKey, "");
-        LOG.info("Get access id {} from provider key: {}", accessId, providerKey);
-      }
-    }
-    if (StringUtils.isEmpty(accessId)) {
-      LOG.warn("Access id key is empty");
+    String accessId = DelegationRssShuffleManagerUtils.acquireAccessId(sparkConf);
+    if (accessId == null) {
+      LOG.warn("Access id key is null");
       return false;
     }
     long retryInterval = sparkConf.get(RssSparkConfig.RSS_CLIENT_ACCESS_RETRY_INTERVAL_MS);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -70,7 +70,8 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     }
   }
 
-  private ShuffleManager createShuffleManagerInDriver(CoordinatorClient coordinatorClient) throws RssException {
+  private ShuffleManager createShuffleManagerInDriver(CoordinatorClient coordinatorClient)
+      throws RssException {
     ShuffleManager shuffleManager;
     user = "user";
     try {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTestBase.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/RssShuffleManagerTestBase.java
@@ -63,7 +63,7 @@ public class RssShuffleManagerTestBase {
     CoordinatorGrpcRetryableClient client =
         new CoordinatorGrpcRetryableClient(coordinatorClients, 0, 1, 1);
     mockedStaticRssShuffleUtils
-        .when(() -> RssSparkShuffleUtils.createCoordinatorClients(any()))
+        .when(() -> RssSparkShuffleUtils.createCoordinatorClientsForAccessCluster(any()))
         .thenReturn(client);
     return mockCoordinatorClient;
   }

--- a/internal-client/src/main/java/org/apache/uniffle/client/api/CoordinatorClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/api/CoordinatorClient.java
@@ -32,7 +32,7 @@ import org.apache.uniffle.client.response.RssFetchRemoteStorageResponse;
 import org.apache.uniffle.client.response.RssGetShuffleAssignmentsResponse;
 import org.apache.uniffle.client.response.RssSendHeartBeatResponse;
 
-public interface CoordinatorClient {
+public interface CoordinatorClient extends AutoCloseable {
 
   RssAppHeartBeatResponse scheduleAtFixedRateToSendAppHeartBeat(RssAppHeartBeatRequest request);
 

--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/CoordinatorClientFactory.java
@@ -100,4 +100,10 @@ public class CoordinatorClientFactory {
     return new CoordinatorGrpcRetryableClient(
         coordinatorClients, retryIntervalMs, retryTimes, heartBeatThreadNum);
   }
+
+  public synchronized CoordinatorGrpcRetryableClient createCoordinatorClientWithoutHeartbeat(
+      ClientType clientType, String coordinators, long retryIntervalMs, int retryTimes) {
+    List<CoordinatorClient> coordinatorClients = createCoordinatorClient(clientType, coordinators);
+    return new CoordinatorGrpcRetryableClient(coordinatorClients, retryIntervalMs, retryTimes, 0);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Close coordinator client in time.

### Why are the changes needed?

Grpc retry will throw exception for all the time.

```
[16:44:57:437] [grpc-default-executor-0] WARN  org.apache.uniffle.shaded.io.grpc.internal.ManagedChannelImpl.handleErrorInSyncContext:1866 - [Channel<1>: (a:10000)] Failed to resolve name. status=Status{code=UNAVAILABLE, description=Unable to resolve host a, cause=java.lang.RuntimeException: java.net.UnknownHostException: a: 未知的名称或服务
    at org.apache.uniffle.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:223)
    at org.apache.uniffle.shaded.io.grpc.internal.DnsNameResolver.doResolve(DnsNameResolver.java:282)
    at org.apache.uniffle.shaded.io.grpc.internal.DnsNameResolver$Resolve.run(DnsNameResolver.java:318)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:750)
Caused by: java.net.UnknownHostException: a: 未知的名称或服务
    at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)
    at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:867)
    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1302)
    at java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:815)
    at java.net.InetAddress.getAllByName0(InetAddress.java:1291)
    at java.net.InetAddress.getAllByName(InetAddress.java:1144)
    at java.net.InetAddress.getAllByName(InetAddress.java:1065)
    at org.apache.uniffle.shaded.io.grpc.internal.DnsNameResolver$JdkAddressResolver.resolveAddress(DnsNameResolver.java:632)
    at org.apache.uniffle.shaded.io.grpc.internal.DnsNameResolver.resolveAddresses(DnsNameResolver.java:219)
    ... 5 more
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.
