### PR TITLE
[#2682] feat(spark): Make `shuffleWriteTaskStats` visible about integrity validation for Gluten

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -156,7 +156,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
   private boolean isShuffleWriteFailed = false;
   private Optional<String> shuffleWriteFailureReason = Optional.empty();
 
-  private Optional<ShuffleWriteTaskStats> shuffleTaskStats = Optional.empty();
+  // Visible for the Gluten
+  protected Optional<ShuffleWriteTaskStats> shuffleTaskStats = Optional.empty();
 
   // Only for tests
   @VisibleForTesting


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `shuffleWriteTaskStats` visible about integrity validation for Gluten

### Why are the changes needed?

tracked in #2682 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't