### PR TITLE
[#2201]Improvement:  Remove the ShuffleBlockInfo used in the communication between client and server via handleSendShuffleDataRequest.

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/netty/protocol/Encoders.java
+++ b/common/src/main/java/org/apache/uniffle/common/netty/protocol/Encoders.java
@@ -38,7 +38,6 @@ public class Encoders {
   public static void encodeShuffleBlockInfo(ShuffleBlockInfo shuffleBlockInfo, ByteBuf byteBuf) {
     byteBuf.writeInt(shuffleBlockInfo.getPartitionId());
     byteBuf.writeLong(shuffleBlockInfo.getBlockId());
-    byteBuf.writeInt(shuffleBlockInfo.getLength());
     byteBuf.writeInt(shuffleBlockInfo.getShuffleId());
     byteBuf.writeLong(shuffleBlockInfo.getCrc());
     byteBuf.writeLong(shuffleBlockInfo.getTaskAttemptId());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the ShuffleBlockInfo used in the communication between client and server via handleSendShuffleDataRequest.

### Why are the changes needed?
Fix: #2201

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
current UT