### PR TITLE
[#2517] fix(client): IllegalReferenceCountException about ShuffleBlockInfo

### DIFF
--- a/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/org/apache/uniffle/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -574,7 +574,10 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
         int partitionRequireSize = 0;
         for (ShuffleBlockInfo sbi : ptb.getValue()) {
           if (sbi.getData().refCnt() == 0) {
-            continue;
+            throw new RssException(
+                "Detected a ShuffleBlockInfo with a released buffer (refCnt=0) for blockId["
+                    + sbi.getBlockId()
+                    + "].");
           }
           shuffleBlocks.add(
               ShuffleBlock.newBuilder()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `IllegalReferenceCountException` about ShuffleBlockInfo

### Why are the changes needed?
for https://github.com/apache/uniffle/issues/2517

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
current UT