### PR TITLE
[#2353] Improvement: Fix the warning: unchecked method invocation: method `sendCachedBuffer` in class `RMRecordsReader.RecordsCombiner` is applied to given types

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -561,7 +561,7 @@ public class RMRecordsReader<K, V, C> {
     // The RecordBuffer has a capacity limit, records for the same key may be
     // distributed in different RecordBuffers. So we need a cachedBuffer used
     // to record the buffer of the last combine.
-    private RecordBuffer cached;
+    private RecordBuffer<K, C> cached;
     private Queue<RecordBuffer> nextQueue;
 
     RecordsCombiner(int partitionId) {

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -262,7 +262,6 @@ public class RMRecordsReader<K, V, C> {
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -290,7 +289,6 @@ public class RMRecordsReader<K, V, C> {
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -336,7 +334,6 @@ public class RMRecordsReader<K, V, C> {
             return true;
           }
         } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -388,7 +385,6 @@ public class RMRecordsReader<K, V, C> {
                   curr = results.take();
                   return ret;
                 } catch (InterruptedException | IOException e) {
-                  Thread.currentThread().interrupt();
                   throw new RssException(e);
                 }
               }
@@ -612,7 +608,6 @@ public class RMRecordsReader<K, V, C> {
             }
           }
         } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
           throw new RssException(e);
         }
       }
@@ -661,7 +656,6 @@ public class RMRecordsReader<K, V, C> {
                   }
                   return new BufferedSegment(recordBuffer);
                 } catch (InterruptedException ex) {
-                  Thread.currentThread().interrupt();
                   throw new RssException(ex);
                 }
               });
@@ -677,7 +671,6 @@ public class RMRecordsReader<K, V, C> {
       } catch (InterruptedException | IOException e) {
         error = e;
         stop = true;
-        Thread.currentThread().interrupt();
       }
     }
   }

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -452,7 +452,7 @@ public class RMRecordsReader<K, V, C> {
     RecordsFetcher(int partitionId) {
       this.partitionId = partitionId;
       this.sleepTime = initFetchSleepTime;
-      this.recordBuffer = new RecordBuffer(partitionId);
+      this.recordBuffer = new RecordBuffer<>(partitionId);
       this.nextQueue =
           combiner == null ? mergeBuffers.get(partitionId) : combineBuffers.get(partitionId);
       this.serverInfos = shuffleServerInfoMap.get(partitionId);
@@ -530,7 +530,7 @@ public class RMRecordsReader<K, V, C> {
                 }
                 if (recordBuffer.size() >= maxRecordsNumPerBuffer) {
                   nextQueue.put(recordBuffer);
-                  recordBuffer = new RecordBuffer(partitionId);
+                  recordBuffer = new RecordBuffer<>(partitionId);
                 }
                 recordBuffer.addRecord(reader.getCurrentKey(), reader.getCurrentValue());
               }
@@ -570,7 +570,7 @@ public class RMRecordsReader<K, V, C> {
 
     RecordsCombiner(int partitionId) {
       this.partitionId = partitionId;
-      this.cached = new RecordBuffer(partitionId);
+      this.cached = new RecordBuffer<>(partitionId);
       this.nextQueue = mergeBuffers.get(partitionId);
       setName("RecordsCombiner-" + partitionId);
     }
@@ -593,7 +593,7 @@ public class RMRecordsReader<K, V, C> {
             //   we can send the cached to downstream directly.
             if (cached.size() > 0 && !isSameKey(cached.getLastKey(), current.getFirstKey())) {
               sendCachedBuffer(cached);
-              cached = new RecordBuffer(partitionId);
+              cached = new RecordBuffer<>(partitionId);
             }
 
             // 3 combine the current, then cache it. By this way, we can handle the specical case

--- a/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
+++ b/client/src/main/java/org/apache/uniffle/client/record/reader/RMRecordsReader.java
@@ -262,6 +262,7 @@ public class RMRecordsReader<K, V, C> {
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -289,6 +290,7 @@ public class RMRecordsReader<K, V, C> {
           curr = results.take();
           return curr != null;
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -334,6 +336,7 @@ public class RMRecordsReader<K, V, C> {
             return true;
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new IOException(e);
         }
       }
@@ -385,6 +388,7 @@ public class RMRecordsReader<K, V, C> {
                   curr = results.take();
                   return ret;
                 } catch (InterruptedException | IOException e) {
+                  Thread.currentThread().interrupt();
                   throw new RssException(e);
                 }
               }
@@ -512,7 +516,7 @@ public class RMRecordsReader<K, V, C> {
               // split into two different threads, then will be asynchronous processes. Although it
               // seems to save time, it actually consumes more memory.
               reader =
-                  new RecordsReader(
+                  new RecordsReader<>(
                       rssConf,
                       SerInputStream.newInputStream(byteBuf),
                       keyClass,
@@ -595,7 +599,7 @@ public class RMRecordsReader<K, V, C> {
             // 3 combine the current, then cache it. By this way, we can handle the specical case
             // that next record
             // buffer has same key in current.
-            RecordBlob recordBlob = new RecordBlob(partitionId);
+            RecordBlob recordBlob = new RecordBlob<>(partitionId);
             recordBlob.addRecords(current);
             recordBlob.combine(combiner, isMapCombine);
             for (Object record : recordBlob.getResult()) {
@@ -608,6 +612,7 @@ public class RMRecordsReader<K, V, C> {
             }
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RssException(e);
         }
       }
@@ -616,7 +621,7 @@ public class RMRecordsReader<K, V, C> {
     private void sendCachedBuffer(RecordBuffer<K, C> cachedBuffer) throws InterruptedException {
       // Multiple records with the same key may span different recordbuffers. we were only combined
       // within the same recordbuffer. So before send to downstream, we should combine the cached.
-      RecordBlob recordBlob = new RecordBlob(partitionId);
+      RecordBlob recordBlob = new RecordBlob<K, C, Object>(partitionId);
       recordBlob.addRecords(cachedBuffer);
       recordBlob.combine(combiner, true);
       RecordBuffer recordBuffer = new RecordBuffer<>(partitionId);
@@ -656,6 +661,7 @@ public class RMRecordsReader<K, V, C> {
                   }
                   return new BufferedSegment(recordBuffer);
                 } catch (InterruptedException ex) {
+                  Thread.currentThread().interrupt();
                   throw new RssException(ex);
                 }
               });
@@ -671,6 +677,7 @@ public class RMRecordsReader<K, V, C> {
       } catch (InterruptedException | IOException e) {
         error = e;
         stop = true;
+        Thread.currentThread().interrupt();
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the warning: unchecked method invocation: method `sendCachedBuffer` in class `RMRecordsReader.RecordsCombiner` is applied to given types

### Why are the changes needed?
Fix: #2353

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
current UT

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/1ac86c0d-d902-47e0-8ff9-1de3fbc3299c" />

