### PR TITLE
improvement(client): Simplify skipping processed blockIds check to speed up

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/DataSkippableReadHandler.java
@@ -96,8 +96,7 @@ public abstract class DataSkippableReadHandler extends PrefetchableClientReadHan
       blocksOfSegment.and(expectBlockIds);
       if (!blocksOfSegment.isEmpty()) {
         // skip processed blockIds
-        blocksOfSegment.or(processBlockIds);
-        blocksOfSegment.xor(processBlockIds);
+        blocksOfSegment.andNot(processBlockIds);
         if (!blocksOfSegment.isEmpty()) {
           result = readShuffleData(segment);
           segmentIndex++;


### PR DESCRIPTION

### What changes were proposed in this pull request?

Simplify skipping processed blockIds check to speed up

### Why are the changes needed?

To speed up

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests
