### PR TITLE
[#2763] fix(spark): use 1.0 spill ratio for final clear

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -371,7 +371,7 @@ public class WriteBufferManager extends MemoryConsumer {
 
   // Gluten needs this method.
   public synchronized List<ShuffleBlockInfo> clear() {
-    return clear(bufferSpillRatio);
+    return clear(1.0);
   }
 
   // transform all [partition, records] to [partition, ShuffleBlockInfo] and clear cache


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the no-argument `WriteBufferManager.clear()` method used by the Gluten shuffle writer to call `clear(1.0)` instead of `clear(bufferSpillRatio)`.

### Why are the changes needed?

A spill ratio of `1.0` should be used for this final call to ensure that all remaining buffered data is converted into shuffle blocks and flushed.

Fix: #2763

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No specific error was observed because we use the default `spillRatio` of `1.0`. This issue was identified while reviewing the relevant code. The existing unit tests already cover the `clear(1.0)` code path.