### PR TITLE
[#2686] fix(client): Prefetch should be finished once shuffle result is empty or null

### DIFF
--- a/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PrefetchableClientReadHandler.java
+++ b/storage/src/main/java/org/apache/uniffle/storage/handler/impl/PrefetchableClientReadHandler.java
@@ -78,6 +78,10 @@ public abstract class PrefetchableClientReadHandler extends AbstractClientReadHa
     }
   }
 
+  public boolean isFinished() {
+    return finishedTag.get();
+  }
+
   protected abstract ShuffleDataResult doReadShuffleData();
 
   @Override
@@ -97,7 +101,7 @@ public abstract class PrefetchableClientReadHandler extends AbstractClientReadHa
                 return;
               }
               ShuffleDataResult result = doReadShuffleData();
-              if (result == null) {
+              if (result == null || result.isEmpty()) {
                 this.finishedTag.set(true);
               }
               prefetchResultQueue.offer(Optional.ofNullable(result));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Prefetch should be finished once shuffle result is empty or null

### Why are the changes needed?

fix #2686 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests
