### PR TITLE
improvement(spark): Always reset decompression buffer with explicit position and limit

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -219,10 +219,11 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
       unCompressedBytesLength += uncompressedLen;
       long decompressDuration = System.currentTimeMillis() - startDecompress;
       decompressTime += decompressDuration;
+
       // uncompressedData's limit is not updated by `codec.decompress`, however this information is
-      // used
-      // by `createKVIterator`. Update limit here.
-      uncompressedData.limit(uncompressedData.position() + uncompressedLen);
+      // used by `createKVIterator`. update position and limit
+      uncompressedData.position(0);
+      uncompressedData.limit(uncompressedLen);
     } else {
       uncompressedData = rawData;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor the uncompression buffer to reset by the explicit position=0 and limit=len

### Why are the changes needed?

This may be related with the bug #2630 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests
