### PR TITLE
[#2609] feat(spark): Expose `checkDataIfAnyFailure` method so that Gluten can invoke it to trigger reassign ASSP

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -562,7 +562,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
     }
   }
 
-  private void checkDataIfAnyFailure() {
+  // This method should remain protected so that Gluten can invoke it
+  protected void checkDataIfAnyFailure() {
     if (blockFailSentRetryEnabled) {
       collectFailedBlocksToResend();
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is exposing the `checkDataIfAnyFailure` method with protected modifier, so that the Gluten can invoke this to trigger reassign mechanism as soon as possible.

### Why are the changes needed?

for #2609 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Neen't