### PR TITLE
[#2654] fix(spark): NPE on adding data into overlapping decompression worker

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -343,14 +343,14 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
       sdr = null;
     }
     final ShuffleDataResult shuffleDataResult = clientReadHandler.readShuffleData();
-    if (decompressionWorker != null) {
-      decompressionWorker.add(batchIndex++, shuffleDataResult);
-      segmentIndex = 0;
-    }
     sdr = shuffleDataResult;
     readDataTime.addAndGet(System.currentTimeMillis() - start);
     if (sdr == null) {
       return 0;
+    }
+    if (decompressionWorker != null) {
+      decompressionWorker.add(batchIndex++, shuffleDataResult);
+      segmentIndex = 0;
     }
     readBuffer = sdr.getDataBuffer();
     if (readBuffer == null || readBuffer.capacity() == 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix npe on adding data into overlapping decompression worker

### Why are the changes needed?

fix #2654 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

internal job tests
