### PR TITLE
[#2771] feat(spark): Support Spark 4.2

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -79,6 +79,8 @@ jobs:
             java-version: 17
           - profile: spark4.1
             java-version: 17
+          - profile: spark4.2
+            java-version: 17
           - profile: mr-hadoop2.8
             java-version: 8
           - profile: mr-hadoop3.2

--- a/.github/workflows/sequential.yml
+++ b/.github/workflows/sequential.yml
@@ -76,6 +76,10 @@ jobs:
       if: inputs.java-version == '17'
       run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.1 | tee -a /tmp/maven.log;
       shell: bash
+    - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark4.2`
+      if: inputs.java-version == '17'
+      run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark4.2 | tee -a /tmp/maven.log;
+      shell: bash
     - name: Execute `./mvnw ${{ inputs.maven-args }} -Pspark3`
       run: ./mvnw -B -fae ${{ inputs.maven-args }} -Pspark3 | tee -a /tmp/maven.log;
       shell: bash

--- a/client-spark/extension/pom.xml
+++ b/client-spark/extension/pom.xml
@@ -157,5 +157,16 @@
                 <extension.servlet.source.dir>src/main/scala-jakarta</extension.servlet.source.dir>
             </properties>
         </profile>
+        <profile>
+            <!--
+                Co-activated with the root pom's spark4.2 profile via the shared
+                -Pspark4.2 flag. Spark 4.2 keeps the jakarta servlet API, so this
+                mirrors the spark4.1 profile (scala-jakarta variant).
+            -->
+            <id>spark4.2</id>
+            <properties>
+                <extension.servlet.source.dir>src/main/scala-jakarta</extension.servlet.source.dir>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
+++ b/client-spark/extension/src/main/scala/org/apache/spark/ui/ShufflePage.scala
@@ -307,6 +307,28 @@ class ShufflePage(parent: ShuffleTab) extends WebUIPage("") with Logging {
 
     val summary: NodeSeq = {
       <div>
+        <!--
+            Fallback for the collapsible-section toggles below. Spark 3.x / 4.0 / 4.1
+            ship a global collapseTable(name, table) in webui.js that the onClick
+            handlers call. Spark 4.2 dropped that function (it moved its own pages to
+            Bootstrap 5 data-bs-toggle collapse), so the onClick handlers would hit
+            "collapseTable is not defined" and the sections could not be expanded.
+            Define a compatible collapseTable only when the host Spark didn't provide
+            one, so 3.x/4.0/4.1 keep Spark's implementation and 4.2 gets a working
+            equivalent. Uses the same .collapsed / arrow-open|closed CSS classes that
+            every Spark line still ships.
+        -->
+        <script type="text/javascript">{scala.xml.Unparsed("""
+          if (typeof window.collapseTable !== 'function') {
+            window.collapseTable = function(thisName, table) {
+              var thisClass = '.' + thisName;
+              var tableDiv = $(thisClass).parent().find('.' + table);
+              $(tableDiv).toggleClass('collapsed');
+              $(thisClass).find('.collapse-table-arrow')
+                .toggleClass('arrow-open').toggleClass('arrow-closed');
+            };
+          }
+        """)}</script>
         <div>
           <ul class="list-unstyled">
             <li>

--- a/client-spark/spark4-shaded/pom.xml
+++ b/client-spark/spark4-shaded/pom.xml
@@ -37,6 +37,13 @@
       <version>${project.version}</version>
       <!-- use the lz4 from spark env -->
       <exclusions>
+        <!--
+            Must stay org.lz4, do NOT switch to ${lz4.groupId}: Maven matches
+            exclusions on the as-declared coordinate. client-spark/common declares
+            lz4 as org.lz4, so this org.lz4 exclusion strips it. Parameterizing it
+            would make the exclusion miss the at.yawk.lz4 coordinate under -Pspark4.2
+            and leak lz4 into the shaded jar.
+        -->
         <exclusion>
             <groupId>org.lz4</groupId>
           <artifactId>lz4-java</artifactId>

--- a/client-spark/spark4/pom.xml
+++ b/client-spark/spark4/pom.xml
@@ -44,6 +44,12 @@
         contributes its own properties/build sections) switches it to the
         4.1 variant.
 
+        Spark 4.2.0 keeps the 4.1 signatures for both APIs (verified with javap:
+        MapStatus.apply and the ExternalSorter constructor are byte-identical to
+        4.1.1), so the spark4.2 profile reuses src/main/java-spark4_1 as-is rather
+        than duplicating a byte-identical java-spark4_2. If a future 4.2.x changes
+        either signature, fork a new source root — same pattern as 4.0 -> 4.1.
+
         Keep the public method surface of Spark4Compat in lock-step across both
         variants; only the bodies differ.
     -->
@@ -161,6 +167,18 @@
                 does not merge profiles across poms by id.
             -->
             <id>spark4.1</id>
+            <properties>
+                <spark4.compat.source.dir>src/main/java-spark4_1</spark4.compat.source.dir>
+            </properties>
+        </profile>
+        <profile>
+            <!--
+                Co-activated with the root pom's spark4.2 profile via the shared
+                -Pspark4.2 flag. Reuses the 4.1 compat source root: Spark 4.2.0's
+                MapStatus.apply and ExternalSorter constructor signatures are
+                identical to 4.1.1, so java-spark4_1 satisfies both.
+            -->
+            <id>spark4.2</id>
             <properties>
                 <spark4.compat.source.dir>src/main/java-spark4_1</spark4.compat.source.dir>
             </properties>

--- a/integration-test/spark-common/pom.xml
+++ b/integration-test/spark-common/pom.xml
@@ -172,7 +172,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>${lz4.groupId}</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integration-test/spark4/pom.xml
+++ b/integration-test/spark4/pom.xml
@@ -131,7 +131,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>${lz4.groupId}</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,15 @@
     <spotless-maven-plugin.version>2.30.0</spotless-maven-plugin.version>
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>3.12.4</mockito.version>
+    <!--
+        lz4-java relocated its Maven coordinates from org.lz4 to at.yawk.lz4 in the
+        1.9+ line (org.lz4 only publishes up to a 1.8.1 relocation stub). Spark 4.2
+        needs at.yawk.lz4:1.11.0 (LZ4BlockInputStream.newBuilder). Modules that must
+        follow Spark's lz4 declare ${lz4.groupId}:lz4-java; the spark4.2 profile
+        flips this to at.yawk.lz4, every other profile keeps org.lz4. Both
+        coordinates are version-managed in the root dependencyManagement below.
+    -->
+    <lz4.groupId>org.lz4</lz4.groupId>
     <netty.version>4.1.109.Final</netty.version>
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -716,6 +725,21 @@
         <groupId>org.lz4</groupId>
         <artifactId>lz4-java</artifactId>
         <version>1.8.1</version>
+      </dependency>
+
+      <!--
+          lz4-java relocated org.lz4 -> at.yawk.lz4 after 1.8.1 (org.lz4 only ships a
+          1.8.1 relocation stub). Spark 4.2 needs the at.yawk.lz4 1.11 line for
+          LZ4BlockInputStream.newBuilder(). This coordinate only reaches the graph
+          under the spark4.2 profile (which flips ${lz4.groupId} to at.yawk.lz4 and
+          pulls spark-core 4.2.0); every other profile stays on org.lz4:1.8.1 above.
+          Managed here (not in the profile) so flatten-maven-plugin always resolves
+          the version.
+      -->
+      <dependency>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>1.11.0</version>
       </dependency>
 
       <dependency>
@@ -2171,6 +2195,191 @@
         <jackson.version>2.20.0</jackson.version>
         <log4j.version>2.24.3</log4j.version>
         <slf4j.version>2.0.16</slf4j.version>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <extraJavaTestArgs>
+          -XX:+IgnoreUnrecognizedVMOptions
+          --add-opens=java.base/java.lang=ALL-UNNAMED
+          --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens=java.base/java.io=ALL-UNNAMED
+          --add-opens=java.base/java.net=ALL-UNNAMED
+          --add-opens=java.base/java.nio=ALL-UNNAMED
+          --add-opens=java.base/java.util=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens=java.base/sun.security.action=ALL-UNNAMED
+          --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+          --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+          -Djdk.reflect.useDirectMethodHandle=false
+          -Duniffle.test.skip.kerberos=true
+        </extraJavaTestArgs>
+      </properties>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark4</module>
+        <module>client-spark/spark4-shaded</module>
+        <module>integration-test/spark-common</module>
+        <module>integration-test/spark4</module>
+        <module>client-spark/extension</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark4</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.uniffle</groupId>
+            <artifactId>rss-integration-spark-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>${hadoop.artifact.core}</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>${hadoop.artifact.client}</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!-- Remove log4j-slf4j-impl dependency -->
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!-- Add log4j-slf4j2-impl dependency -->
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <!-- Hadoop 3.4.1 needs commons-logging explicitly since it's excluded from hadoop-client -->
+        <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark4.2</id>
+      <!--
+          Mutually exclusive with the spark4 / spark4.1 profiles: all three pin
+          spark.version and the spark4 module's compat source dir to incompatible
+          values. Activate exactly one, never more than one. The CI matrix and
+          sequential.yml run them in separate invocations.
+
+          Structurally a clone of the spark4.1 profile: only spark.version,
+          scala.version, netty.version, and jackson.version differ. Keep the three
+          spark4.x profiles in lock-step when editing.
+      -->
+      <properties>
+        <scala.binary.version>2.13</scala.binary.version>
+        <scala.version>2.13.18</scala.version>
+        <spark.version>4.2.0</spark.version>
+        <!--
+            Same Netty 4.2 line as spark4.1 (4.2.7.Final); Spark 4.2.0 ships against
+            4.2.13.Final, so pin to that. Spark's NettyUtils.createEventLoop still
+            references io.netty.channel.nio.NioIoHandler (Netty 4.2+), which resolves
+            on this line, so no code change over spark4.1 is needed.
+        -->
+        <netty.version>4.2.13.Final</netty.version>
+        <client.type>4</client.type>
+        <hadoop.version>3.4.1</hadoop.version>
+        <hadoop.artifact.core>hadoop-client-api</hadoop.artifact.core>
+        <hadoop.artifact.client>hadoop-client-runtime</hadoop.artifact.client>
+        <!--
+          Kerberos tests are skipped via uniffle.test.skip.kerberos=true for two reasons:
+          HADOOP-17324: hadoop-client-minicluster does not include Bouncy Castle; and MiniKdc
+          is not compatible with JDK 17+.
+        -->
+        <hadoop.artifact.minicluster>hadoop-client-minicluster</hadoop.artifact.minicluster>
+        <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
+        <enforcer.skip>true</enforcer.skip>
+        <!--
+            Spark 4.2.0 ships jackson-module-scala_2.13 2.21.2, which requires
+            jackson-databind in [2.21.0, 2.22.0). Pin databind/core to 2.21.2
+            so RDDOperationScope's static initializer (registers DefaultScalaModule
+            on a shared ObjectMapper) doesn't blow up under -Pspark4.2.
+        -->
+        <jackson.version>2.21.2</jackson.version>
+        <log4j.version>2.24.3</log4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <!--
+            Spark 4.2 needs at.yawk.lz4:lz4-java:1.11.0 (LZ4BlockInputStream.newBuilder).
+            Flip the coordinate the spark modules declare from org.lz4 to at.yawk.lz4;
+            its version (1.11.0) is pinned in the root dependencyManagement.
+        -->
+        <lz4.groupId>at.yawk.lz4</lz4.groupId>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,17 @@
     <metrics.version>3.1.0</metrics.version>
     <mockito.version>3.12.4</mockito.version>
     <!--
-        lz4-java relocated its Maven coordinates from org.lz4 to at.yawk.lz4 in the
-        1.9+ line (org.lz4 only publishes up to a 1.8.1 relocation stub). Spark 4.2
-        needs at.yawk.lz4:1.11.0 (LZ4BlockInputStream.newBuilder). Modules that must
-        follow Spark's lz4 declare ${lz4.groupId}:lz4-java; the spark4.2 profile
-        flips this to at.yawk.lz4, every other profile keeps org.lz4. Both
-        coordinates are version-managed in the root dependencyManagement below.
+        lz4-java relocated its Maven coordinates from org.lz4 to at.yawk.lz4 after
+        1.8.1: org.lz4 ships real jars through 1.8.0 and a 1.8.1 relocation stub,
+        while at.yawk.lz4 hosts 1.8.1 onward. Spark 4.2 needs at.yawk.lz4:1.11.0
+        (LZ4BlockInputStream.newBuilder). Modules that must follow Spark's lz4
+        declare ${lz4.groupId}:lz4-java at ${lz4.version}; the spark4.2 profile
+        flips these to at.yawk.lz4 / 1.11.0, every other profile keeps
+        org.lz4 / 1.8.1. Both coordinates are version-managed in the root
+        dependencyManagement below.
     -->
     <lz4.groupId>org.lz4</lz4.groupId>
+    <lz4.version>1.8.1</lz4.version>
     <netty.version>4.1.109.Final</netty.version>
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -728,18 +731,19 @@
       </dependency>
 
       <!--
-          lz4-java relocated org.lz4 -> at.yawk.lz4 after 1.8.1 (org.lz4 only ships a
-          1.8.1 relocation stub). Spark 4.2 needs the at.yawk.lz4 1.11 line for
-          LZ4BlockInputStream.newBuilder(). This coordinate only reaches the graph
-          under the spark4.2 profile (which flips ${lz4.groupId} to at.yawk.lz4 and
-          pulls spark-core 4.2.0); every other profile stays on org.lz4:1.8.1 above.
-          Managed here (not in the profile) so flatten-maven-plugin always resolves
-          the version.
+          lz4-java relocated org.lz4 -> at.yawk.lz4 after 1.8.1 (org.lz4 real jars
+          stop at 1.8.0, 1.8.1 is a relocation stub; at.yawk.lz4 hosts 1.8.1 onward).
+          Everything that pulls lz4 transitively resolves the relocated at.yawk.lz4
+          coordinate, so this entry governs it. Version comes from ${lz4.version}:
+          1.8.1 by default (matches org.lz4:1.8.1 below), bumped to 1.11.0 only by
+          the spark4.2 profile, which needs LZ4BlockInputStream.newBuilder(). Kept
+          here (not in the profile) so flatten-maven-plugin always resolves a version
+          for the ${lz4.groupId}-declared modules.
       -->
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.0</version>
+        <version>${lz4.version}</version>
       </dependency>
 
       <dependency>
@@ -2338,8 +2342,9 @@
           sequential.yml run them in separate invocations.
 
           Structurally a clone of the spark4.1 profile: only spark.version,
-          scala.version, netty.version, and jackson.version differ. Keep the three
-          spark4.x profiles in lock-step when editing.
+          scala.version, netty.version, jackson.version, and the lz4 coordinate
+          (lz4.groupId + lz4.version) differ. Keep the three spark4.x profiles in
+          lock-step when editing.
       -->
       <properties>
         <scala.binary.version>2.13</scala.binary.version>
@@ -2376,10 +2381,12 @@
         <slf4j.version>2.0.16</slf4j.version>
         <!--
             Spark 4.2 needs at.yawk.lz4:lz4-java:1.11.0 (LZ4BlockInputStream.newBuilder).
-            Flip the coordinate the spark modules declare from org.lz4 to at.yawk.lz4;
-            its version (1.11.0) is pinned in the root dependencyManagement.
+            Flip both the coordinate (org.lz4 -> at.yawk.lz4) and the version
+            (1.8.1 -> 1.11.0) the spark modules declare; the default build and every
+            other profile keep org.lz4 / 1.8.1.
         -->
         <lz4.groupId>at.yawk.lz4</lz4.groupId>
+        <lz4.version>1.11.0</lz4.version>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a mutually-exclusive `spark4.2` Maven profile that builds the existing `client-spark/spark4` module against **Apache Spark 4.2.0**, mirroring the `spark4.1` profile added in #2751.

- **Root `pom.xml`**: new `spark4.2` profile — a structural clone of `spark4.1`, differing only in `spark.version=4.2.0`, `scala.version=2.13.18`, `netty.version=4.2.13.Final`, `jackson.version=2.21.2`, and the lz4 coordinate (`lz4.groupId` + `lz4.version`, see below).
- **`client-spark/spark4/pom.xml`**: `spark4.2` profile reuses the `src/main/java-spark4_1` compat source root (the 4.1 `Spark4Compat` shim).
- **`client-spark/extension/pom.xml`**: `spark4.2` profile reuses the `scala-jakarta` servlet source root.
- **`client-spark/extension` — `ShufflePage.scala`**: the Uniffle UI tab's collapsible sections use `onClick="collapseTable(...)"`, relying on a global `collapseTable()` that Spark 3.x/4.0/4.1 ship in `webui.js`. Spark 4.2 removed that function (its own pages moved to Bootstrap 5 `data-bs-toggle` collapse), so under `-Pspark4.2` the sections could not be expanded. Inline a fallback that defines a compatible `collapseTable` only when the host Spark didn't provide one — 3.x/4.0/4.1 keep Spark's implementation, 4.2 gets a working equivalent, reusing the `.collapsed` / `arrow-open|closed` CSS every Spark line still ships.
- **lz4**: introduce `${lz4.groupId}` (`org.lz4` by default, `at.yawk.lz4` under `spark4.2`) and `${lz4.version}` (`1.8.1` by default, `1.11.0` under `spark4.2`); the two integration-test modules declare `${lz4.groupId}:lz4-java`, and the `at.yawk.lz4` root-`dependencyManagement` entry is pinned to `${lz4.version}`. The default build and every non-`spark4.2` profile stay on `org.lz4:1.8.1` — the bump is scoped to `spark4.2` only.
- **CI**: `parallel.yml` gains a `spark4.2 / java 17` matrix entry; `sequential.yml` gains a `-Pspark4.2` step gated on `java-version == 17`.

No new Maven module. `client-spark/spark4-shaded` needs no relocation change (its bouncycastle/jctools relocations are already global); a comment was added there noting its lz4 exclusion must stay `org.lz4` — Maven matches exclusions on the as-declared coordinate, so parameterizing it would leak `at.yawk.lz4` into the shaded jar under `-Pspark4.2`.

### Why are the changes needed?

Fix: #2771

Users should be able to build and run Uniffle's Spark client against Spark 4.2.0 with full parity to the existing 4.1 support.

The three cross-major APIs called from `client-spark/spark4` are **byte-identical** between 4.1.1 and 4.2.0 (verified with `javap`), so no shim change is required:

| API | 4.1.1 | 4.2.0 |
|---|---|---|
| `MapStatus.apply(BlockManagerId, long[], long, long)` | 4-arg | identical |
| `ExternalSorter(…, RowBasedChecksum[])` ctor | 6-arg | identical |
| `WebUIPage.render(jakarta…HttpServletRequest)` | jakarta | identical |

Dependency notes:
- **jackson → 2.21.2 (required):** Spark 4.2.0 ships `jackson-module-scala_2.13` 2.21.2, which validates the classpath `jackson-databind` on registration and throws in `RDDOperationScope`'s static initializer if it is outside `[2.21.0, 2.22.0)`. Same class of failure the 4.1 work hit.
- **netty → 4.2.13.Final:** matches what Spark 4.2.0 was compiled/tested against (still Netty 4.2, same major as 4.1's 4.2.7, so #2751's `NioIoHandler`/refCnt handling still applies — no code change).
- **lz4 → at.yawk.lz4:1.11.0, scoped to spark4.2 (required):** Spark 4.2.0 bumped lz4 to 1.11.0 and calls `LZ4BlockInputStream.newBuilder()` (added in the 1.11 line); without it the integration tests fail at runtime with `NoSuchMethodError`. Because `org.lz4:1.8.1` is a relocation stub that Maven rewrites to `at.yawk.lz4:1.8.1`, a globally-managed `at.yawk.lz4:1.11.0` would silently bump lz4 across the whole reactor (server/client/coordinator/…), which is out of this PR's scope and would override the `org.lz4:1.8.1` pin from #2693 (CVE-2025-12183). The `${lz4.groupId}`/`${lz4.version}` properties confine the bump to the `spark4.2` profile; every other build stays on 1.8.1.
- hadoop / jetty / log4j / slf4j / commons-lang3 deltas are deferred; the profile keeps the 4.1 values.

### Does this PR introduce _any_ user-facing change?

No behavioral change to existing profiles. Adds a new opt-in `-Pspark4.2` build profile, and fixes the Uniffle Spark UI tab so its collapsible sections expand under Spark 4.2. Existing `-Pspark4` (4.0.2) and `-Pspark4.1` (4.1.1) are unchanged.

### How was this patch tested?

Verified locally on JDK 17 (Zulu 17.0.18):

1. `mvn clean install -Pspark4.2 -DskipTests` — compiles + shades against 4.2.0 (spark-core/sql/catalyst 4.2.0, scala 2.13.18, netty 4.2.13.Final, jackson 2.21.2, lz4 `at.yawk.lz4:1.11.0` resolved).
2. `mvn clean install -Pspark4.1 -DskipTests` + integration tests — 4.1.1 build and `AQERepartitionTest` / `MapSideCombineTest` still green (lz4 stays `org.lz4:1.8.1`); confirms no regression. Also confirmed the default build (no profile) and other spark profiles keep lz4 at 1.8.1.
3. `AQERepartitionTest`, `MapSideCombineTest` pass under `-Pspark4.2`.
4. `TransportFrameDecoderTest` (2 tests) passes on Netty 4.2.13 under `-Pspark4.2`.
5. `RepartitionWithLocalFileRssTest` (NOOP/ZSTD/**LZ4** codecs) passes under `-Pspark4.2` — exercises the lz4 runtime path.
6. `dev/scripts/checkshade.sh` on the spark4.2 shaded jar — "check success", 0 unshaded classes; bouncycastle/jctools relocated, no `net.jpountz` (lz4) leak.
7. **End-to-end on a real Spark 4.2.0 distribution** against a local Uniffle cluster (coordinator + shuffle server): a shuffle job runs through `RssShuffleManager`, and the Uniffle Spark UI tab renders and its collapsible sections (Build Info / Shuffle Server / Assignment / …) expand with no page JS errors.

CI runs the build + unit + integration tests via the new `spark4.2` matrix entry / `-Pspark4.2` step.
