### PR TITLE
[#2714] feat(spark): Respect compression type when activating overlapping compression mechanism

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusher.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/OverlappingCompressionDataPusher.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.uniffle.client.api.ShuffleWriteClient;
 import org.apache.uniffle.client.impl.FailedBlockSendTracker;
+import org.apache.uniffle.common.compression.Codec;
+import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
 import org.apache.uniffle.common.util.ThreadUtils;
 
@@ -81,5 +83,18 @@ public class OverlappingCompressionDataPusher extends DataPusher {
               // Step 2: forward to the parent class's send method
               return super.send(processedEvent);
             });
+  }
+
+  public static boolean isEnabled(RssConf rssConf) {
+    boolean overlappingCompressionEnabled =
+        rssConf.get(RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_ENABLED);
+    int overlappingCompressionThreadsPerVcore =
+        rssConf.get(RssSparkConfig.RSS_WRITE_OVERLAPPING_COMPRESSION_THREADS_PER_VCORE);
+    if (Codec.hasCodec(rssConf)
+        && overlappingCompressionEnabled
+        && overlappingCompressionThreadsPerVcore > 0) {
+      return true;
+    }
+    return false;
   }
 }

--- a/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
+++ b/common/src/main/java/org/apache/uniffle/common/compression/Codec.java
@@ -27,6 +27,11 @@ import static org.apache.uniffle.common.config.RssClientConf.COMPRESSION_TYPE;
 
 public abstract class Codec {
 
+  public static boolean hasCodec(RssConf rssConf) {
+    Type type = rssConf.get(COMPRESSION_TYPE);
+    return type != Type.NONE;
+  }
+
   public static Optional<Codec> create(RssConf rssConf) {
     Optional<Codec> codec = newInstance(rssConf);
     if (codec.isPresent() && rssConf.getBoolean(COMPRESSION_STATISTICS_ENABLED)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Respect compression type when activating overlapping compression mechanism

### Why are the changes needed?

#2714 . Unify the overlapping compression checking logic into one place and also respect the compression type when activating this mechanism. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests are enough. 
