### PR TITLE
[#2761] fix(spark): remove unnecessary synchronized

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/RssShuffleManagerBase.java
@@ -949,7 +949,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
    * @param shuffleId shuffleId
    * @return ShuffleHandleInfo
    */
-  protected synchronized StageAttemptShuffleHandleInfo getRemoteShuffleHandleInfoWithStageRetry(
+  protected StageAttemptShuffleHandleInfo getRemoteShuffleHandleInfoWithStageRetry(
       int stageAttemptId, int stageAttemptNumber, int shuffleId, boolean isWritePhase) {
     RssPartitionToShuffleServerRequest rssPartitionToShuffleServerRequest =
         new RssPartitionToShuffleServerRequest(
@@ -970,7 +970,7 @@ public abstract class RssShuffleManagerBase implements RssShuffleManagerInterfac
    * @param shuffleId shuffleId
    * @return ShuffleHandleInfo
    */
-  protected synchronized MutableShuffleHandleInfo getRemoteShuffleHandleInfoWithBlockRetry(
+  protected MutableShuffleHandleInfo getRemoteShuffleHandleInfoWithBlockRetry(
       int stageAttemptId, int stageAttemptNumber, int shuffleId, boolean isWritePhase) {
     RssPartitionToShuffleServerRequest rssPartitionToShuffleServerRequest =
         new RssPartitionToShuffleServerRequest(

--- a/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
+++ b/client/src/test/java/org/apache/uniffle/client/impl/FailedBlockSendTrackerTest.java
@@ -82,16 +82,7 @@ public class FailedBlockSendTrackerTest {
     ShuffleServerInfo shuffleServerInfo = new ShuffleServerInfo("host1", 19999);
     ShuffleBlockInfo shuffleBlockInfo =
         new ShuffleBlockInfo(
-            0,
-            0,
-            1L,
-            0,
-            0L,
-            new byte[] {},
-            Lists.newArrayList(shuffleServerInfo),
-            0,
-            0L,
-            0L);
+            0, 0, 1L, 0, 0L, new byte[] {}, Lists.newArrayList(shuffleServerInfo), 0, 0L, 0L);
 
     tracker.add(shuffleBlockInfo, shuffleServerInfo, StatusCode.INTERNAL_ERROR);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove unnecessary synchronized for getRemoteShuffleHandleInfo methods

### Why are the changes needed?

closes #2761

### Does this PR introduce _any_ user-facing change?
<!--
(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)
-->
No.

### How was this patch tested?

Existing tests