### PR TITLE
chore: Update lz4 to address CVE-2025-12183

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -272,7 +272,7 @@ io.prometheus:simpleclient_pushgateway
 io.prometheus:simpleclient_servlet
 jakarta.validation:jakarta.validation-api
 javax.inject:javax.inject
-net.jpountz.lz4:lz4
+org.lz4:lz4-java
 org.apache.commons:commons-lang3
 org.apache.httpcomponents:httpclient
 org.apache.httpcomponents:httpcore

--- a/client-mr/core/pom.xml
+++ b/client-mr/core/pom.xml
@@ -83,8 +83,8 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
         </dependency>
 
         <dependency>
@@ -169,7 +169,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
-                                    <include>net.jpountz.lz4:lz4</include>
+                                    <include>org.lz4:lz4-java</include>
                                     <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>

--- a/client-spark/common/pom.xml
+++ b/client-spark/common/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
         </dependency>
     </dependencies>
 

--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -38,8 +38,8 @@
       <!-- use the lz4 from spark env -->
       <exclusions>
         <exclusion>
-          <artifactId>lz4</artifactId>
-          <groupId>net.jpountz.lz4</groupId>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
         </exclusion>
         <exclusion>
           <artifactId>log4j-slf4j-impl</artifactId>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -38,8 +38,8 @@
       <!-- use the lz4 from spark env -->
       <exclusions>
         <exclusion>
-          <artifactId>lz4</artifactId>
-          <groupId>net.jpountz.lz4</groupId>
+            <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
         </exclusion>
         <exclusion>
           <artifactId>log4j-slf4j-impl</artifactId>

--- a/client-tez/pom.xml
+++ b/client-tez/pom.xml
@@ -82,8 +82,8 @@
         <artifactId>commons-lang3</artifactId>
       </dependency>
       <dependency>
-        <groupId>net.jpountz.lz4</groupId>
-        <artifactId>lz4</artifactId>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -185,7 +185,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
-                                    <include>net.jpountz.lz4:lz4</include>
+                                    <include>org.lz4:lz4-java</include>
                                     <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -83,8 +83,8 @@
       <artifactId>RoaringBitmap</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/common/src/main/java/org/apache/uniffle/common/compression/Lz4Codec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/Lz4Codec.java
@@ -36,7 +36,7 @@ public class Lz4Codec extends Codec {
   }
 
   public Lz4Codec() {
-    this.lz4Factory = LZ4Factory.fastestInstance();
+    this.lz4Factory = LZ4Factory.safeInstance();
   }
 
   @Override

--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -103,8 +103,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -139,8 +139,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -172,8 +172,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/integration-test/spark2/pom.xml
+++ b/integration-test/spark2/pom.xml
@@ -167,8 +167,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/integration-test/spark3/pom.xml
+++ b/integration-test/spark3/pom.xml
@@ -131,8 +131,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -703,9 +703,9 @@
       </dependency>
 
       <dependency>
-        <groupId>net.jpountz.lz4</groupId>
-        <artifactId>lz4</artifactId>
-        <version>1.3.0</version>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>1.8.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. upgrade lz to the latest version of org.lz4:lz4-java 
2. replace `fastestInstance` to `safeInstance`
 
### Why are the changes needed?
To address [CVE-202512183](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.