### PR TITLE
[#2591] fix(client): Missing task_id propagation in getLocalShuffleDataV3

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -86,6 +86,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
   private ShuffleDependency<K, ?, C> shuffleDependency;
   private int numMaps;
   private Serializer serializer;
+  private long taskAttemptId;
   private String taskId;
   private String basePath;
   private int partitionNum;
@@ -134,6 +135,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
     this.shuffleId = shuffleDependency.shuffleId();
     this.serializer = rssShuffleHandle.getDependency().serializer();
     this.taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();
+    this.taskAttemptId = context.taskAttemptId();
     this.basePath = basePath;
     this.partitionNum = partitionNum;
     this.partitionToExpectBlocks = partitionToExpectBlocks;
@@ -317,10 +319,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
                 .retryMax(retryMax)
                 .retryIntervalMax(retryIntervalMax)
                 .rssConf(rssConf)
-                .taskAttemptId(
-                    Optional.ofNullable(TaskContext.get())
-                        .map(taskContext -> taskContext.taskAttemptId())
-                        .orElse(0L));
+                .taskAttemptId(taskAttemptId);
         if (codec.isPresent() && rssConf.get(RSS_READ_OVERLAPPING_DECOMPRESSION_ENABLED)) {
           builder
               .overlappingDecompressionEnabled(true)

--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -199,6 +199,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     request.setRetryMax(builder.getRetryMax());
     request.setRetryIntervalMax(builder.getRetryIntervalMax());
     request.setReadCostTracker(readCostTracker);
+    request.setTaskAttemptId(builder.getTaskAttemptId());
     if (builder.isExpectedTaskIdsBitmapFilterEnable()) {
       request.useExpectedTaskIdsBitmapFilter();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix missing task_id propagation in getLocalShuffleDataV3

### Why are the changes needed?

Task_id is invalid 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal tests.