### PR TITLE
[#2529] fix(spark3): Incorrect clientInfo without nettyPort if netty is enabled

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/factory/ShuffleServerClientFactory.java
@@ -46,8 +46,7 @@ public class ShuffleServerClientFactory {
   private ShuffleServerClient createShuffleServerClient(
       String clientType, ShuffleServerInfo shuffleServerInfo, RssConf rssConf) {
     if (clientType.equalsIgnoreCase(ClientType.GRPC.name())) {
-      return new ShuffleServerGrpcClient(
-          rssConf, shuffleServerInfo.getHost(), shuffleServerInfo.getGrpcPort());
+      return new ShuffleServerGrpcClient(rssConf, shuffleServerInfo);
     } else if (clientType.equalsIgnoreCase(ClientType.GRPC_NETTY.name())) {
       return new ShuffleServerGrpcNettyClient(
           rssConf,

--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -152,6 +152,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
           StatusCode.INTERNAL_NOT_RETRY_ERROR,
           StatusCode.EXCEED_HUGE_PARTITION_HARD_LIMIT);
 
+  private ShuffleServerInfo serverInfo;
+
   @VisibleForTesting
   public ShuffleServerGrpcClient(String host, int port) {
     this(
@@ -164,6 +166,11 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         0,
         0,
         -1);
+  }
+
+  public ShuffleServerGrpcClient(RssConf rssConf, ShuffleServerInfo rssServerInfo) {
+    this(rssConf, rssServerInfo.getHost(), rssServerInfo.getGrpcPort());
+    this.serverInfo = rssServerInfo;
   }
 
   public ShuffleServerGrpcClient(RssConf rssConf, String host, int port) {
@@ -1271,7 +1278,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
 
   @Override
   public ClientInfo getClientInfo() {
-    return new ClientInfo(ClientType.GRPC, new ShuffleServerInfo(host, port));
+    return new ClientInfo(
+        ClientType.GRPC, serverInfo == null ? new ShuffleServerInfo(host, port) : serverInfo);
   }
 
   protected void waitOrThrow(


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the shuffle server enables Netty RPC, clients collect push cost metrics along with client information. However, the collected shuffle server information lacks the Netty port, which causes subsequent analysis to be inaccurate or invalid.

### Why are the changes needed?

for #2529 
![image](https://github.com/user-attachments/assets/0c550086-ffeb-43c8-8fc2-3a2e42e3150e)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Yes. Test in the internal cluster spark jobs and existing UTs
