### PR TITLE
[#2346] Improvement: Fix the warning that delete(Path) in FileSystem has been deprecated

### DIFF
--- a/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/org/apache/uniffle/coordinator/SimpleClusterManager.java
@@ -235,7 +235,7 @@ public class SimpleClusterManager implements ClusterManager {
       String tempExcludedNodesPath = excludedNodesPath.concat("_tmp");
       Path tmpHadoopPath = new Path(tempExcludedNodesPath);
       if (hadoopFileSystem.exists(tmpHadoopPath)) {
-        hadoopFileSystem.delete(tmpHadoopPath);
+        hadoopFileSystem.delete(tmpHadoopPath, true);
       }
       try (BufferedWriter bufferedWriter =
           new BufferedWriter(
@@ -246,7 +246,7 @@ public class SimpleClusterManager implements ClusterManager {
           bufferedWriter.newLine();
         }
       }
-      hadoopFileSystem.delete(hadoopPath);
+      hadoopFileSystem.delete(hadoopPath, true);
       hadoopFileSystem.rename(tmpHadoopPath, hadoopPath);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning that delete(Path) in FileSystem has been deprecated

### Why are the changes needed?
Fix: #2346 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
current UT