### PR TITLE
[#2733] fix(spark): Calculate total value for ShuffleReadTimesSummary

### DIFF
--- a/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/UniffleStatusStore.scala
@@ -188,6 +188,7 @@ case class ShuffleReadTimesSummary(var fetch: Long = 0,
                                    var total: Long = 0) {
   def inc(times: ShuffleReadTimes): Unit = {
     if (times == null) return
+    this.total += times.getTotal
     this.fetch += times.getFetch
     this.crc += times.getCrc
     this.copy += times.getCopy


### PR DESCRIPTION
### What changes were proposed in this pull request?

Calculate total value for ShuffleReadTimesSummary.

### Why are the changes needed?

Fix the total shuffle read time to zero in uniffle UI.

Closes #2733

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

After:
<img width="1865" height="131" alt="image" src="https://github.com/user-attachments/assets/1ca5ee6c-24cc-45b8-b580-8d760273574a" />

