### PR TITLE
[#2382] improvement(test): Fix ServletTest, ShuffleServerFaultToleranceTest,ShuffleServerWithKerberizedHadoopTest to use random port

### DIFF
--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -137,7 +137,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
       server.start();
     }
     for (ShuffleServer server : nettyShuffleServers) {
-      server.getShuffleServerConf().setInteger(RssBaseConf.JETTY_HTTP_PORT, 0);
+      server.getShuffleServerConf().setInteger(ShuffleServerConf.NETTY_SERVER_PORT, 0);
       server.start();
     }
   }
@@ -212,8 +212,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   }
 
   private static ShuffleServerConf getShuffleServerConf(
-      ServerType serverType, String quorum, int grpcPort, int nettyPort, int jettyPort)
-      throws Exception {
+      ServerType serverType, String quorum, int grpcPort, int nettyPort, int jettyPort) {
     ShuffleServerConf serverConf = new ShuffleServerConf();
     serverConf.setInteger("rss.rpc.server.port", grpcPort);
     serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
@@ -241,7 +240,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
   }
 
   protected static ShuffleServerConf shuffleServerConfWithoutPort(
-      int subDirIndex, File tmpDir, ServerType serverType) throws Exception {
+      int subDirIndex, File tmpDir, ServerType serverType) {
     ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType, "", 0, 0, 0);
     File dataDir1 = new File(tmpDir, subDirIndex + "_1");
     File dataDir2 = new File(tmpDir, subDirIndex + "_2");
@@ -266,7 +265,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     coordinators.add(new CoordinatorServer(coordinatorConf));
   }
 
-  protected static void storeCoordinatorConf(CoordinatorConf coordinatorConf) throws Exception {
+  protected static void storeCoordinatorConf(CoordinatorConf coordinatorConf) {
     coordinatorConfList.add(coordinatorConf);
   }
 
@@ -284,11 +283,11 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     }
   }
 
