### PR TITLE
[#2376] test(coordinator): The interval of `SimpleClusterManager.nodesCheck` should be bigger than that of `org.awaitility.Awaitility.await`

### DIFF
--- a/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
+++ b/coordinator/src/test/java/org/apache/uniffle/coordinator/SimpleClusterManagerTest.java
@@ -132,7 +132,7 @@ public class SimpleClusterManagerTest {
   public void getLostServerListTest() throws Exception {
     CoordinatorConf coordinatorConf = new CoordinatorConf();
     // Shorten the heartbeat time
-    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 300L);
+    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 600L);
     try (SimpleClusterManager clusterManager =
         new SimpleClusterManager(coordinatorConf, new Configuration())) {
       ServerNode sn1 = new ServerNode("sn1", "ip", 0, 100L, 50L, 20, 10, grpcTags);
@@ -174,7 +174,7 @@ public class SimpleClusterManagerTest {
   public void getUnhealthyServerList() throws Exception {
     CoordinatorConf coordinatorConf = new CoordinatorConf();
     // Shorten the heartbeat time
-    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 300L);
+    coordinatorConf.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 600L);
     try (SimpleClusterManager clusterManager =
         new SimpleClusterManager(coordinatorConf, new Configuration())) {
       ServerNode sn1 = new ServerNode("sn1", "ip", 0, 100L, 50L, 20, 10, grpcTags);
@@ -375,7 +375,7 @@ public class SimpleClusterManagerTest {
   @Test
   public void heartbeatTimeoutTest() throws Exception {
     CoordinatorConf ssc = new CoordinatorConf();
-    ssc.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 300L);
+    ssc.setLong(CoordinatorConf.COORDINATOR_HEARTBEAT_TIMEOUT, 600L);
     try (SimpleClusterManager clusterManager = new SimpleClusterManager(ssc, new Configuration())) {
       addNode("sn0", clusterManager);
       addNode("sn1", clusterManager);


### PR DESCRIPTION
### What changes were proposed in this pull request?
The initial an interval execution time of `SimpleClusterManager.nodesCheck` changed from 100ms to 200ms, this can make condition verify of unit test execute before and after `nodesCheck`

### Why are the changes needed?
    - Pass the flaky test
    - set bigger rss.coordinator.server.heartbeat.timeout to avoid `SimpleClusterManager.nodesCheck` happens before the first execution of await condition, since the default poll time of the `org.awaitility.Awaitility.await` is 100ms

Fix: #2376

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Flaky test can be fixed
