### PR TITLE
[#2716] feat(client): More overlapping decompression stats to log

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/DecompressionWorker.java
@@ -156,7 +156,7 @@ public class DecompressionWorker {
         wait,
         peekMemoryUsed.get() / 1024 / 1024,
         decompressionBytes,
-        (decompressionBytes * 1000L) / decompressionMillis);
+        decompressionMillis == 0 ? 0 : (decompressionBytes * 1000L) / decompressionMillis);
     executorService.shutdown();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add more decompression stats to log
1. peek memory used to dig when OOM happens
2. decompression throughput 

### Why are the changes needed?

to fix #2716 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests are enough
