### PR TITLE
[#2417] improvement: Remove "incubating" in scripts and docs

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,4 +1,4 @@
-Apache Uniffle (incubating) is an effort undergoing incubation at The Apache
+Apache Uniffle is an effort undergoing incubation at The Apache
 Software Foundation (ASF), sponsored by the Apache Incubator PMC.
 
 Incubation is required of all newly accepted projects until a further review

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Uniffle (incubating)
+Apache Uniffle
 Copyright 2022 and onwards The Apache Software Foundation.
 
 This product includes software developed at

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,4 +1,4 @@
-Apache Uniffle (incubating)
+Apache Uniffle
 Copyright 2022 and onwards The Apache Software Foundation.
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-# Apache Uniffle (Incubating)
+# Apache Uniffle
 
 Uniffle is a high performance, general purpose remote shuffle service for distributed computing engines.
 It provides the ability to push shuffle data into centralized storage service,

--- a/release/create-package.sh
+++ b/release/create-package.sh
@@ -53,7 +53,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 package_source() {
-  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-src.tar.gz"
+  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-src.tar.gz"
   SRC_TGZ="${RELEASE_DIR}/${SRC_TGZ_FILE}"
 
   mkdir -p "${RELEASE_DIR}"
@@ -61,7 +61,7 @@ package_source() {
 
   echo "Creating source release tarball ${SRC_TGZ_FILE}"
 
-  git archive --prefix="apache-uniffle-${RELEASE_VERSION}-incubating-src/" -o "${SRC_TGZ}" HEAD
+  git archive --prefix="apache-uniffle-${RELEASE_VERSION}-src/" -o "${SRC_TGZ}" HEAD
 
   if [ "$SKIP_GPG" == "false" ] ; then
     gpg --armor --detach-sig "${SRC_TGZ}"
@@ -70,7 +70,7 @@ package_source() {
 }
 
 package_binary() {
-  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-bin.tar.gz"
+  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-bin.tar.gz"
   BIN_TGZ="${RELEASE_DIR}/${BIN_TGZ_FILE}"
 
   mkdir -p "${RELEASE_DIR}"
@@ -80,8 +80,8 @@ package_binary() {
 
   ${PROJECT_DIR}/build_distribution.sh
 
-  BIN_ORIGIN_NAME="apache-uniffle-${RELEASE_VERSION}-incubating-hadoop2.8.tgz"
-  BIN_DIR_NAME="apache-uniffle-${RELEASE_VERSION}-incubating-hadoop2.8"
+  BIN_ORIGIN_NAME="apache-uniffle-${RELEASE_VERSION}-hadoop2.8.tgz"
+  BIN_DIR_NAME="apache-uniffle-${RELEASE_VERSION}-hadoop2.8"
   tar -zxf $BIN_ORIGIN_NAME
   cp "${PROJECT_DIR}/LICENSE-binary" "${BIN_DIR_NAME}/LICENSE"
   cp "${PROJECT_DIR}/NOTICE-binary" "${BIN_DIR_NAME}/NOTICE"

--- a/release/publish_to_svn.sh
+++ b/release/publish_to_svn.sh
@@ -54,8 +54,8 @@ upload_svn_staging() {
   mkdir -p "${SVN_STAGING_DIR}/${RELEASE_TAG}"
   rm -f "${SVN_STAGING_DIR}/${RELEASE_TAG}/*"
 
-  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-src.tar.gz"
-  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-incubating-bin.tar.gz"
+  SRC_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-src.tar.gz"
+  BIN_TGZ_FILE="apache-uniffle-${RELEASE_VERSION}-bin.tar.gz"
 
   echo "Copying release tarballs"
   cp "${RELEASE_DIR}/${SRC_TGZ_FILE}"        "${SVN_STAGING_DIR}/${RELEASE_TAG}/${SRC_TGZ_FILE}"

--- a/security.md
+++ b/security.md
@@ -17,7 +17,7 @@
 
 # Security
 
-The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. Likewise, Apache Uniffle (incubating) is also vigilant and takes security issues related to its features and functionality into the highest consideration.
+The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. Likewise, Apache Uniffle is also vigilant and takes security issues related to its features and functionality into the highest consideration.
 
 If you have any concerns regarding Uniffle's security,
 or you discover a vulnerability or potential threat,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove "incubating" in scripts and docs.

### Why are the changes needed?

For https://github.com/apache/incubator-uniffle/issues/2417

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Exsiting UTs.