### PR TITLE
fix(spark): decompression time is always 0 when overlapping decompression is enabled

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -150,6 +150,7 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
         } else {
           decompressed = shuffleBlock.getByteBuffer();
           unCompressedBytesLength += shuffleBlock.getUncompressLength();
+          decompressTime += getBufferDuration;
         }
         long uncompressionDuration = System.currentTimeMillis() - startUncompression;
         uncompressionDuration += getBufferDuration;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is to fix the decompression time is always 0 when overlapping decompression is enabled

### Why are the changes needed?

When the overlapping decompression is enabled, the decompression time is always zero.

<img width="1915" height="576" alt="image" src="https://github.com/user-attachments/assets/098a95ff-6a75-4a50-80bb-b7cbef1f5d25" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Internal job tests.
