### PR TITLE
[MINOR] fix(test): Fix flaky test SimpleClusterManagerTest#updateExcludeNodesTest

### DIFF
--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
@@ -451,6 +451,8 @@ public class SimpleClusterManagerTest {
           remainNodes, availableNodes.stream().map(ServerNode::getId).collect(Collectors.toSet()));
 
       final Set<String> nodes2 = Sets.newHashSet("node3-1999", "node4-1999");
+      // Make sure last modification time change
+      Thread.sleep(1000);
       writeExcludeHosts(excludeNodesPath, nodes2);
       await().atMost(3, TimeUnit.SECONDS).until(() -> scm.getExcludedNodes().equals(nodes2));
       assertEquals(nodes2, scm.getExcludedNodes());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix flaky test SimpleClusterManagerTest#updateExcludeNodesTest

### Why are the changes needed?
```
Error:  Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 9.317 s <<< FAILURE! - in org.apache.uniffle.coordinator.SimpleClusterManagerTest
Error:  getUnhealthyServerList  Time elapsed: 0.633 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <[sn4, sn2, sn1]> but was: <[sn2, sn1, sn4, sn3]>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
	at org.apache.uniffle.coordinator.SimpleClusterManagerTest.getUnhealthyServerList(SimpleClusterManagerTest.java:219)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT