### PR TITLE
[#2679] fix(spark): Potential data mismatch on overlapping decompression

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -308,6 +308,8 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
         // mark block as processed
         processedBlockIds.add(bs.getBlockId());
         pendingBlockIds.removeLong(bs.getBlockId());
+        // update the segment index to skip the unnecessary block in overlapping decompression mode
+        segmentIndex += 1;
       }
 
       if (bs != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is to fix the potential data mismatch when encountering the duplicate blockIds when the overlapping decompression is enabled.

In the one batch remote fetching, if partial blocks should be filtered out due to duplicating or unneed, we should skip it to inc the `segmentIndex` 

### Why are the changes needed?

fix the data mismatch cases, that is found by the uniffle integrity validation mechanism.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests.