### PR TITLE
[#2675] test(spark)(followup): Add tests for Roaring64NavigableMap optimization in checkSentBlockCount

### DIFF
--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -521,9 +521,9 @@ public class RssShuffleWriterTest {
     // (representing replicas)
     Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds = Maps.newHashMap();
 
-    ShuffleServerInfo server1 = new ShuffleServerInfo("id1", "host1", 100);
-    ShuffleServerInfo server2 = new ShuffleServerInfo("id2", "host2", 100);
-    ShuffleServerInfo server3 = new ShuffleServerInfo("id3", "host3", 100);
+    final ShuffleServerInfo server1 = new ShuffleServerInfo("id1", "host1", 100);
+    final ShuffleServerInfo server2 = new ShuffleServerInfo("id2", "host2", 100);
+    final ShuffleServerInfo server3 = new ShuffleServerInfo("id3", "host3", 100);
 
     // Server1 has blockIds: 1, 2, 3 for partition 0
     Map<Integer, Set<Long>> server1Partitions = Maps.newHashMap();

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -1076,9 +1076,9 @@ public class RssShuffleWriterTest {
     // (representing replicas)
     Map<ShuffleServerInfo, Map<Integer, Set<Long>>> serverToPartitionToBlockIds = Maps.newHashMap();
 
-    ShuffleServerInfo server1 = new ShuffleServerInfo("id1", "host1", 100);
-    ShuffleServerInfo server2 = new ShuffleServerInfo("id2", "host2", 100);
-    ShuffleServerInfo server3 = new ShuffleServerInfo("id3", "host3", 100);
+    final ShuffleServerInfo server1 = new ShuffleServerInfo("id1", "host1", 100);
+    final ShuffleServerInfo server2 = new ShuffleServerInfo("id2", "host2", 100);
+    final ShuffleServerInfo server3 = new ShuffleServerInfo("id3", "host3", 100);
 
     // Server1 has blockIds: 1, 2, 3 for partition 0
     Map<Integer, Set<Long>> server1Partitions = Maps.newHashMap();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add unit tests to verify the `Roaring64NavigableMap` optimization introduced in PR #2687 for filtering duplicate blockIds from multiple replicas in `RssShuffleWriter#checkSentBlockCount`.

### Why are the changes needed?

As suggested by the reviewer in PR #2687, tests should be added to cover the `Roaring64NavigableMap` optimization change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests added:
- `testRoaring64NavigableMapDeduplication`: Verifies correct deduplication of blockIds across multiple servers (replicas)
- `testRoaring64NavigableMapWithLargeBlockIds`: Verifies behavior with large number of consecutive blockIds

Test results:
- Spark3 `RssShuffleWriterTest`: 9 tests passed (including 2 new tests)
- Spark2 `RssShuffleWriterTest`: 5 tests passed (including 2 new tests)

Related PR: #2687