### PR TITLE
[#2335] Improvement: Fix the warning:   Parameter `systemProperties` is deprecated: Use `systemPropertyVariables` instead.

### DIFF
--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -169,12 +169,12 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                     <configuration>
-                        <systemProperties>
+                        <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
                             <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
                             <project.version>${project.version}</project.version>
                             <test.mode>true</test.mode>
-                        </systemProperties>
+                        </systemPropertyVariables>
                         <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
                         <useFile>${test.redirectToFile}</useFile>
                         <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -153,12 +153,12 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                     <configuration>
-                        <systemProperties>
+                        <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
                             <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
                             <project.version>${project.version}</project.version>
                             <test.mode>true</test.mode>
-                        </systemProperties>
+                        </systemPropertyVariables>
                         <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
                         <useFile>${test.redirectToFile}</useFile>
                         <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -186,12 +186,12 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
           <configuration>
-            <systemProperties>
+            <systemPropertyVariables>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <project.version>${project.version}</project.version>
               <test.mode>true</test.mode>
-            </systemProperties>
+            </systemPropertyVariables>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
             <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>

--- a/integration-test/tez/pom.xml
+++ b/integration-test/tez/pom.xml
@@ -159,12 +159,12 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
           <configuration>
-            <systemProperties>
+            <systemPropertyVariables>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <project.version>${project.version}</project.version>
               <test.mode>true</test.mode>
-            </systemProperties>
+            </systemPropertyVariables>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
             <argLine>-ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -959,13 +959,13 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
           <configuration>
-            <systemProperties>
+            <systemPropertyVariables>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <project.version>${project.version}</project.version>
               <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
               <test.mode>true</test.mode>
-            </systemProperties>
+            </systemPropertyVariables>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
             <argLine>${argLine} -ea -Xmx5g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=1g</argLine>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning:   Parameter `systemProperties` is deprecated: Use `systemPropertyVariables` instead.

### Why are the changes needed?
Fix: #2335 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
current UT