### PR TITLE
fix(spark): Correct shuffle read time metrics

### DIFF
--- a/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/ShuffleReadClientImpl.java
@@ -424,8 +424,8 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
 
     return new ShuffleReadTimes(
         readDataTime.get(),
-        copyTime.get(),
         crcCheckTime.get(),
+        copyTime.get(),
         backgroundDecompressionTime,
         backgroundFetchTime);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct shuffle read time metrics

### Why are the changes needed?

The metrics for shuffle read time are mismatched.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Needn't