-  protected static void storeShuffleServerConf(ShuffleServerConf serverConf) throws Exception {
+  protected static void storeShuffleServerConf(ShuffleServerConf serverConf) {
     shuffleServerConfList.add(serverConf);
   }
 
-  protected static void storeMockShuffleServerConf(ShuffleServerConf serverConf) throws Exception {
+  protected static void storeMockShuffleServerConf(ShuffleServerConf serverConf) {
     mockShuffleServerConfList.add(serverConf);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -211,7 +211,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
         getNextJettyServerPort());
   }
 
-  protected static ShuffleServerConf getShuffleServerConf(
+  private static ShuffleServerConf getShuffleServerConf(
       ServerType serverType, String quorum, int grpcPort, int nettyPort, int jettyPort)
       throws Exception {
     ShuffleServerConf serverConf = new ShuffleServerConf();
@@ -240,7 +240,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     return serverConf;
   }
 
-  protected static ShuffleServerConf getShuffleServerConf(
+  protected static ShuffleServerConf shuffleServerConfWithoutPort(
       int subDirIndex, File tmpDir, ServerType serverType) throws Exception {
     ShuffleServerConf shuffleServerConf = getShuffleServerConf(serverType, "", 0, 0, 0);
     File dataDir1 = new File(tmpDir, subDirIndex + "_1");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/IntegrationTestBase.java
@@ -169,6 +169,7 @@ public abstract class IntegrationTestBase extends HadoopTestBase {
     coordinators.clear();
     shuffleServerConfList.clear();
     mockShuffleServerConfList.clear();
+    coordinatorConfList.clear();
     jettyPorts.clear();
     ShuffleServerMetrics.clear();
     CoordinatorMetrics.clear();

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -82,7 +82,7 @@ public class ServletTest extends IntegrationTestBase {
 
   private static void prepareShuffleServerConf(int subDirIndex, File tmpDir) throws Exception {
     ShuffleServerConf shuffleServerConf =
-        getShuffleServerConf(subDirIndex, tmpDir, ServerType.GRPC);
+        shuffleServerConfWithoutPort(subDirIndex, tmpDir, ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_SHUTDOWN, false);
     storeShuffleServerConf(shuffleServerConf);
   }

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -80,29 +80,28 @@ public class ServletTest extends IntegrationTestBase {
   private static CoordinatorServer coordinatorServer;
   private ObjectMapper objectMapper = new ObjectMapper();
 
-  private static void createShuffleServer(int id, File tmpDir, String quorum) throws Exception {
+  private static void prepareShuffleServerConf(int subDirIndex, File tmpDir) throws Exception {
     ShuffleServerConf shuffleServerConf =
-        getShuffleServerConf(id, tmpDir, ServerType.GRPC, quorum, jettyPorts.get(id));
+        getShuffleServerConf(subDirIndex, tmpDir, ServerType.GRPC);
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_SHUTDOWN, false);
-    createShuffleServer(shuffleServerConf);
+    storeShuffleServerConf(shuffleServerConf);
   }
 
   @BeforeAll
   public static void setUp(@TempDir File tmpDir) throws Exception {
-    reserveJettyPorts(5);
-    coordinatorHttpPort = jettyPorts.get(4);
-    CoordinatorConf coordinatorConf = coordinatorConf(coordinatorHttpPort);
+
+    CoordinatorConf coordinatorConf = coordinatorConfWithoutPort();
     coordinatorConf.set(RssBaseConf.JETTY_CORE_POOL_SIZE, 128);
     coordinatorConf.set(RssBaseConf.REST_AUTHORIZATION_CREDENTIALS, AUTHORIZATION_CREDENTIALS);
-    createCoordinatorServer(coordinatorConf);
-    String quorum = startCoordinators();
+    storeCoordinatorConf(coordinatorConf);
 
-    createShuffleServer(0, tmpDir, quorum);
-    createShuffleServer(1, tmpDir, quorum);
-    createShuffleServer(2, tmpDir, quorum);
-    createShuffleServer(3, tmpDir, quorum);
+    prepareShuffleServerConf(0, tmpDir);
+    prepareShuffleServerConf(1, tmpDir);
+    prepareShuffleServerConf(2, tmpDir);
+    prepareShuffleServerConf(3, tmpDir);
 
-    startShuffleServers();
+    startServersWithRandomPorts();
+    coordinatorHttpPort = jettyPorts.get(0);
     coordinatorServer = coordinators.get(0);
     Awaitility.await()
         .timeout(30, TimeUnit.SECONDS)

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ServletTest.java
@@ -81,9 +81,9 @@ public class ServletTest extends IntegrationTestBase {
   private ObjectMapper objectMapper = new ObjectMapper();
 
   private static void createShuffleServer(int id, File tmpDir, String quorum) throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(id, tmpDir, ServerType.GRPC, quorum);
+    ShuffleServerConf shuffleServerConf =
+        getShuffleServerConf(id, tmpDir, ServerType.GRPC, quorum, jettyPorts.get(id));
     shuffleServerConf.set(ShuffleServerConf.SERVER_DECOMMISSION_SHUTDOWN, false);
-    shuffleServerConf.set(ShuffleServerConf.JETTY_HTTP_PORT, jettyPorts.get(id));
     createShuffleServer(shuffleServerConf);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -285,7 +285,8 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
 
   public static void prepareShuffleServerConf(int subDirIndex, File tmpDir, ServerType serverType)
       throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(subDirIndex, tmpDir, serverType);
+    ShuffleServerConf shuffleServerConf =
+        shuffleServerConfWithoutPort(subDirIndex, tmpDir, serverType);
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerFaultToleranceTest.java
@@ -290,7 +290,8 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
 
   public static MockedShuffleServer createServer(
       int id, File tmpDir, String quorum, ServerType serverType) throws Exception {
-    ShuffleServerConf shuffleServerConf = getShuffleServerConf(id, tmpDir, serverType, quorum);
+    ShuffleServerConf shuffleServerConf =
+        getShuffleServerConf(id, tmpDir, serverType, quorum, jettyPorts.get(id));
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.LOCALFILE.name());
     shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
@@ -303,8 +304,6 @@ public class ShuffleServerFaultToleranceTest extends ShuffleReadWriteBase {
     shuffleServerConf.setString(
         ShuffleServerConf.RSS_STORAGE_TYPE.key(), StorageType.MEMORY_LOCALFILE_HDFS.name());
     shuffleServerConf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 450L);
-    shuffleServerConf.setInteger(ShuffleServerConf.RPC_SERVER_PORT, 0);
-    shuffleServerConf.setInteger("rss.jetty.http.port", jettyPorts.get(id));
     return new MockedShuffleServer(shuffleServerConf);
   }
 

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -100,7 +100,6 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
     File dataDir2 = new File(tmpDir, id + "_2");
     String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
     serverConf.setInteger("rss.rpc.server.port", 0);
-    serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
     serverConf.setString("rss.storage.basePath", basePath);
     serverConf.setString("rss.server.buffer.capacity", "671088640");
     serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");

--- a/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
+++ b/integration-test/common/src/test/java/org/apache/uniffle/test/ShuffleServerWithKerberizedHadoopTest.java
@@ -81,9 +81,6 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
     }
   }
 
-  private static final int COORDINATOR_RPC_PORT = 19999;
-  private static final String COORDINATOR_QUORUM = LOCALHOST + ":" + COORDINATOR_RPC_PORT;
-
   private ShuffleServerGrpcClient grpcShuffleServerClient;
   private ShuffleServerGrpcNettyClient nettyShuffleServerClient;
   private static CoordinatorServer coordinatorServer;
@@ -94,19 +91,23 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
 
   static @TempDir File tempDir;
 
-  private static ShuffleServerConf getShuffleServerConf(ServerType serverType) throws Exception {
+  private static ShuffleServerConf getShuffleServerConf(
+      int id, File tmpDir, int coordinatorRpcPort, ServerType serverType) throws Exception {
     ShuffleServerConf serverConf = new ShuffleServerConf();
-    serverConf.setInteger("rss.rpc.server.port", IntegrationTestBase.getNextRpcServerPort());
+    File dataDir1 = new File(tmpDir, id + "_1");
+    File dataDir2 = new File(tmpDir, id + "_2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    serverConf.setInteger("rss.rpc.server.port", 0);
     serverConf.setString("rss.storage.type", StorageType.MEMORY_LOCALFILE_HDFS.name());
-    serverConf.setString("rss.storage.basePath", tempDir.getAbsolutePath());
+    serverConf.setString("rss.storage.basePath", basePath);
     serverConf.setString("rss.server.buffer.capacity", "671088640");
     serverConf.setString("rss.server.memory.shuffle.highWaterMark", "50.0");
     serverConf.setString("rss.server.memory.shuffle.lowWaterMark", "0.0");
     serverConf.setString("rss.server.read.buffer.capacity", "335544320");
-    serverConf.setString("rss.coordinator.quorum", COORDINATOR_QUORUM);
+    serverConf.setString("rss.coordinator.quorum", LOCALHOST + ":" + coordinatorRpcPort);
     serverConf.setString("rss.server.heartbeat.delay", "1000");
     serverConf.setString("rss.server.heartbeat.interval", "1000");
-    serverConf.setInteger("rss.jetty.http.port", IntegrationTestBase.getNextJettyServerPort());
+    serverConf.setInteger("rss.jetty.http.port", 0);
     serverConf.setInteger("rss.jetty.corePool.size", 64);
     serverConf.setInteger("rss.rpc.executor.size", 10);
     serverConf.setString("rss.server.hadoop.dfs.replication", "2");
@@ -116,29 +117,30 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
     serverConf.setBoolean(ShuffleServerConf.RSS_TEST_MODE_ENABLE, true);
     serverConf.set(ShuffleServerConf.RPC_SERVER_TYPE, serverType);
     if (serverType == ServerType.GRPC_NETTY) {
-      serverConf.setInteger(
-          ShuffleServerConf.NETTY_SERVER_PORT, IntegrationTestBase.getNextNettyServerPort());
+      serverConf.setInteger(ShuffleServerConf.NETTY_SERVER_PORT, 0);
     }
     return serverConf;
   }
 
   @BeforeAll
-  public static void setup() throws Exception {
+  public static void setup(@TempDir File tempDir) throws Exception {
     testRunner = ShuffleServerWithKerberizedHadoopTest.class;
     KerberizedHadoopBase.init();
-
     CoordinatorConf coordinatorConf = new CoordinatorConf();
-    coordinatorConf.setInteger(CoordinatorConf.RPC_SERVER_PORT, 19999);
-    coordinatorConf.setInteger(CoordinatorConf.JETTY_HTTP_PORT, 19998);
+    coordinatorConf.setInteger(CoordinatorConf.RPC_SERVER_PORT, 0);
+    coordinatorConf.setInteger(CoordinatorConf.JETTY_HTTP_PORT, 0);
     coordinatorConf.setInteger(CoordinatorConf.RPC_EXECUTOR_SIZE, 10);
     coordinatorServer = new CoordinatorServer(coordinatorConf);
     coordinatorServer.start();
 
-    ShuffleServerConf grpcShuffleServerConf = getShuffleServerConf(ServerType.GRPC);
+    ShuffleServerConf grpcShuffleServerConf =
+        getShuffleServerConf(0, tempDir, coordinatorServer.getRpcListenPort(), ServerType.GRPC);
     grpcShuffleServer = new ShuffleServer(grpcShuffleServerConf);
     grpcShuffleServer.start();
 
-    ShuffleServerConf nettyShuffleServerConf = getShuffleServerConf(ServerType.GRPC_NETTY);
+    ShuffleServerConf nettyShuffleServerConf =
+        getShuffleServerConf(
+            1, tempDir, coordinatorServer.getRpcListenPort(), ServerType.GRPC_NETTY);
     nettyShuffleServer = new ShuffleServer(nettyShuffleServerConf);
     nettyShuffleServer.start();
 
@@ -163,16 +165,10 @@ public class ShuffleServerWithKerberizedHadoopTest extends KerberizedHadoopBase 
   public void beforeEach() throws Exception {
     initHadoopSecurityContext();
     grpcShuffleServerClient =
-        new ShuffleServerGrpcClient(
-            LOCALHOST,
-            getShuffleServerConf(ServerType.GRPC).getInteger(ShuffleServerConf.RPC_SERVER_PORT));
+        new ShuffleServerGrpcClient(LOCALHOST, grpcShuffleServer.getGrpcPort());
     nettyShuffleServerClient =
         new ShuffleServerGrpcNettyClient(
-            LOCALHOST,
-            getShuffleServerConf(ServerType.GRPC_NETTY)
-                .getInteger(ShuffleServerConf.RPC_SERVER_PORT),
-            getShuffleServerConf(ServerType.GRPC_NETTY)
-                .getInteger(ShuffleServerConf.NETTY_SERVER_PORT));
+            LOCALHOST, nettyShuffleServer.getGrpcPort(), nettyShuffleServer.getNettyPort());
   }
 
   @AfterEach


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce a new way to start servers
1. Store coordinator and shuffleServer conf
2. Initialize coordinator and shuffleServer lazily by using random port in `startServersWithRandomPorts`
3. Pass coordinator quorum to shuffleServer after coordinator started

### Why are the changes needed?
Avoid port conflicts of unit test
Fix: #2382


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT
