### PR TITLE
[#2753] fix(spark): ignore removed failed blocks

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/ReassignExecutor.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/ReassignExecutor.java
@@ -133,6 +133,9 @@ public class ReassignExecutor {
     for (Long blockId : failedBlockIds) {
       List<TrackingBlockStatus> failedBlockStatus =
           failedBlockSendTracker.getFailedBlockStatus(blockId);
+      if (CollectionUtils.isEmpty(failedBlockStatus)) {
+        continue;
+      }
       synchronized (failedBlockStatus) {
         int retryCnt =
             failedBlockStatus.stream()
@@ -179,6 +182,9 @@ public class ReassignExecutor {
         // todo: if setting multi replica and another replica is succeed to send, no need to resend
         resendBlocks.addAll(failedBlockStatus);
       }
+    }
+    if (resendBlocks.isEmpty()) {
+      return;
     }
     reassignAndResendBlocks(resendBlocks);
   }

--- a/client-spark/common/src/test/java/org/apache/uniffle/shuffle/ReassignExecutorTest.java
+++ b/client-spark/common/src/test/java/org/apache/uniffle/shuffle/ReassignExecutorTest.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.shuffle;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class ReassignExecutorTest {
@@ -102,6 +104,18 @@ public class ReassignExecutorTest {
     assertThrows(RssSendFailedException.class, executor::reassign);
 
     verify(blockInfo).executeCompletionCallback(true);
+  }
+
+  @Test
+  void testRemovedFailureStatusShouldBeIgnored() {
+    long blockId = 100L;
+    when(failedBlockSendTracker.getFailedBlockIds())
+        .thenReturn(new HashSet<>(Arrays.asList(blockId)));
+    when(failedBlockSendTracker.getFailedBlockStatus(blockId)).thenReturn(Collections.emptyList());
+
+    executor.reassign();
+
+    verifyNoInteractions(removeBlockStatsFunction, resendBlocksFunction, shuffleManagerClient);
   }
 
   @Test

--- a/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
+++ b/client/src/main/java/org/apache/uniffle/client/impl/FailedBlockSendTracker.java
@@ -84,11 +84,12 @@ public class FailedBlockSendTracker {
   }
 
   public Set<Long> getFailedBlockIds() {
-    return trackingBlockStatusMap.keySet();
+    return Sets.newHashSet(trackingBlockStatusMap.keySet());
   }
 
   public List<TrackingBlockStatus> getFailedBlockStatus(Long blockId) {
-    return trackingBlockStatusMap.get(blockId);
+    List<TrackingBlockStatus> statuses = trackingBlockStatusMap.get(blockId);
+    return statuses == null ? Collections.emptyList() : statuses;
   }
 
   public Set<ShuffleServerInfo> getFaultyShuffleServers() {

--- a/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
@@ -18,6 +18,7 @@
 package org.apache.uniffle.client.impl;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,8 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.rpc.StatusCode;
 
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FailedBlockSendTrackerTest {
   @Test
@@ -71,5 +74,31 @@ public class FailedBlockSendTrackerTest {
                       .collect(Collectors.toList());
               return CollectionUtils.isEqualCollection(expected, actual);
             });
+  }
+
+  @Test
+  public void getFailedBlockIdsShouldReturnSnapshot() {
+    FailedBlockSendTracker tracker = new FailedBlockSendTracker();
+    ShuffleServerInfo shuffleServerInfo = new ShuffleServerInfo("host1", 19999);
+    ShuffleBlockInfo shuffleBlockInfo =
+        new ShuffleBlockInfo(
+            0,
+            0,
+            1L,
+            0,
+            0L,
+            new byte[] {},
+            Lists.newArrayList(shuffleServerInfo),
+            0,
+            0L,
+            0L);
+
+    tracker.add(shuffleBlockInfo, shuffleServerInfo, StatusCode.INTERNAL_ERROR);
+
+    Set<Long> failedBlockIds = tracker.getFailedBlockIds();
+    tracker.remove(shuffleBlockInfo.getBlockId());
+
+    assertEquals(1, failedBlockIds.size());
+    assertTrue(tracker.getFailedBlockStatus(shuffleBlockInfo.getBlockId()).isEmpty());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix NPE by better handling removed blocks

### Why are the changes needed?

`getFailedBlockIds()` returned a live key set from a concurrent map. After one thread got a failed block id, another thread could clear that block’s failed state after the block was resent successfully. Then `getFailedBlockStatus(blockId)` returned null, and the resend logic later accessed it, causing a `NullPointerException.`

fix #2753

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?

Unit test