### PR TITLE
[#2349] Improvement: Fix the warning: unchecked method invocation: method put in interface Map is applied to given types

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -194,9 +194,9 @@ public class RMRecordsReader<K, V, C> {
 
   public void start() {
     for (int partitionId : partitionIds) {
-      mergeBuffers.put(partitionId, new Queue(maxBufferPerPartition));
+      mergeBuffers.put(partitionId, new Queue<>(maxBufferPerPartition));
       if (this.combiner != null) {
-        combineBuffers.put(partitionId, new Queue(maxBufferPerPartition));
+        combineBuffers.put(partitionId, new Queue<>(maxBufferPerPartition));
       }
       RecordsFetcher fetcher = new RecordsFetcher(partitionId);
       fetcher.start();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTest.java
@@ -641,7 +641,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     Map<Integer, Set<Long>> ptb = new HashMap<>();
     for (int i = PARTITION_ID; i < PARTITION_ID + 3; i++) {
       final int partitionId = i;
-      ptb.put(partitionId, new HashSet());
+      ptb.put(partitionId, new HashSet<>());
       ptb.get(partitionId)
           .addAll(
               blocks1.stream()
@@ -854,7 +854,7 @@ public class RemoteMergeShuffleWithRssClientTest extends ShuffleReadWriteBase {
     Map<Integer, Set<Long>> ptb = new HashMap<>();
     for (int i = PARTITION_ID; i < PARTITION_ID + 3; i++) {
       final int partitionId = i;
-      ptb.put(partitionId, new HashSet());
+      ptb.put(partitionId, new HashSet<>());
       ptb.get(partitionId)
           .addAll(
               blocks1.stream()

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed.java
@@ -655,7 +655,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     Map<Integer, Set<Long>> ptb = new HashMap<>();
     for (int i = PARTITION_ID; i < PARTITION_ID + 3; i++) {
       final int partitionId = i;
-      ptb.put(partitionId, new HashSet());
+      ptb.put(partitionId, new HashSet<>());
       ptb.get(partitionId)
           .addAll(
               blocks1.stream()
@@ -869,7 +869,7 @@ public class RemoteMergeShuffleWithRssClientTestWhenShuffleFlushed extends Shuff
     Map<Integer, Set<Long>> ptb = new HashMap<>();
     for (int i = PARTITION_ID; i < PARTITION_ID + 3; i++) {
       final int partitionId = i;
-      ptb.put(partitionId, new HashSet());
+      ptb.put(partitionId, new HashSet<>());
       ptb.get(partitionId)
           .addAll(
               blocks1.stream()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning: unchecked method invocation: method put in interface Map is applied to given types

### Why are the changes needed?
Fix: #2349 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
current UT
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/36935007-9cbf-4ef7-8af2-17b8a0f3269b" />
