### PR TITLE
[#2705] fix(spark): Use read-write lock for `MutableShuffleHandleInfo` to avoid global locking

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -1083,7 +1083,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
       throw new RssException(
           "An unexpected error occurred: internalHandle is null, which should not happen");
     }
-    synchronized (internalHandle) {
+    internalHandle.writeLock().lock();
+    try {
       // If the reassignment servers for one partition exceeds the max reassign server num,
       // it should fast fail.
       if (!partitionSplit) {
@@ -1185,6 +1186,8 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
       postReassignTriggeredEvent(
           partitionSplit ? reassignTriggeredOnPartitionSplit : reassignTriggeredOnBlockSendFailure);
       return internalHandle;
+    } finally {
+      internalHandle.writeLock().unlock();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add read-write lock for MutableShuffleHandleInfo to avoid global locking

### Why are the changes needed?

closes #2705

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?
<!--
(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
-->
