### PR TITLE
[WIP] Add Spark 4.2 support

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -79,6 +79,8 @@ jobs:
             java-version: 17
           - profile: spark4.1
             java-version: 17
+          - profile: spark4.2
+            java-version: 17
           - profile: mr-hadoop2.8
             java-version: 8
           - profile: mr-hadoop3.2

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -76,6 +76,10 @@ jobs:
       if: inputs.java-version == '17'
       run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
       shell: bash
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.2`
+      if: inputs.java-version == '17'
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.2 | tee -a /tmp/maven.log;
+      shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
       run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The shuffle data is stored with index file and data file. Data file has all bloc
 ![Rss Shuffle_Write](docs/asset/rss_data_format.png)
 
 ## Supported Spark Version
-Currently supports Spark 2.3.x, Spark 2.4.x, Spark 3.0.x, Spark 3.1.x, Spark 3.2.x, Spark 3.3.x, Spark 3.4.x, Spark 3.5.x
+Currently supports Spark 2.3.x, Spark 2.4.x, Spark 3.0.x, Spark 3.1.x, Spark 3.2.x, Spark 3.3.x, Spark 3.4.x, Spark 3.5.x, Spark 4.0.x, Spark 4.1.x, Spark 4.2.x
 
 Note: To support dynamic allocation, the patch(which is included in patch/spark folder) should be applied to Spark
 
@@ -101,6 +101,10 @@ Build against Spark 3.2.x, Except 3.2.0
 Build against Spark 3.2.0
 
     ./mvnw -DskipTests clean package -Pspark3.2.0
+
+Build against Spark 4.2.0 (requires JDK 17)
+
+    ./mvnw -DskipTests clean package -Pspark4.2
 
 Build against Hadoop MapReduce 2.8.5
 

--- a/client-mr/core/pom.xml
+++ b/client-mr/core/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
         </dependency>
 
@@ -169,7 +169,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
-                                    <include>org.lz4:lz4-java</include>
+                                    <include>${lz4-java.groupId}:lz4-java</include>
                                     <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>

--- a/client-spark/common/pom.xml
+++ b/client-spark/common/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
         </dependency>
     </dependencies>

--- a/client-spark/extension/pom.xml
+++ b/client-spark/extension/pom.xml
@@ -35,17 +35,17 @@
 
     <!--
         WebUIPage.render's request parameter uses javax.servlet in Spark 3
-        and jakarta.servlet in Spark 4. A single ShufflePage.scala cannot
-        override both signatures, so the module ships two source roots
-        (src/main/scala-javax and src/main/scala-jakarta), each with its
-        own ServletCompat aliasing HttpServletRequest to the matching
-        package. build-helper-maven-plugin picks one via
+        and jakarta.servlet in Spark 4. Spark 4.2 also replaced the legacy
+        collapseTable JavaScript helper with Bootstrap 5 markup. A single
+        compatibility object cannot cover those differences, so the module
+        ships profile-specific source roots. Each has a ServletCompat that
+        aliases HttpServletRequest and emits matching collapse markup.
+        build-helper-maven-plugin picks one via
         ${extension.servlet.source.dir}; the javax variant is the default
         and the spark4 profile at the bottom of this pom overrides it.
 
-        To add another servlet flavor, create src/main/scala-<flavor>/
-        with a mirrored ServletCompat (same aliases), then point a new
-        profile at it. Keep aliases in lock-step across every variant.
+        To add another UI compatibility flavor, create src/main/scala-<flavor>/
+        with a mirrored ServletCompat surface, then point a new profile at it.
 
         rss-client-spark-ui is published under a single Maven coordinate,
         but different profiles produce incompatible bytecode (servlet +
@@ -155,6 +155,16 @@
             <id>spark4.1</id>
             <properties>
                 <extension.servlet.source.dir>src/main/scala-jakarta</extension.servlet.source.dir>
+            </properties>
+        </profile>
+        <profile>
+            <!--
+                Co-activated with the root pom's spark4.2 profile via the shared
+                -Pspark4.2 flag. Spark 4.2 continues to use Jakarta Servlet.
+            -->
+            <id>spark4.2</id>
+            <properties>
+                <extension.servlet.source.dir>src/main/scala-jakarta-spark4_2</extension.servlet.source.dir>
             </properties>
         </profile>
     </profiles>

--- a/client-spark/extension/src/main/scala-jakarta-spark4_2/org/apache/spark/ui/ServletCompat.scala
+++ b/client-spark/extension/src/main/scala-jakarta-spark4_2/org/apache/spark/ui/ServletCompat.scala
@@ -19,16 +19,26 @@ package org.apache.spark.ui
 
 import scala.xml.{MetaData, Null, UnprefixedAttribute}
 
-// javax.servlet variant of ServletCompat, picked up by the default
-// ${extension.servlet.source.dir} (see client-spark/extension/pom.xml).
-// Every alias here must also exist in the scala-jakarta/ variant —
-// only the underlying servlet package may differ.
+// Spark 4.2 uses Jakarta Servlet and Bootstrap 5 collapse markup. Spark 4.1 and
+// earlier rely on the collapseTable JavaScript helper and use the other source variants.
 private[ui] object ServletCompat {
-  type HttpServletRequest = javax.servlet.http.HttpServletRequest
+  type HttpServletRequest = jakarta.servlet.http.HttpServletRequest
 
   def collapseToggleAttributes(name: String, table: String): MetaData =
-    new UnprefixedAttribute("onClick", s"collapseTable('$name', '$table')", Null)
+    new UnprefixedAttribute(
+      "data-bs-toggle",
+      "collapse",
+      new UnprefixedAttribute(
+        "data-bs-target",
+        s"#$table",
+        new UnprefixedAttribute(
+          "data-collapse-name",
+          name,
+          new UnprefixedAttribute(
+            "aria-expanded",
+            "false",
+            new UnprefixedAttribute("aria-controls", table, Null)))))
 
   def collapsibleTableClass(table: String): String =
-    s"$table collapsible-table collapsed"
+    s"$table collapsible-table collapse"
 }

--- a/client-spark/extension/src/main/scala-jakarta/org/apache/spark/ui/ServletCompat.scala
+++ b/client-spark/extension/src/main/scala-jakarta/org/apache/spark/ui/ServletCompat.scala
@@ -17,10 +17,18 @@
 
 package org.apache.spark.ui
 
+import scala.xml.{MetaData, Null, UnprefixedAttribute}
+
 // jakarta.servlet variant of ServletCompat, picked up by the spark4
 // profile (see client-spark/extension/pom.xml). Every alias here must
 // also exist in the scala-javax/ variant — only the underlying servlet
 // package may differ.
 private[ui] object ServletCompat {
   type HttpServletRequest = jakarta.servlet.http.HttpServletRequest
+
+  def collapseToggleAttributes(name: String, table: String): MetaData =
+    new UnprefixedAttribute("onClick", s"collapseTable('$name', '$table')", Null)
+
+  def collapsibleTableClass(table: String): String =
+    s"$table collapsible-table collapsed"
 }

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -29,6 +29,14 @@ import scala.xml.{Node, NodeSeq}
 class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
   private val runtimeStatusStore = parent.store
 
+  private def collapseHeader(name: String, table: String, title: String): Node =
+    (<span class={s"$name collapse-table"}>
+      <h4>
+        <span class="collapse-table-arrow arrow-closed"></span>
+        <a>{title}</a>
+      </h4>
+    </span>) % ServletCompat.collapseToggleAttributes(name, table)
+
   private def propertyHeader = Seq("Name", "Value")
 
   private def propertyRow(kv: (String, String)) = <tr>
@@ -359,118 +367,64 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
         </div>
 
         <div>
-          <span class="collapse-build-info-properties collapse-table"
-                onClick="collapseTable('collapse-build-info-properties', 'build-info-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Uniffle Build Information</a>
-            </h4>
-          </span>
-          <div class="build-info-table collapsible-table collapsed">
+          {collapseHeader("collapse-build-info-properties", "build-info-table", "Uniffle Build Information")}
+          <div id="build-info-table" class={ServletCompat.collapsibleTableClass("build-info-table")}>
             {buildInfoTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-uniffle-config-properties collapse-table"
-                onClick="collapseTable('collapse-uniffle-config-properties', 'uniffle-config-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Uniffle Properties</a>
-            </h4>
-          </span>
-          <div class="uniffle-config-table collapsible-table collapsed">
+          {collapseHeader("collapse-uniffle-config-properties", "uniffle-config-table", "Uniffle Properties")}
+          <div id="uniffle-config-table" class={ServletCompat.collapsibleTableClass("uniffle-config-table")}>
             {rssConfTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-throughput-properties collapse-table"
-                onClick="collapseTable('collapse-throughput-properties', 'statistics-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Shuffle Throughput Statistics</a>
-            </h4>
-          </span>
-          <div class="statistics-table collapsible-table collapsed">
+          {collapseHeader("collapse-throughput-properties", "statistics-table", "Shuffle Throughput Statistics")}
+          <div id="statistics-table" class={ServletCompat.collapsibleTableClass("statistics-table")}>
             {shuffleMetricsTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-read-throughput-properties collapse-table"
-                onClick="collapseTable('collapse-read-throughput-properties', 'read-statistics-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Hybrid Storage Read Statistics</a>
-            </h4>
-          </span>
-          <div class="read-statistics-table collapsible-table collapsed">
+          {collapseHeader("collapse-read-throughput-properties", "read-statistics-table", "Hybrid Storage Read Statistics")}
+          <div id="read-statistics-table" class={ServletCompat.collapsibleTableClass("read-statistics-table")}>
             {readTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-server-properties collapse-table"
-                onClick="collapseTable('collapse-server-properties', 'all-servers-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Shuffle Server ({allServers.length})</a>
-            </h4>
-          </span>
-          <div class="all-servers-table collapsible-table collapsed">
+          {collapseHeader("collapse-server-properties", "all-servers-table", s"Shuffle Server (${allServers.length})")}
+          <div id="all-servers-table" class={ServletCompat.collapsibleTableClass("all-servers-table")}>
             {allServersTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-assignment-properties collapse-table"
-                onClick="collapseTable('collapse-assignment-properties', 'assignment-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Assignment ({assignmentInfos.length})</a>
-            </h4>
-          </span>
-          <div class="assignment-table collapsible-table collapsed">
+          {collapseHeader("collapse-assignment-properties", "assignment-table", s"Assignment (${assignmentInfos.length})")}
+          <div id="assignment-table" class={ServletCompat.collapsibleTableClass("assignment-table")}>
             {assignmentTableUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-write-times-properties collapse-table"
-                onClick="collapseTable('collapse-write-times-properties', 'write-times-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Shuffle Write Times</a>
-            </h4>
-          </span>
-          <div class="write-times-table collapsible-table collapsed">
+          {collapseHeader("collapse-write-times-properties", "write-times-table", "Shuffle Write Times")}
+          <div id="write-times-table" class={ServletCompat.collapsibleTableClass("write-times-table")}>
             {writeTimesUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-read-times-properties collapse-table"
-                onClick="collapseTable('collapse-read-times-properties', 'read-times-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Shuffle Read Times</a>
-            </h4>
-          </span>
-          <div class="read-times-table collapsible-table collapsed">
+          {collapseHeader("collapse-read-times-properties", "read-times-table", "Shuffle Read Times")}
+          <div id="read-times-table" class={ServletCompat.collapsibleTableClass("read-times-table")}>
             {readTimesUI}
           </div>
         </div>
 
         <div>
-          <span class="collapse-failures-properties collapse-table"
-                onClick="collapseTable('collapse-failures-properties', 'failures-table')">
-            <h4>
-              <span class="collapse-table-arrow arrow-closed"></span>
-              <a>Shuffle Failures</a>
-            </h4>
-          </span>
-          <div class="failures-table collapsible-table collapsed">
+          {collapseHeader("collapse-failures-properties", "failures-table", "Shuffle Failures")}
+          <div id="failures-table" class={ServletCompat.collapsibleTableClass("failures-table")}>
             <h4>Write {writeSummary.failedTaskNumber} Failures (maxAttemptNumber:{writeSummary.failedTaskMaxAttemptNumber})</h4>
             <pre>
               {writeSummary.failureReasons.mkString("\n\n")}

--- a/client-spark/extension/src/test/scala/org/apache/spark/ui/ServletCompatTest.scala
+++ b/client-spark/extension/src/test/scala/org/apache/spark/ui/ServletCompatTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+class ServletCompatTest {
+  @Test
+  def testCollapseMarkupMatchesSparkUi(): Unit = {
+    val attributes =
+      ServletCompat.collapseToggleAttributes("collapse-test-properties", "test-table")
+        .asAttrMap
+    val contentClasses = ServletCompat.collapsibleTableClass("test-table").split(" ").toSet
+    val isSpark42 = org.apache.spark.SPARK_VERSION_SHORT.startsWith("4.2.")
+
+    if (isSpark42) {
+      assertEquals("collapse", attributes("data-bs-toggle"))
+      assertEquals("#test-table", attributes("data-bs-target"))
+      assertEquals("collapse-test-properties", attributes("data-collapse-name"))
+      assertEquals("false", attributes("aria-expanded"))
+      assertEquals("test-table", attributes("aria-controls"))
+      assertFalse(attributes.keys.exists(_.equalsIgnoreCase("onclick")))
+      assertTrue(contentClasses.contains("collapse"))
+      assertFalse(contentClasses.contains("collapsed"))
+    } else {
+      assertTrue(attributes.keys.exists(_.equalsIgnoreCase("onclick")))
+      assertFalse(attributes.contains("data-bs-toggle"))
+      assertTrue(contentClasses.contains("collapsed"))
+      assertFalse(contentClasses.contains("collapse"))
+    }
+  }
+}

--- a/client-spark/spark2-shaded/pom.xml
+++ b/client-spark/spark2-shaded/pom.xml
@@ -38,7 +38,7 @@
       <!-- use the lz4 from spark env -->
       <exclusions>
         <exclusion>
-          <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
           <artifactId>lz4-java</artifactId>
         </exclusion>
         <exclusion>

--- a/client-spark/spark3-shaded/pom.xml
+++ b/client-spark/spark3-shaded/pom.xml
@@ -38,7 +38,7 @@
       <!-- use the lz4 from spark env -->
       <exclusions>
         <exclusion>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
           <artifactId>lz4-java</artifactId>
         </exclusion>
         <exclusion>

--- a/client-spark/spark4-shaded/pom.xml
+++ b/client-spark/spark4-shaded/pom.xml
@@ -38,7 +38,7 @@
       <!-- use the lz4 from spark env -->
       <exclusions>
         <exclusion>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
           <artifactId>lz4-java</artifactId>
         </exclusion>
         <exclusion>

--- a/client-spark/spark4/pom.xml
+++ b/client-spark/spark4/pom.xml
@@ -39,10 +39,9 @@
         (src/main/java-spark4_0, src/main/java-spark4_1) each ship a Spark4Compat
         with the matching call shape. build-helper-maven-plugin picks one via
         ${spark4.compat.source.dir}; the spark4 profile keeps the 4.0 default
-        while the spark4.1 profile in this pom (co-activated with the root
-        pom's spark4.1 profile via the shared -Pspark4.1 flag — each pom
-        contributes its own properties/build sections) switches it to the
-        4.1 variant.
+        while the spark4.1 and spark4.2 profiles in this pom (co-activated with
+        the matching root pom profiles — each pom contributes its own
+        properties/build sections) switch it to the 4.1-compatible variant.
 
         Keep the public method surface of Spark4Compat in lock-step across both
         variants; only the bodies differ.
@@ -161,6 +160,13 @@
                 does not merge profiles across poms by id.
             -->
             <id>spark4.1</id>
+            <properties>
+                <spark4.compat.source.dir>src/main/java-spark4_1</spark4.compat.source.dir>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Spark 4.2 retains the Spark 4.1 MapStatus and ExternalSorter signatures. -->
+            <id>spark4.2</id>
             <properties>
                 <spark4.compat.source.dir>src/main/java-spark4_1</spark4.compat.source.dir>
             </properties>

--- a/client-spark/spark4/src/main/java-spark4_1/org/apache/spark/shuffle/compat/Spark4Compat.java
+++ b/client-spark/spark4/src/main/java-spark4_1/org/apache/spark/shuffle/compat/Spark4Compat.java
@@ -30,8 +30,9 @@ import org.apache.spark.storage.BlockManagerId;
 import org.apache.spark.util.collection.ExternalSorter;
 
 /**
- * Compatibility shim for Spark 4.1.x. Selected by the build via the
- * {@code src/main/java-spark4_1} source root under the {@code spark4.1} profile.
+ * Compatibility shim for Spark 4.1 and 4.2. Selected by the build via the
+ * {@code src/main/java-spark4_1} source root under the {@code spark4.1} and {@code spark4.2}
+ * profiles.
  *
  * <p>Spark 4.1 added a {@code checksumVal} parameter to {@code MapStatus.apply} and a
  * {@code rowBasedChecksums} parameter to {@link ExternalSorter}'s constructor. Both have Scala

--- a/client-tez/pom.xml
+++ b/client-tez/pom.xml
@@ -82,7 +82,7 @@
         <artifactId>commons-lang3</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>${lz4-java.groupId}</groupId>
         <artifactId>lz4-java</artifactId>
       </dependency>
       <dependency>
@@ -185,7 +185,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
-                                    <include>org.lz4:lz4-java</include>
+                                    <include>${lz4-java.groupId}:lz4-java</include>
                                     <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -83,7 +83,7 @@
       <artifactId>RoaringBitmap</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>${lz4-java.groupId}</groupId>
       <artifactId>lz4-java</artifactId>
     </dependency>
     <dependency>

--- a/integration-test/common/pom.xml
+++ b/integration-test/common/pom.xml
@@ -103,7 +103,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -139,7 +139,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -172,7 +172,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>${lz4-java.groupId}</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-test/spark2/pom.xml
+++ b/integration-test/spark2/pom.xml
@@ -167,7 +167,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>${lz4-java.groupId}</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-test/spark3/pom.xml
+++ b/integration-test/spark3/pom.xml
@@ -131,7 +131,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-test/spark4/pom.xml
+++ b/integration-test/spark4/pom.xml
@@ -131,7 +131,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4-java.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,8 @@
     <junit.platform.version>1.8.2</junit.platform.version>
     <system.stubs.version>2.0.1</system.stubs.version>
     <log4j.version>2.23.0</log4j.version>
+    <lz4-java.groupId>org.lz4</lz4-java.groupId>
+    <lz4-java.version>1.8.1</lz4-java.version>
     <lombok.version>1.18.34</lombok.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -713,9 +715,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>${lz4-java.groupId}</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.8.1</version>
+        <version>${lz4-java.version}</version>
       </dependency>
 
       <dependency>
@@ -2133,9 +2135,9 @@
     <profile>
       <id>spark4.1</id>
       <!--
-          Mutually exclusive with the spark4 profile: both pin spark.version and the
-          spark4 module's compat source dir to incompatible values. Activate one or
-          the other, never both. The CI matrix and sequential.yml run them in
+          Mutually exclusive with the spark4 and spark4.2 profiles: they pin
+          spark.version and the spark4 module's compat source dir to incompatible
+          values. Activate exactly one. The CI matrix and sequential.yml run them in
           separate invocations.
       -->
       <properties>
@@ -2297,6 +2299,182 @@
           <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <!-- Hadoop 3.4.1 needs commons-logging explicitly since it's excluded from hadoop-client -->
+        <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark4.2</id>
+      <!--
+          Mutually exclusive with the spark4 and spark4.1 profiles: these profiles
+          compile the same Maven coordinates against different Spark APIs and
+          dependency lines. Activate exactly one and run mvn clean when switching.
+      -->
+      <properties>
+        <scala.binary.version>2.13</scala.binary.version>
+        <scala.version>2.13.18</scala.version>
+        <spark.version>4.2.0</spark.version>
+        <netty.version>4.2.13.Final</netty.version>
+        <client.type>4</client.type>
+        <hadoop.version>3.5.0</hadoop.version>
+        <hadoop.artifact.core>hadoop-client-api</hadoop.artifact.core>
+        <hadoop.artifact.client>hadoop-client-runtime</hadoop.artifact.client>
+        <!--
+          Kerberos tests are skipped via uniffle.test.skip.kerberos=true for two reasons:
+          HADOOP-17324: hadoop-client-minicluster does not include Bouncy Castle; and MiniKdc
+          is not compatible with JDK 17+.
+        -->
+        <hadoop.artifact.minicluster>hadoop-client-minicluster</hadoop.artifact.minicluster>
+        <fasterxml.jackson.version>2.21.2</fasterxml.jackson.version>
+        <!-- Spark shades its Jetty 12 classes; Uniffle's web server remains on Jetty 9.4. -->
+        <jetty.version>9.4.53.v20231009</jetty.version>
+        <enforcer.skip>true</enforcer.skip>
+        <jackson.version>2.21.2</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
+        <log4j.version>2.25.4</log4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <commons-io.version>2.22.0</commons-io.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <lz4-java.groupId>at.yawk.lz4</lz4-java.groupId>
+        <lz4-java.version>1.11.0</lz4-java.version>
+        <extraJavaTestArgs>
+          -XX:+IgnoreUnrecognizedVMOptions
+          --add-modules=jdk.incubator.vector
+          --add-opens=java.base/java.lang=ALL-UNNAMED
+          --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens=java.base/java.io=ALL-UNNAMED
+          --add-opens=java.base/java.net=ALL-UNNAMED
+          --add-opens=java.base/java.nio=ALL-UNNAMED
+          --add-opens=java.base/java.util=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+          --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+          --add-opens=java.base/sun.security.action=ALL-UNNAMED
+          --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+          --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+          -Djdk.reflect.useDirectMethodHandle=false
+          -Dio.netty.tryReflectionSetAccessible=true
+          -Duniffle.test.skip.kerberos=true
+        </extraJavaTestArgs>
+      </properties>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark4</module>
+        <module>client-spark/spark4-shaded</module>
+        <module>integration-test/spark-common</module>
+        <module>integration-test/spark4</module>
+        <module>client-spark/extension</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotations.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark4</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-spark-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>${hadoop.artifact.core}</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>${hadoop.artifact.client}</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!-- Remove log4j-slf4j-impl dependency -->
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!-- Add log4j-slf4j2-impl dependency -->
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <!-- Hadoop 3.5.0 needs commons-logging explicitly since it's excluded from hadoop-client -->
         <dependency>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add Apache Spark 4.2.0 support to Uniffle.

The main changes include:

- Add a `spark4.2` Maven profile using JDK 17 and Scala 2.13.18.
- Align Spark 4.2 dependencies, including Hadoop 3.5.0, Netty 4.2.13.Final, Jackson 2.21.2, Log4j 2.25.4, and SLF4J 2.0.17.
- Reuse the Spark 4.1 compatibility implementation for the unchanged `MapStatus` and `ExternalSorter` APIs.
- Upgrade LZ4 to `at.yawk.lz4:lz4-java:1.11.0` for Spark 4.2 while preserving the existing version for other profiles.
- Adapt the Spark UI extension to Spark 4.2's Bootstrap 5 and CSP-compatible collapse markup.
- Add Spark 4.2 UI compatibility tests.
- Add Spark 4.2 builds to the parallel and sequential CI workflows.
- Update the supported Spark versions and build instructions in the README.

### Why are the changes needed?

Spark 4.2 updates several dependency versions and removes the legacy global `collapseTable()` JavaScript function from its Web UI.

Without these changes:

- Spark shuffle integration tests fail because Spark 4.2 requires the newer LZ4 builder API.
- Collapsible sections on the Uniffle Spark UI page do not work.
- Uniffle cannot be built or validated directly against Spark 4.2.0.

### How was this patch tested?

The following validations passed with JDK 17 and the `spark4.2` profile:

- `RssSpark4ShuffleUtilsTest`: 3 tests passed.
- `SparkVersionUtilsTest`: 2 tests passed.
- `ServletCompatTest` with Spark 4.2: passed.
- `ServletCompatTest` with Spark 4.1: passed.
- `MapSideCombineTest`: passed.
- `AQERepartitionTest`: passed.
- Spark 4.2 shaded client build: passed.
- Shaded dependency check: `unshaded count: 0`.
- `git diff --check`: passed.

----
Generated by Codex (GPT-5.6)