### PR TITLE
[#2711] fix(spark): Race condition on deferred compressed block initialization

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/DeferredCompressedBlock.java
+++ b/common/src/main/java/org/apache/uniffle/common/DeferredCompressedBlock.java
@@ -67,8 +67,13 @@ public class DeferredCompressedBlock extends ShuffleBlockInfo {
   }
 
   private void initialize() {
-    if (isInitialized.compareAndSet(false, true)) {
-      rebuildFunction.apply(this);
+    if (!isInitialized.get()) {
+      synchronized (this) {
+        if (!isInitialized.get()) {
+          rebuildFunction.apply(this);
+          isInitialized.set(true);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix race condition on deferred compressed block initialization

### Why are the changes needed?

fix #2711 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests
