### PR TITLE
minor(spark): remove shuffle write status on unregister

### DIFF
--- a/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
+++ b/client-spark/common/src/main/java/org/apache/uniffle/shuffle/manager/ShuffleManagerGrpcService.java
@@ -362,6 +362,7 @@ public class ShuffleManagerGrpcService extends ShuffleManagerImplBase {
    */
   public void unregisterShuffle(int shuffleId) {
     shuffleStatus.remove(shuffleId);
+    shuffleWriteStatus.remove(shuffleId);
   }
 
   private static class ShuffleServerWriterFailureRecord {


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove shuffle write status on unregister

### Why are the changes needed?

clean unused shuffleWriteStatus like `org.apache.uniffle.shuffle.manager.ShuffleManagerGrpcService#shuffleStatus`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

minor fix
