### PR TITLE
[#2646] feat(netty): Support converting CompositeByteBuf to a direct nio buffer

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/util/NettyUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/NettyUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.uniffle.common.util;
 
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -178,5 +179,26 @@ public class NettyUtils {
 
   public static long getMaxDirectMemory() {
     return MAX_DIRECT_MEMORY_IN_BYTES;
+  }
+
+  private static final String PREFER_DIRECT_FOR_COMPOSITE_BUFFER_PROPERTY_KEY =
+      "rss.netty.preferDirectForCompositeBuffer";
+  private static final String PREFER_DIRECT_FOR_COMPOSITE_BUFFER_ENV_KEY =
+      "RSS_NETTY_PREFER_DIRECT_FOR_COMPOSITE_BUFFER";
+  private static final boolean PREFER_DIRECT_FOR_COMPOSITE_BUFFER_DEFAULT = false;
+  private static final boolean _preferDirectForCompositeBuffer;
+
+  static {
+    _preferDirectForCompositeBuffer =
+        Optional.ofNullable(System.getProperty(PREFER_DIRECT_FOR_COMPOSITE_BUFFER_PROPERTY_KEY))
+            .map(Boolean::new)
+            .orElse(
+                Optional.ofNullable(System.getenv(PREFER_DIRECT_FOR_COMPOSITE_BUFFER_ENV_KEY))
+                    .map(Boolean::new)
+                    .orElse(PREFER_DIRECT_FOR_COMPOSITE_BUFFER_DEFAULT));
+  }
+
+  public static boolean preferDirectForCompositeBuffer() {
+    return _preferDirectForCompositeBuffer;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support converting CompositeByteBuf to a direct nio buffer

### Why are the changes needed?

CompositeByteBuf.nioBuffer will return a heap buffer if the composite buffer has more than one component, even if all components are direct buffers. In native client scenarios (like gluten), we prefer to use direct buffer to reduce data copying.

closes #2646

### Does this PR introduce _any_ user-facing change?

yes, a new configuration

### How was this patch tested?

Tested it locally, after adding the following configuration, the gluten shuffle reader will use LowCopyNettyJniByteInputStream.

```
spark.executorEnv.RSS_NETTY_PREFER_DIRECT_FOR_COMPOSITE_BUFFER=true
```