### PR TITLE
[#1603] improvement(spark): Disable dataPusher initialization for Spark Driver

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -110,7 +110,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     // will be called many times depend on how many shuffle stage
     if ("".equals(appId)) {
       appId = SparkEnv.get().conf().getAppId() + "_" + uuid;
-      dataPusher.setRssAppId(appId);
+      if (dataPusher != null) {
+        dataPusher.setRssAppId(appId);
+      }
       LOG.info("Generate application id used in rss: " + appId);
     }
 
@@ -203,7 +205,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     if (handle instanceof RssShuffleHandle) {
       RssShuffleHandle<K, V, ?> rssHandle = (RssShuffleHandle<K, V, ?>) handle;
       appId = rssHandle.getAppId();
-      dataPusher.setRssAppId(appId);
+      if (dataPusher != null) {
+        dataPusher.setRssAppId(appId);
+      }
 
       int shuffleId = rssHandle.getShuffleId();
       String taskId = "" + context.taskAttemptId() + "_" + context.attemptNumber();

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -142,7 +142,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     if (id.get() == null) {
       id.compareAndSet(null, SparkEnv.get().conf().getAppId() + "_" + uuid);
       appId = id.get();
-      dataPusher.setRssAppId(id.get());
+      if (dataPusher != null) {
+        dataPusher.setRssAppId(id.get());
+      }
     }
     LOG.info("Generate application id used in rss: " + id.get());
     // If stage retry is enabled, the Deterministic status of the ShuffleId needs to be recorded.
@@ -273,7 +275,9 @@ public class RssShuffleManager extends RssShuffleManagerBase {
     // todo: this implement is tricky, we should refactor it
     if (id.get() == null) {
       id.compareAndSet(null, rssShuffleHandle.getAppId());
-      dataPusher.setRssAppId(id.get());
+      if (dataPusher != null) {
+        dataPusher.setRssAppId(id.get());
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables the `dataPusher` initialization for Spark driver in cluster mode, as it's only needed for executors to push shuffle data.

### Why are the changes needed?

The `dataPusher` is used to push shuffle data to shuffle servers, which is an executor-side operation. In cluster mode, driver does not push shuffle data, so initializing `dataPusher` (along with its thread pool) for driver is unnecessary and wastes resources.

**Note**: In local mode, driver also acts as executor, so `dataPusher` is still initialized in local mode.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Compiled successfully for both Spark 2 and Spark 3 profiles
- All unit tests pass
- Integration tests pass (tested `CombineByKeyTest` and `GroupByKeyTest` which were previously failing)

### Summary of Changes:
1. **RssShuffleManagerBase.java**: Wrapped `dataPusher` initialization with `(!isDriver || isLocalMode)` condition, where `isLocalMode` is determined by checking if `spark.master` starts with "local"
2. **RssShuffleManager.java (Spark 3)**: Added null check for `dataPusher.setRssAppId()` calls
3. **RssShuffleManager.java (Spark 2)**: Added null check for `dataPusher.setRssAppId()` calls

Closes #1603