### PR TITLE
[#2758] fix(rpc): simplify server port fallback to improve success rate

### DIFF
--- a/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/GrpcServer.java
@@ -17,7 +17,6 @@
 
 package org.apache.uniffle.common.rpc;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -56,7 +55,7 @@ public class GrpcServer implements ServerInterface {
 
   private static volatile boolean poolExecutorHasExecuted;
   private Server server;
-  private final int port;
+  private final int configuredPort;
   private int listenPort;
   private final GrpcThreadPoolExecutor pool;
   private List<Pair<BindableService, List<ServerInterceptor>>> servicesWithInterceptors;
@@ -68,7 +67,7 @@ public class GrpcServer implements ServerInterface {
       List<Pair<BindableService, List<ServerInterceptor>>> servicesWithInterceptors,
       GRPCMetrics grpcMetrics) {
     this.rssConf = conf;
-    this.port = rssConf.getInteger(RssBaseConf.RPC_SERVER_PORT);
+    this.configuredPort = rssConf.getInteger(RssBaseConf.RPC_SERVER_PORT);
     this.servicesWithInterceptors = servicesWithInterceptors;
     this.grpcMetrics = grpcMetrics;
 
@@ -211,18 +210,18 @@ public class GrpcServer implements ServerInterface {
   }
 
   @Override
-  public int start() throws IOException {
+  public int start() throws Exception {
     try {
       this.listenPort =
-          RssUtils.startServiceOnPort(this, Constants.GRPC_SERVICE_NAME, port, rssConf);
+          RssUtils.startServiceOnPortWithFallback(
+              this::startOnPort, Constants.GRPC_SERVICE_NAME, configuredPort);
     } catch (Exception e) {
-      ExitUtils.terminate(1, "Fail to start grpc server on conf port:" + port, e, LOG);
+      ExitUtils.terminate(1, "Fail to start grpc server on conf port:" + configuredPort, e, LOG);
     }
     return listenPort;
   }
 
-  @Override
-  public void startOnPort(int startPort) throws Exception {
+  private int startOnPort(int startPort) throws Exception {
     this.server = buildGrpcServer(startPort);
     try {
       server.start();
@@ -230,7 +229,8 @@ public class GrpcServer implements ServerInterface {
     } catch (Exception e) {
       throw e;
     }
-    LOG.info("Grpc server started, configured port: {}, listening on {}.", port, listenPort);
+    LOG.info("Grpc server started, start port: {}, listening on {}.", startPort, listenPort);
+    return listenPort;
   }
 
   @Override

--- a/common/src/main/java/org/apache/uniffle/common/rpc/ServerInterface.java
+++ b/common/src/main/java/org/apache/uniffle/common/rpc/ServerInterface.java
@@ -17,13 +17,9 @@
 
 package org.apache.uniffle.common.rpc;
 
-import java.io.IOException;
-
 public interface ServerInterface {
 
-  int start() throws IOException;
-
-  void startOnPort(int port) throws Exception;
+  int start() throws Exception;
 
   void stop() throws InterruptedException;
 

--- a/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
+++ b/common/src/main/java/org/apache/uniffle/common/util/RssUtils.java
@@ -60,7 +60,6 @@ import org.apache.uniffle.common.ShuffleServerInfo;
 import org.apache.uniffle.common.config.RssBaseConf;
 import org.apache.uniffle.common.config.RssConf;
 import org.apache.uniffle.common.exception.RssException;
-import org.apache.uniffle.common.rpc.ServerInterface;
 
 import static org.apache.uniffle.common.config.RssClientConf.RSS_CLIENT_EXTRA_JAVA_SYSTEM_PROPERTIES;
 
@@ -68,6 +67,11 @@ public class RssUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RssUtils.class);
   public static final String RSS_LOCAL_DIR_KEY = "RSS_LOCAL_DIRS";
+
+  @FunctionalInterface
+  public interface ServiceStarter {
+    int startOnPort(int port) throws Exception;
+  }
 
   private RssUtils() {}
 
@@ -184,37 +188,34 @@ public class RssUtils {
     return siteLocalAddress;
   }
 
-  public static int startServiceOnPort(
-      ServerInterface service, String serviceName, int servicePort, RssBaseConf conf) {
+  public static int startServiceOnPortWithFallback(
+      ServiceStarter serviceStarter, String serviceName, int servicePort) {
     if (servicePort < 0 || servicePort > 65535) {
       throw new IllegalArgumentException(
           String.format("Bad service %s on port (%s)", serviceName, servicePort));
     }
-    int actualPort = servicePort;
-    int maxRetries = conf.get(RssBaseConf.SERVER_PORT_MAX_RETRIES);
-    for (int i = 0; i < maxRetries; i++) {
-      try {
-        if (servicePort == 0) {
-          actualPort = findRandomTcpPort(conf);
-        } else {
-          actualPort += i;
-        }
-        service.startOnPort(actualPort);
-        return actualPort;
-      } catch (Exception e) {
-        if (isServerPortBindCollision(e)) {
-          LOGGER.warn(
-              String.format(
-                  "%s:Service %s failed after %s retries (on a random free port (%s))!",
-                  e.getMessage(), serviceName, i + 1, actualPort));
-        } else {
+    try {
+      return serviceStarter.startOnPort(servicePort);
+    } catch (Exception e) {
+      if (servicePort > 0 && isServerPortBindCollision(e)) {
+        LOGGER.warn(
+            "{}: Service {} failed to bind on port {}, falling back to port 0.",
+            e.getMessage(),
+            serviceName,
+            servicePort);
+        try {
+          return serviceStarter.startOnPort(0);
+        } catch (Exception fallbackException) {
           throw new RssException(
-              String.format("Failed to start service %s on port %s", serviceName, servicePort), e);
+              String.format(
+                  "Failed to start service %s on port 0 after falling back from port %s",
+                  serviceName, servicePort),
+              fallbackException);
         }
       }
+      throw new RssException(
+          String.format("Failed to start service %s on port %s", serviceName, servicePort), e);
     }
-    throw new RssException(
-        String.format("Failed to start service %s on port %s", serviceName, servicePort));
   }
 
   /** check whether the exception is caused by an address-port collision when binding. */

--- a/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
+++ b/common/src/test/java/org/apache/uniffle/common/util/RssUtilsTest.java
@@ -102,19 +102,16 @@ public class RssUtilsTest {
   }
 
   @Test
-  public void testStartServiceOnPort() throws InterruptedException {
-    RssBaseConf rssBaseConf = new RssBaseConf();
-    rssBaseConf.set(RssBaseConf.SERVER_PORT_MAX_RETRIES, 100);
-    rssBaseConf.set(RssBaseConf.RSS_RANDOM_PORT_MIN, 30000);
-    rssBaseConf.set(RssBaseConf.RSS_RANDOM_PORT_MAX, 39999);
-    // zero port to get random port
+  public void testStartServiceOnPortWithFallback() throws InterruptedException {
+    // zero port should be delegated to the service, so the OS assigns an available port.
     MockServer mockServer = new MockServer();
     int port = 0;
     try {
-      int actualPort = RssUtils.startServiceOnPort(mockServer, "MockServer", port, rssBaseConf);
-      assertTrue(
-          actualPort >= 30000
-              && actualPort < 39999 + rssBaseConf.get(RssBaseConf.SERVER_PORT_MAX_RETRIES));
+      int actualPort =
+          RssUtils.startServiceOnPortWithFallback(mockServer::startOnPort, "MockServer", port);
+      assertEquals(0, mockServer.startPort);
+      assertEquals(mockServer.serverSocket.getLocalPort(), actualPort);
+      assertTrue(actualPort > 0);
     } finally {
       if (mockServer != null) {
         mockServer.stop();
@@ -123,7 +120,7 @@ public class RssUtilsTest {
     // error port test
     try {
       port = -1;
-      RssUtils.startServiceOnPort(mockServer, "MockServer", port, rssBaseConf);
+      RssUtils.startServiceOnPortWithFallback(mockServer::startOnPort, "MockServer", port);
     } catch (RuntimeException e) {
       assertTrue(e.toString().startsWith("java.lang.IllegalArgumentException: Bad service"));
     }
@@ -131,11 +128,9 @@ public class RssUtilsTest {
     try {
       mockServer = new MockServer();
       port = 10000;
-      rssBaseConf.set(RssBaseConf.SERVER_PORT_MAX_RETRIES, 100);
-      int actualPort = RssUtils.startServiceOnPort(mockServer, "MockServer", port, rssBaseConf);
-      assertTrue(
-          actualPort >= port
-              && actualPort < port + rssBaseConf.get(RssBaseConf.SERVER_PORT_MAX_RETRIES));
+      int actualPort =
+          RssUtils.startServiceOnPortWithFallback(mockServer::startOnPort, "MockServer", port);
+      assertEquals(port, actualPort);
     } finally {
       if (mockServer != null) {
         mockServer.stop();
@@ -147,17 +142,21 @@ public class RssUtilsTest {
     try {
       mockServer = new MockServer();
       port = 10000;
-      int actualPort1 = RssUtils.startServiceOnPort(mockServer, "MockServer", port, rssBaseConf);
-      rssBaseConf.set(RssBaseConf.SERVER_PORT_MAX_RETRIES, 10);
+      int actualPort1 =
+          RssUtils.startServiceOnPortWithFallback(mockServer::startOnPort, "MockServer", port);
       int actualPort2 =
-          RssUtils.startServiceOnPort(toStartSockServer, "MockServer", actualPort1, rssBaseConf);
-      assertTrue(actualPort1 < actualPort2);
+          RssUtils.startServiceOnPortWithFallback(
+              toStartSockServer::startOnPort, "MockServer", actualPort1);
+      assertEquals(0, toStartSockServer.startPort);
+      assertEquals(toStartSockServer.serverSocket.getLocalPort(), actualPort2);
+      assertTrue(actualPort2 > 0);
+      assertTrue(actualPort1 != actualPort2);
       toStartSockServer.stop();
-      rssBaseConf.set(RssBaseConf.SERVER_PORT_MAX_RETRIES, 0);
-      RssUtils.startServiceOnPort(toStartSockServer, "MockServer", actualPort1, rssBaseConf);
-      assertFalse(false);
+      toStartSockServer = new MockServer();
+      RssUtils.startServiceOnPortWithFallback(toStartSockServer::startOnPort, "MockServer", 0);
+      assertEquals(0, toStartSockServer.startPort);
     } catch (RuntimeException e) {
-      assertTrue(e.getMessage().startsWith("Failed to start service"));
+      fail(e.getMessage());
     } finally {
       if (mockServer != null) {
         mockServer.stop();
@@ -351,15 +350,15 @@ public class RssUtilsTest {
   public static class MockServer implements ServerInterface {
 
     ServerSocket serverSocket;
+    int startPort = -1;
 
     @Override
     public int start() throws IOException {
-      // not implement
-      return -1;
+      return startOnPort(0);
     }
 
-    @Override
-    public void startOnPort(int port) throws IOException {
+    int startOnPort(int port) throws IOException {
+      startPort = port;
       serverSocket =
           ServerSocketFactory.getDefault()
               .createServerSocket(port, 1, InetAddress.getByName("localhost"));
@@ -374,6 +373,7 @@ public class RssUtilsTest {
                 }
               })
           .start();
+      return serverSocket.getLocalPort();
     }
 
     @Override

--- a/server/src/main/java/org/apache/uniffle/server/netty/StreamServer.java
+++ b/server/src/main/java/org/apache/uniffle/server/netty/StreamServer.java
@@ -17,7 +17,7 @@
 
 package org.apache.uniffle.server.netty;
 
-import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -171,20 +171,19 @@ public class StreamServer implements ServerInterface {
   }
 
   @Override
-  public int start() throws IOException {
+  public int start() throws Exception {
     int port = shuffleServerConf.getInteger(ShuffleServerConf.NETTY_SERVER_PORT);
     try {
       port =
-          RssUtils.startServiceOnPort(
-              this, Constants.NETTY_STREAM_SERVICE_NAME, port, shuffleServerConf);
+          RssUtils.startServiceOnPortWithFallback(
+              this::startOnPort, Constants.NETTY_STREAM_SERVICE_NAME, port);
     } catch (Exception e) {
       ExitUtils.terminate(1, "Fail to start stream server", e, LOG);
     }
     return port;
   }
 
-  @Override
-  public void startOnPort(int port) throws Exception {
+  private int startOnPort(int port) throws Exception {
 
     ServerBootstrap serverBootstrap =
         bootstrapChannel(
@@ -201,7 +200,9 @@ public class StreamServer implements ServerInterface {
       channelFuture = serverBootstrap.bind(port);
       channelFuture.syncUninterruptibly();
       LOG.info("bind localAddress is " + channelFuture.channel().localAddress());
-      LOG.info("Start stream server successfully with port " + port);
+      int actualPort = ((InetSocketAddress) channelFuture.channel().localAddress()).getPort();
+      LOG.info("Start stream server successfully with port " + actualPort);
+      return actualPort;
     } catch (Exception e) {
       throw e;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. simplify the `serverInterface`
2. simplify server port fallback to improve success rate
3. use the port=0 to make the built-in port binding mechanism valid

### Why are the changes needed?

to fix #2758 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests
