### PR TITLE
[#2599] fix(spark): Fix bug the incorrect shuffle read metric for spark

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -152,7 +152,8 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
         long startSerialization = System.currentTimeMillis();
         recordsIterator = createKVIterator(decompressed);
         long serializationDuration = System.currentTimeMillis() - startSerialization;
-        shuffleReadMetrics.incFetchWaitTime(serializationDuration + uncompressionDuration);
+        shuffleReadMetrics.incFetchWaitTime(
+            serializationDuration + uncompressionDuration + readDuration);
         readTime += readDuration;
         serializeTime += serializationDuration;
       } else {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
@@ -47,7 +46,6 @@ import org.apache.uniffle.client.api.ShuffleReadClient;
 import org.apache.uniffle.client.factory.ShuffleClientFactory;
 import org.apache.uniffle.client.impl.ShuffleReadClientImpl;
 import org.apache.uniffle.common.ClientType;
-import org.apache.uniffle.common.ShuffleReadTimes;
 import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.compression.Codec;
 import org.apache.uniffle.common.config.RssConf;
@@ -336,10 +334,7 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
 
     validateResult(rssShuffleDataIterator, expectedData, 20);
     assertEquals(20, rssShuffleDataIterator.getShuffleReadMetrics().recordsRead());
-    ShuffleReadTimes readTimes = rssShuffleDataIterator.getReadTimes();
-    ShuffleReadMetrics shuffleReadMetrics = rssShuffleDataIterator.getShuffleReadMetrics();
-    shuffleReadMetrics.incFetchWaitTime(TimeUnit.MILLISECONDS.toNanos(readTimes.getTotal()));
-    assertTrue(shuffleReadMetrics.fetchWaitTime() > 0);
+    assertTrue(rssShuffleDataIterator.getShuffleReadMetrics().fetchWaitTime() > 0);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix bug: Incorrect shuffle read metric for Spark

### Why are the changes needed?
for https://github.com/apache/uniffle/issues/2599

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
UT